### PR TITLE
Unify configuration of hard delete timeout

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,12 +8,12 @@ $ manager --help
 Usage of ./manager:
   -chart-namespace string
     	Namespace to install chart resources. (default "kyma-system")
-  -chart-path string
-    	Module chart path. (default "./module-chart")
   -config-name string
     	ConfigMap name with configuration knobs for the btp-manager internals. (default "sap-btp-manager")
   -deployment-name string
     	Name of the deployment of sap-btp-operator for deprovisioning. (default "sap-btp-operator-controller-manager")
+  -hard-delete-timeout duration
+    	Hard delete timeout. (default 20m0s)
   -health-probe-bind-address string
     	The address the probe endpoint binds to. (default ":8081")
   -kubeconfig string

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,7 +28,7 @@ Usage of ./manager:
     	Requeue interval for state "ready". (default 1h0m0s)
   -ready-timeout duration
     	Helm chart timeout. (default 1m0s)
-  -retry-interval duration
+  -hard-delete-check-interval duration
     	Hard delete retry interval. (default 10s)
   -secret-name string
     	Secret name with input values for sap-btp-operator chart templating. (default "sap-btp-manager")
@@ -59,5 +59,5 @@ data:
   ProcessingStateRequeueInterval: 5m
   ReadyStateRequeueInterval: 1h
   ReadyTimeout: 1m
