### PR TITLE
Github Actions: Exclude Readme.md from pipline execution

### DIFF
--- a/.github/workflows/e2e-test-k3s.yml
+++ b/.github/workflows/e2e-test-k3s.yml
@@ -1,10 +1,5 @@
 name: e2e-test-k3s
 
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 on:
   pull_request:
     branches: [ main ]

--- a/.github/workflows/e2e-test-k3s.yml
+++ b/.github/workflows/e2e-test-k3s.yml
@@ -10,7 +10,8 @@ on:
     branches: [ main ]
     paths:
         - operator/**
-
+    paths-ignore:
+      - 'operator/README.md'
 jobs:
   run-e2e-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/make-test.yaml
+++ b/.github/workflows/make-test.yaml
@@ -9,6 +9,8 @@ on:
     branches: [ main ]
     paths:
         - operator/**
+    paths-ignore:
+        - 'operator/README.md'
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When Readme is changed in the operator fodler the pipelines do not get triggered 