### PR TITLE
Decrease execution time of controller integration test

### DIFF
--- a/.github/workflows/make-test.yaml
+++ b/.github/workflows/make-test.yaml
@@ -1,4 +1,4 @@
-name: make-unit-tests
+name: make-test
 
 on:
  push:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -19,13 +19,14 @@ jobs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
+          ~/btp-manager/operator/bin
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.19
 
     - name: Unit tests
       run: |


### PR DESCRIPTION
PR introduces additional caching and does the checks in controller_test.go concurrently