-  RetryInterval: 10s
+  HardDeleteCheckInterval: 10s
 ```

--- a/examples/btp-operator-configmap.yaml
+++ b/examples/btp-operator-configmap.yaml
@@ -12,3 +12,4 @@ data:
   ReadyStateRequeueInterval: 1h
   ReadyTimeout: 1m
   RetryInterval: 10s
+  HardDeleteTimeout: 20m

--- a/examples/btp-operator-configmap.yaml
+++ b/examples/btp-operator-configmap.yaml
@@ -11,5 +11,5 @@ data:
   ProcessingStateRequeueInterval: 5m
   ReadyStateRequeueInterval: 1h
   ReadyTimeout: 1m
-  RetryInterval: 10s
+  HardDeleteCheckInterval: 10s
   HardDeleteTimeout: 20m

--- a/operator/controllers/btpoperator_controller.go
+++ b/operator/controllers/btpoperator_controller.go
@@ -62,6 +62,7 @@ var (
 	ReadyStateRequeueInterval      = time.Hour * 1
 	ReadyTimeout                   = time.Minute * 1
 	RetryInterval                  = time.Second * 10
+	HardDeleteTimeout              = time.Minute * 20
 )
 
 const (
@@ -103,13 +104,8 @@ type BtpOperatorReconciler struct {
 	client.Client
 	*rest.Config
 	Scheme                *runtime.Scheme
-	hardDeleteTimeout     time.Duration
 	ChartPath             string
 	WaitForChartReadiness bool
-}
-
-func (r *BtpOperatorReconciler) SetHardDeleteTimeout(timeout time.Duration) {
-	r.hardDeleteTimeout = timeout
 }
 
 //+kubebuilder:rbac:groups=operator.kyma-project.io,resources=btpoperators,verbs=get;list;watch;create;update;patch;delete
@@ -444,6 +440,8 @@ func (r *BtpOperatorReconciler) reconcileConfig(object client.Object) []reconcil
 			ReadyTimeout, err = time.ParseDuration(v)
 		case "RetryInterval":
 			RetryInterval, err = time.ParseDuration(v)
+		case "HardDeleteTimeout":
+			HardDeleteTimeout, err = time.ParseDuration(v)
 		default:
 			logger.Info("unknown config update key", k, v)
 		}
@@ -572,8 +570,8 @@ func (r *BtpOperatorReconciler) handleDeprovisioning(ctx context.Context, cr *v1
 				return err
 			}
 		}
-	case <-time.After(r.hardDeleteTimeout):
-		logger.Info("hard delete timeout reached", "duration", r.hardDeleteTimeout)
+	case <-time.After(HardDeleteTimeout):
+		logger.Info("hard delete timeout reached", "duration", HardDeleteTimeout)
 		timeoutChannel <- true
 		if err := r.UpdateBtpOperatorStatus(ctx, cr, types.StateDeleting, SoftDeleting, "Being soft deleted"); err != nil {
 			logger.Error(err, "failed to update status")
@@ -660,14 +658,14 @@ func (r *BtpOperatorReconciler) handleHardDelete(ctx context.Context, namespaces
 			return
 		}
 
-		time.Sleep(r.hardDeleteTimeout / 20)
+		time.Sleep(HardDeleteTimeout / 20)
 	}
 }
 
 func (r *BtpOperatorReconciler) hardDelete(ctx context.Context, gvk schema.GroupVersionKind, namespaces *corev1.NamespaceList) error {
 	object := &unstructured.Unstructured{}
 	object.SetGroupVersionKind(gvk)
-	deleteCtx, cancel := context.WithTimeout(ctx, r.hardDeleteTimeout/2)
+	deleteCtx, cancel := context.WithTimeout(ctx, HardDeleteTimeout/2)
 	defer cancel()
 
 	for _, namespace := range namespaces.Items {

--- a/operator/controllers/btpoperator_controller.go
+++ b/operator/controllers/btpoperator_controller.go
@@ -61,7 +61,7 @@ var (
 	ProcessingStateRequeueInterval = time.Minute * 5
 	ReadyStateRequeueInterval      = time.Hour * 1
 	ReadyTimeout                   = time.Minute * 1
-	RetryInterval                  = time.Second * 10
+	HardDeleteCheckInterval        = time.Second * 10
 	HardDeleteTimeout              = time.Minute * 20
 )
 
@@ -438,8 +438,8 @@ func (r *BtpOperatorReconciler) reconcileConfig(object client.Object) []reconcil
 			ReadyStateRequeueInterval, err = time.ParseDuration(v)
 		case "ReadyTimeout":
 			ReadyTimeout, err = time.ParseDuration(v)
-		case "RetryInterval":
-			RetryInterval, err = time.ParseDuration(v)
+		case "HardDeleteCheckInterval":
+			HardDeleteCheckInterval, err = time.ParseDuration(v)
 		case "HardDeleteTimeout":
 			HardDeleteTimeout, err = time.ParseDuration(v)
 		default:
@@ -658,7 +658,7 @@ func (r *BtpOperatorReconciler) handleHardDelete(ctx context.Context, namespaces
 			return
 		}
 
-		time.Sleep(HardDeleteTimeout / 20)
+		time.Sleep(HardDeleteCheckInterval)
 	}
 }
 

--- a/operator/controllers/suite_test.go
+++ b/operator/controllers/suite_test.go
@@ -97,6 +97,7 @@ var _ = BeforeSuite(func() {
 	}
 	k8sClientFromManager = k8sManager.GetClient()
 	HardDeleteTimeout = hardDeleteTimeout
+	HardDeleteCheckInterval = hardDeleteTimeout / 20
 
 	err = reconciler.SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())

--- a/operator/controllers/suite_test.go
+++ b/operator/controllers/suite_test.go
@@ -96,7 +96,7 @@ var _ = BeforeSuite(func() {
 		WaitForChartReadiness: false,
 	}
 	k8sClientFromManager = k8sManager.GetClient()
-	reconciler.SetHardDeleteTimeout(hardDeleteTimeout)
+	HardDeleteTimeout = hardDeleteTimeout
 
 	err = reconciler.SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())

--- a/operator/main.go
+++ b/operator/main.go
@@ -69,7 +69,7 @@ func main() {
 	flag.DurationVar(&controllers.ProcessingStateRequeueInterval, "processing-state-requeue-interval", controllers.ProcessingStateRequeueInterval, `Requeue interval for state "processing".`)
 	flag.DurationVar(&controllers.ReadyStateRequeueInterval, "ready-state-requeue-interval", controllers.ReadyStateRequeueInterval, `Requeue interval for state "ready".`)
 	flag.DurationVar(&controllers.ReadyTimeout, "ready-timeout", controllers.ReadyTimeout, "Helm chart timeout.")
-	flag.DurationVar(&controllers.RetryInterval, "retry-interval", controllers.RetryInterval, "Hard delete retry interval.")
+	flag.DurationVar(&controllers.HardDeleteCheckInterval, "hard-delete-check-interval", controllers.HardDeleteCheckInterval, "Hard delete retry interval.")
 	flag.DurationVar(&controllers.HardDeleteTimeout, "hard-delete-timeout", controllers.HardDeleteTimeout, "Hard delete timeout.")
 	opts := zap.Options{
 		Development: true,

--- a/operator/main.go
+++ b/operator/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"flag"
 	"os"
-	"time"
 
 	//test
 
@@ -44,8 +43,7 @@ var (
 )
 
 const (
-	hardDeleteTimeout = time.Minute * 20
-	chartPath         = "./module-chart"
+	chartPath = "./module-chart"
 )
 
 func init() {
@@ -72,6 +70,7 @@ func main() {
 	flag.DurationVar(&controllers.ReadyStateRequeueInterval, "ready-state-requeue-interval", controllers.ReadyStateRequeueInterval, `Requeue interval for state "ready".`)
 	flag.DurationVar(&controllers.ReadyTimeout, "ready-timeout", controllers.ReadyTimeout, "Helm chart timeout.")
 	flag.DurationVar(&controllers.RetryInterval, "retry-interval", controllers.RetryInterval, "Hard delete retry interval.")
+	flag.DurationVar(&controllers.HardDeleteTimeout, "hard-delete-timeout", controllers.HardDeleteTimeout, "Hard delete timeout.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -110,8 +109,6 @@ func main() {
 		ChartPath:             chartPath,
 		WaitForChartReadiness: true,
 	}
-
-	reconciler.SetHardDeleteTimeout(hardDeleteTimeout)
 
 	if err = reconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "BtpOperator")


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

PR https://github.com/kyma-project/btp-manager/pull/41 has introduced dynamic configurability of btp-manager timeouts, sync intervals and other basic settings. The hard delete timeout was implemented differently. 

This PR unifies the code to make the configuration of `HardDeleteTimeout` match the conventions with all other timeouts and intervals.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
