### PR TITLE
CI/CD: Add separate action for unit tests

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,6 +1,3 @@
-# This workflow will build a golang project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
-
 name: Make-Unit-Tests
 
 on:
@@ -28,5 +25,5 @@ jobs:
 
     - name: Unit tests
       run: |
-        make test
+        make -C operator test
       

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,32 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Make-Unit-Tests
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+        - operator/**
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.18
+
+    - name: Unit tests
+      run: |
+        make test
+      

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,4 +1,4 @@
-name: Make-Unit-Tests
+name: make-unit-tests
 
 on:
   pull_request:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,7 +1,11 @@
 name: make-unit-tests
 
 on:
-  pull_request:
+ push:
+   branches: [ "main" ]
+   # Publish semver tags as releases.
+   tags: [ 'v*.*.*' ]
+ pull_request:
     branches: [ main ]
     paths:
         - operator/**

--- a/operator/main.go
+++ b/operator/main.go
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License.
+limitations under the License. 
 */
 
 package main

--- a/operator/main.go
+++ b/operator/main.go
@@ -11,7 +11,7 @@ Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
-limitations under the License. 
+limitations under the License.
 */
 
 package main


### PR DESCRIPTION
To parallelize jobs, this change introduces an action that runs make test in a separate workflow