### PR TITLE
Replace polling with watch

### DIFF
--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -1047,6 +1047,11 @@ func (r *BtpOperatorReconciler) softDelete(ctx context.Context, gvk schema.Group
 
 	isBinding := gvk.Kind == btpOperatorServiceBinding
 	for _, item := range list.Items {
+		if item.GetDeletionTimestamp().IsZero() {
+			if err := r.Delete(ctx, &item); err != nil {
+				return err
+			}
+		}
 		item.SetFinalizers([]string{})
 		if err := r.Update(ctx, &item); err != nil {
 			return err

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"github.com/onsi/ginkgo/v2/types"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,9 +27,14 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	. "github.com/onsi/ginkgo/v2"
+	ginkgotypes "github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	gomegatypes "github.com/onsi/gomega/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -39,13 +43,21 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/kyma-project/btp-manager/api/v1alpha1"
+	"github.com/kyma-project/module-manager/pkg/types"
 	//+kubebuilder:scaffold:imports
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-const hardDeleteTimeout = time.Second * 1
+var logger = logf.Log.WithName("suite_test")
+
+const (
+	hardDeleteTimeout = time.Millisecond * 200
+	resourceAdded     = "added"
+	resourceUpdated   = "updated"
+	resourceDeleted   = "deleted"
+)
 
 var (
 	cfg                  *rest.Config
@@ -56,7 +68,51 @@ var (
 	ctx                  context.Context
 	cancel               context.CancelFunc
 	reconciler           *BtpOperatorReconciler
+	updateCh             chan resourceUpdate = make(chan resourceUpdate, 1000)
 )
+
+type resourceUpdate struct {
+	Cr     *v1alpha1.BtpOperator
+	Action string
+}
+
+func resourceUpdateHandler(obj any, t string) {
+	if cr, ok := obj.(*v1alpha1.BtpOperator); ok {
+		logger.V(1).Info("Triggered update handler for BTPOperator CR", "name", cr.Name, "action", t, "state", cr.Status.State, "conditions", cr.Status.Conditions)
+		updateCh <- resourceUpdate{Cr: cr, Action: t}
+	}
+}
+
+func matchState(state types.State) gomegatypes.GomegaMatcher {
+	return MatchFields(IgnoreExtras, Fields{
+		"Action": Equal(resourceUpdated),
+		"Cr": PointTo(MatchFields(IgnoreExtras, Fields{
+			"Status": MatchFields(IgnoreExtras, Fields{
+				"State": Equal(state),
+			}),
+		})),
+	})
+}
+
+func matchReadyCondition(state types.State, status metav1.ConditionStatus, reason Reason) gomegatypes.GomegaMatcher {
+	return MatchFields(IgnoreExtras, Fields{
+		"Action": Equal(resourceUpdated),
+		"Cr": PointTo(MatchFields(IgnoreExtras, Fields{
+			"Status": MatchFields(IgnoreExtras, Fields{
+				"State": Equal(state),
+				"Conditions": ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":   Equal(ReadyType),
+					"Reason": Equal(string(reason)),
+					"Status": Equal(status),
+				}))),
+			}),
+		})),
+	})
+}
+
+func matchDeleted() gomegatypes.GomegaMatcher {
+	return MatchFields(IgnoreExtras, Fields{"Action": Equal(resourceDeleted)})
+}
 
 func TestAPIs(t *testing.T) {
 
@@ -64,10 +120,12 @@ func TestAPIs(t *testing.T) {
 
 	suiteCfg, reporterCfg := GinkgoConfiguration()
 	ReconfigureGinkgo(&reporterCfg, &suiteCfg)
+	SetDefaultEventuallyTimeout(time.Second * 5)
+	reporterCfg.Verbose = true
 	RunSpecs(t, "Controller Suite", suiteCfg, reporterCfg)
 }
 
-func ReconfigureGinkgo(reporterCfg *types.ReporterConfig, suiteCfg *types.SuiteConfig) {
+func ReconfigureGinkgo(reporterCfg *ginkgotypes.ReporterConfig, suiteCfg *ginkgotypes.SuiteConfig) {
 	verbosity := os.Getenv("GINKGO_VERBOSE_FLAG")
 	switch {
 	case verbosity == "ginkgo.v":
@@ -131,11 +189,21 @@ var _ = BeforeSuite(func() {
 	err = reconciler.SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
+	informer, err := k8sManager.GetCache().GetInformer(ctx, &v1alpha1.BtpOperator{})
+	Expect(err).ToNot(HaveOccurred())
+	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    func(o any) { resourceUpdateHandler(o, resourceAdded) },
+		UpdateFunc: func(o, n any) { resourceUpdateHandler(n, resourceUpdated) },
+		DeleteFunc: func(o any) { resourceUpdateHandler(o, resourceDeleted) },
+	})
+
 	go func() {
 		defer GinkgoRecover()
 		err = k8sManager.Start(ctx)
 		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
 	}()
+
+	k8sManager.GetCache().WaitForCacheSync(ctx)
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

Resource state transitions in tests get asserted by polling. However, states can transition faster than the polling period at which point state sampling can miss change and assertion can fail. This PR introduces watch on resource changes to not miss any temporary state transitions.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
depends on: https://github.com/kyma-project/btp-manager/pull/94, https://github.com/kyma-project/btp-manager/pull/95
related to: https://github.com/kyma-project/btp-manager/issues/88