### PR TITLE
Fix for passing wrong value into cluster.id + sap-btp-manager change …

### DIFF
--- a/operator/controllers/btpoperator_controller.go
+++ b/operator/controllers/btpoperator_controller.go
@@ -319,7 +319,7 @@ func (r *BtpOperatorReconciler) getInstallInfo(ctx context.Context, cr *v1alpha1
 						},
 					},
 					"cluster": map[string]interface{}{
-						"id": string(secret.Data["clientid"]),
+						"id": string(secret.Data["cluster_id"]),
 					},
 				},
 			},
@@ -443,13 +443,8 @@ func (r *BtpOperatorReconciler) watchSecretPredicates() predicate.Funcs {
 			if !ok {
 				return false
 			}
-			newSecret, ok := e.ObjectNew.(*corev1.Secret)
-			if !ok {
-				return false
-			}
-			if (oldSecret.Name == secretName && oldSecret.Namespace == chartNamespace) &&
-				(newSecret.Name == secretName && newSecret.Namespace == chartNamespace) {
-				return !reflect.DeepEqual(oldSecret.Data, newSecret.Data)
+			if oldSecret.Name == secretName && oldSecret.Namespace == chartNamespace {
+				return true
 			}
 			return false
 		},


### PR DESCRIPTION
…was not triggering reconciliation

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Fix for passing wrong value into cluster.id
- Fix for sap-btp-manager change is not triggering reconciliation
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
