### PR TITLE
Introduce configurability via CLI parameters and ConfigMap

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 The btp-manager internal settings can be configured using CLI arguments or `ConfigMap`.
 
-CLI arguments example:
+To configure them using CLI arguments, follow this example:
 ```
 $ manager --help
 Usage of ./manager:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,63 @@
+## Configuration
+
+The btp-manager internal settings can be configured using CLI arguments or `ConfigMap`.
+
+CLI arguments example:
+```
+$ manager --help
+Usage of ./manager:
+  -chart-namespace string
+    	Namespace to install chart resources. (default "kyma-system")
+  -chart-path string
+    	Module chart path. (default "./module-chart")
+  -config-name string
+    	ConfigMap name with configuration knobs for the btp-manager internals. (default "sap-btp-manager")
+  -deployment-name string
+    	Name of the deployment of sap-btp-operator for deprovisioning. (default "sap-btp-operator-controller-manager")
+  -health-probe-bind-address string
+    	The address the probe endpoint binds to. (default ":8081")
+  -kubeconfig string
+    	Paths to a kubeconfig. Only required if out-of-cluster.
+  -leader-elect
+    	Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.
+  -metrics-bind-address string
+    	The address the metric endpoint binds to. (default ":8080")
+  -processing-state-requeue-interval duration
+    	Requeue interval for state "processing". (default 5m0s)
+  -ready-state-requeue-interval duration
+    	Requeue interval for state "ready". (default 1h0m0s)
+  -ready-timeout duration
+    	Helm chart timeout. (default 1m0s)
+  -retry-interval duration
+    	Hard delete retry interval. (default 10s)
+  -secret-name string
+    	Secret name with input values for sap-btp-operator chart templating. (default "sap-btp-manager")
+  -zap-devel
+    	Development Mode defaults(encoder=consoleEncoder,logLevel=Debug,stackTraceLevel=Warn). Production Mode defaults(encoder=jsonEncoder,logLevel=Info,stackTraceLevel=Error) (default true)
+  -zap-encoder value
+    	Zap log encoding (one of 'json' or 'console')
+  -zap-log-level value
+    	Zap Level to configure the verbosity of logging. Can be one of 'debug', 'info', 'error', or any integer value > 0 which corresponds to custom debug levels of increasing verbosity
+  -zap-stacktrace-level value
+    	Zap Level at and above which stacktraces are captured (one of 'info', 'error', 'panic').
+  -zap-time-encoding value
+    	Zap time encoding (one of 'epoch', 'millis', 'nano', 'iso8601', 'rfc3339' or 'rfc3339nano'). Defaults to 'epoch'.
+```
+
+Configuration via `ConfigMap` [example](../examples/btp-operator-configmap.yaml).
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sap-btp-manager
+  namespace: kyma-system
+data:
+  ChartPath: ./module-chart
+  ChartNamespace: kyma-system
+  SecretName: sap-btp-manager
+  DeploymentName: sap-btp-operator-controller-manager
+  ProcessingStateRequeueInterval: 5m
+  ReadyStateRequeueInterval: 1h
+  ReadyTimeout: 1m
+  RetryInterval: 10s
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,7 +44,7 @@ Usage of ./manager:
     	Zap time encoding (one of 'epoch', 'millis', 'nano', 'iso8601', 'rfc3339' or 'rfc3339nano'). Defaults to 'epoch'.
 ```
 
