### PR TITLE
Make test executions not share resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ Dockerfile.cross
 /template.yaml
 .idea/
 /module-chart/manifest/
+/controllers/testdata/test-module-chart/

--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -127,6 +127,7 @@ type BtpOperatorReconciler struct {
 	currentVersion        string
 	updateCheckDone       bool
 	WaitForChartReadiness bool
+	workqueueSize         int
 }
 
 func (r *BtpOperatorReconciler) handleUpdate(ctx context.Context, cr *v1alpha1.BtpOperator, configMap *corev1.ConfigMap) *ErrorWithReason {
@@ -330,6 +331,8 @@ func (r *BtpOperatorReconciler) deleteOrphanedResources(ctx context.Context, con
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
 
 func (r *BtpOperatorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	r.workqueueSize += 1
+	defer func() { r.workqueueSize -= 1 }()
 	logger := log.FromContext(ctx)
 
 	cr := &v1alpha1.BtpOperator{}

--- a/controllers/btpoperator_controller_test.go
+++ b/controllers/btpoperator_controller_test.go
@@ -822,8 +822,12 @@ func testChartPreparation() error {
 	if err != nil {
 		return fmt.Errorf("copying: %v -> %v\n\nout: %v\nerr: %v", src, defaultChartPath, string(out), err)
 	}
+	filterWebhooksDisabled := os.Getenv("DISABLE_WEBHOOK_FILTER_FOR_TESTS")
 
 	return filepath.WalkDir(defaultChartPath, func(path string, de fs.DirEntry, err error) error {
+		if filterWebhooksDisabled == "true" {
+			return nil
+		}
 		if de.IsDir() {
 			return nil
 		}

--- a/controllers/btpoperator_controller_test.go
+++ b/controllers/btpoperator_controller_test.go
@@ -780,7 +780,18 @@ func filterWebhooks(file []byte) (filtered []byte, hasWebhook bool) {
 	for _, l := range lines {
 		buffer = append(buffer, []byte(l+"\n")...)
 		if l == "---" && len(buffer) != 0 {
-			if !isWebhook {
+			if isWebhook {
+				split := strings.Split(string(buffer), "\n")
+				// hack for one case where helm templating block spans across two adjacent documents
+				for _, spl := range split {
+					splTrunc := strings.ReplaceAll(spl, " ", "")
+					splTrunc = strings.ReplaceAll(splTrunc, "-", "")
+					if splTrunc != "{{end}}" {
+						break
+					}
+					filtered = append(filtered, []byte(spl+"\n")...)
+				}
+			} else {
 				filtered = append(filtered, buffer...)
 			}
 			buffer = []byte{}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -42,7 +42,7 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-const hardDeleteTimeout = time.Second * 2
+const hardDeleteTimeout = time.Second * 1
 
 var (
 	cfg                  *rest.Config

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -122,6 +122,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
+	Eventually(func() int { return reconciler.workqueueSize }).Should(Equal(0))
 	cancel()
 	By("tearing down the test environment")
 	err := testEnv.Stop()


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

It was identified that sharing resources between tests could significantly contribute to the test flakiness as described in https://github.com/kyma-project/btp-manager/issues/88. This PR tries to remove accidental undesired dependencies between tests. This PR also removes ad-hoc `time.Sleep` lines from the tests and adds extra checks for more deterministic behaviour.

- first commit https://github.com/kyma-project/btp-manager/pull/94/commits/6c751b4ba563458e47a62fb4bb7fb245db8f93f3 - removes this resource reuse between tests
- second commit https://github.com/kyma-project/btp-manager/commit/7f5d016f213a9c870db1a2ad1e7adf606a9c6d8b - creates a copy of btp-operator chart just for tests without webhooks so we don't have to delete them from testenv kube-apiserver as part of the test execution