### PR TITLE
Custom provisioning - limit operand reconcile to the oldest BtpOperator CR

### DIFF
--- a/operator/api/v1alpha1/btpoperator_types.go
+++ b/operator/api/v1alpha1/btpoperator_types.go
@@ -40,11 +40,7 @@ type BtpOperator struct {
 }
 
 // BtpOperatorSpec defines the desired state of BtpOperator
-type BtpOperatorSpec struct {
-	ReleaseName string `json:"releaseName,omitempty"`
-	Foo         string `json:"foo,omitempty"`
-	Test        bool   `json:"test,omitempty"`
-}
+type BtpOperatorSpec struct{}
 
 var _ types.CustomObject = &BtpOperator{}
 

--- a/operator/config/crd/bases/operator.kyma-project.io_btpoperators.yaml
+++ b/operator/config/crd/bases/operator.kyma-project.io_btpoperators.yaml
@@ -38,13 +38,6 @@ spec:
             type: object
           spec:
             description: BtpOperatorSpec defines the desired state of BtpOperator
-            properties:
-              foo:
-                type: string
-              releaseName:
-                type: string
-              test:
-                type: boolean
             type: object
           status:
             description: Status defines the observed state of CustomObject.

--- a/operator/controllers/btpoperator_controller.go
+++ b/operator/controllers/btpoperator_controller.go
@@ -730,11 +730,11 @@ func (r *BtpOperatorReconciler) deleteAllOfinstalledResources(ctx context.Contex
 	return nil
 }
 
-func (r *BtpOperatorReconciler) HandleReadyState(ctx context.Context, cr *v1alpha1.BtpOperator) error {
-	return nil
-}
-
 func (r *BtpOperatorReconciler) UpdateBtpOperatorState(ctx context.Context, cr *v1alpha1.BtpOperator, newState types.State) error {
 	cr.SetStatus(cr.Status.WithState(newState))
 	return r.Status().Update(ctx, cr)
+}
+
+func (r *BtpOperatorReconciler) HandleReadyState(ctx context.Context, cr *v1alpha1.BtpOperator) error {
+	return nil
 }

--- a/operator/controllers/btpoperator_controller.go
+++ b/operator/controllers/btpoperator_controller.go
@@ -266,6 +266,9 @@ func (r *BtpOperatorReconciler) HandleDeletingState(ctx context.Context, cr *v1a
 			return fmt.Errorf("while getting existing BtpOperators: %w", err)
 		}
 		for _, item := range existingBtpOperators.Items {
+			if item.GetUID() == cr.GetUID() {
+				continue
+			}
 			cr := item
 			if err := r.UpdateBtpOperatorState(ctx, &cr, types.StateProcessing); err != nil {
 				logger.Error(err, "unable to set \"Processing\" state")

--- a/operator/controllers/btpoperator_controller.go
+++ b/operator/controllers/btpoperator_controller.go
@@ -259,6 +259,18 @@ func (r *BtpOperatorReconciler) HandleDeletingState(ctx context.Context, cr *v1a
 		if err := r.Update(ctx, cr); err != nil {
 			return err
 		}
+		existingBtpOperators := &v1alpha1.BtpOperatorList{}
+		if err := r.List(ctx, existingBtpOperators); err != nil {
+			logger.Error(err, "unable to fetch existing BtpOperators")
+			return fmt.Errorf("while getting existing BtpOperators: %w", err)
+		}
+		for _, item := range existingBtpOperators.Items {
+			cr := item
+			if err := r.UpdateBtpOperatorState(ctx, &cr, types.StateProcessing); err != nil {
+				logger.Error(err, "unable to set \"Processing\" state")
+			}
+		}
+
 		return nil
 	}
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- limit operand reconciling responsibility to the oldest BtpOperator,
- handle redundant BtpOperators,
- trigger Reconcile() on all remaining BtpOperators after BtpOperator managing the operand is deleted.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