-Configuration via `ConfigMap` [example](../examples/btp-operator-configmap.yaml).
+Configuration with `ConfigMap` [example](../examples/btp-operator-configmap.yaml).
 ```yaml
 apiVersion: v1
 kind: ConfigMap

--- a/examples/btp-operator-configmap.yaml
+++ b/examples/btp-operator-configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sap-btp-manager
+  namespace: kyma-system
+data:
+  ChartPath: ./module-chart
+  ChartNamespace: kyma-system
+  SecretName: sap-btp-manager
+  DeploymentName: sap-btp-operator-controller-manager
+  ProcessingStateRequeueInterval: 5m
+  ReadyStateRequeueInterval: 1h
+  ReadyTimeout: 1m
+  RetryInterval: 10s

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -56,7 +56,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
+	GINKGO_EDITOR_INTEGRATION=TRUE KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -coverprofile cover.out
 
 ##@ Build
 

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -8,6 +8,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - secrets
   verbs:
   - get

--- a/operator/controllers/btpoperator_controller.go
+++ b/operator/controllers/btpoperator_controller.go
@@ -113,6 +113,7 @@ func (r *BtpOperatorReconciler) SetTimeout(timeout time.Duration) {
 //+kubebuilder:rbac:groups=operator.kyma-project.io,resources=btpoperators/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=operator.kyma-project.io,resources=btpoperators/finalizers,verbs=update
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 func (r *BtpOperatorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)

--- a/operator/controllers/btpoperator_controller_test.go
+++ b/operator/controllers/btpoperator_controller_test.go
@@ -130,6 +130,16 @@ var _ = Describe("BTP Operator controller", func() {
 
 	})
 
+	Describe("Configurability", func() {
+		Context("When the ConfigMap is present", func() {
+			It("should adjust configuration settings in the operator accordingly", func() {
+				cm := initConfig(map[string]string{"ProcessingStateRequeueInterval": "10s"})
+				reconciler.reconcileConfig(cm)
+				Expect(ProcessingStateRequeueInterval).To(Equal(time.Second * 10))
+			})
+		})
+	})
+
 	Describe("Deprovisioning", func() {
 		BeforeEach(func() {
 			createSecret()
@@ -213,6 +223,16 @@ func createBtpOperator() *v1alpha1.BtpOperator {
 			Name:      btpOperatorName,
 			Namespace: testNamespace,
 		},
+	}
+}
+
+func initConfig(data map[string]string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ConfigName,
+			Namespace: ChartNamespace,
+		},
+		Data: data,
 	}
 }
 

--- a/operator/controllers/btpoperator_controller_test.go
+++ b/operator/controllers/btpoperator_controller_test.go
@@ -132,7 +132,7 @@ var _ = Describe("BTP Operator controller", func() {
 
 	Describe("Configurability", func() {
 		Context("When the ConfigMap is present", func() {
-			It("should adjust configuration settings in the operator accordingly", func() {
+			FIt("should adjust configuration settings in the operator accordingly", func() {
 				cm := initConfig(map[string]string{"ProcessingStateRequeueInterval": "10s"})
 				reconciler.reconcileConfig(cm)
 				Expect(ProcessingStateRequeueInterval).To(Equal(time.Second * 10))

--- a/operator/main.go
+++ b/operator/main.go
@@ -62,6 +62,15 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&controllers.ChartPath, "chart-path", controllers.ChartPath, "Module chart path.")
+	flag.StringVar(&controllers.ChartNamespace, "chart-namespace", controllers.ChartNamespace, "Namespace to install chart resources.")
+	flag.StringVar(&controllers.SecretName, "secret-name", controllers.SecretName, "Secret name with input values for sap-btp-operator chart templating.")
+	flag.StringVar(&controllers.ConfigName, "config-name", controllers.ConfigName, "ConfigMap name with configuration knobs for the btp-manager internals.")
+	flag.StringVar(&controllers.DeploymentName, "deployment-name", controllers.DeploymentName, "Name of the deployment of sap-btp-operator for deprovisioning.")
+	flag.DurationVar(&controllers.ProcessingStateRequeueInterval, "processing-state-requeue-interval", controllers.ProcessingStateRequeueInterval, `Requeue interval for state "processing".`)
+	flag.DurationVar(&controllers.ReadyStateRequeueInterval, "ready-state-requeue-interval", controllers.ReadyStateRequeueInterval, `Requeue interval for state "ready".`)
+	flag.DurationVar(&controllers.ReadyTimeout, "ready-timeout", controllers.ReadyTimeout, "Helm chart timeout.")
+	flag.DurationVar(&controllers.RetryInterval, "retry-interval", controllers.RetryInterval, "Hard delete retry interval.")
 	opts := zap.Options{
 		Development: true,
 	}


### PR DESCRIPTION
This PR introduces configurability for btp-manager via CLI parameters and `ConfigMap`

Example:
```yaml
apiVersion: v1
data:
  ProcessingStateRequeueInterval: 10s
kind: ConfigMap
metadata:
  creationTimestamp: "2022-12-01T14:02:14Z"
  name: sap-btp-manager
  namespace: kyma-system
  resourceVersion: "6476"
  uid: f6f522db-9b4c-4254-a7ae-7e306305544d
```

closes: https://github.com/kyma-project/btp-manager/issues/31
