### PR TITLE
Platform independent tests

### DIFF
--- a/operator/controllers/suite_test.go
+++ b/operator/controllers/suite_test.go
@@ -18,8 +18,10 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -63,7 +65,9 @@ var _ = BeforeSuite(func() {
 		CRDDirectoryPaths:     []string{filepath.Join("..", "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
 	}
-	Expect(os.Setenv("KUBEBUILDER_ASSETS", "../bin/k8s/1.25.0-darwin-arm64")).To(Succeed())
+	kubeVersion := "1.25.0"
+	k8sBinPath := fmt.Sprintf("../bin/k8s/%v-%v-%v", kubeVersion, runtime.GOOS, runtime.GOARCH)
+	Expect(os.Setenv("KUBEBUILDER_ASSETS", k8sBinPath)).To(Succeed())
 
 	var err error
 	// cfg is defined in this file globally.


### PR DESCRIPTION
At the moment, tests have hardcoded dependency on darwin and arm64. Trying to run them on other architectures / operating systems fails with similar error:

```
  Unexpected error:
      <*fmt.wrapError | 0xc0009ae5a0>: {
          msg: "unable to start control plane itself: failed to start the controlplane. retried 5 times: fork/exec ../bin/k8s/1.25.0-darwin-arm64/etcd: no such file or directory",
          err: <*fmt.wrapError | 0xc0009ae580>{
              msg: "failed to start the controlplane. retried 5 times: fork/exec ../bin/k8s/1.25.0-darwin-arm64/etcd: no such file or directory",
              err: <*fs.PathError | 0xc000a18330>{
                  Op: "fork/exec",
                  Path: "../bin/k8s/1.25.0-darwin-arm64/etcd",
                  Err: <syscall.Errno>0x2,
              },
          },
      }
      unable to start control plane itself: failed to start the controlplane. retried 5 times: fork/exec ../bin/k8s/1.25.0-darwin-arm64/etcd: no such file or directory occurred

...

  Test Panicked
  runtime error: invalid memory address or nil pointer dereference

...

Ran 7 of 0 Specs in 0.011 seconds
FAIL! -- 0 Passed | 7 Failed | 0 Pending | 0 Skipped
```

This PR tries to remove that dependency and allows running them on other supported architectures and operating systems.