### PR TITLE
Module update based on manifests without dependencies to module-manager

### DIFF
--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -767,7 +767,7 @@ func (r *BtpOperatorReconciler) deleteAllInstalledResources(ctx context.Context,
 		obj := &unstructured.Unstructured{}
 		obj.SetGroupVersionKind(gvk)
 		if err := r.DeleteAllOf(ctx, obj, client.InNamespace(ChartNamespace), managedByLabelFilter); err != nil {
-			if !k8serrors.IsNotFound(err) && !k8serrors.IsMethodNotSupported(err) && !meta.IsNoMatchError(err) {
+			if !(k8serrors.IsNotFound(err) || k8serrors.IsMethodNotSupported(err) || meta.IsNoMatchError(err)) {
 				return err
 			}
 		}

--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -929,7 +929,7 @@ func (r *BtpOperatorReconciler) HandleReadyState(ctx context.Context, cr *v1alph
 		return r.UpdateBtpOperatorStatus(ctx, cr, types.StateError, ReconcileFailed, err.Error())
 	}
 
-	return nil
+	return r.UpdateBtpOperatorStatus(ctx, cr, types.StateReady, ReconcileSucceeded, "Module reconciliation succeeded")
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -936,7 +936,7 @@ func (r *BtpOperatorReconciler) HandleReadyState(ctx context.Context, cr *v1alph
 	}
 
 	logger.Info("reconciliation succeeded")
-	return r.UpdateBtpOperatorStatus(ctx, cr, types.StateReady, ReconcileSucceeded, "Module reconciliation succeeded")
+	return nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/btpoperator_controller_test.go
+++ b/controllers/btpoperator_controller_test.go
@@ -267,6 +267,16 @@ var _ = Describe("BTP Operator controller", Ordered, func() {
 			manifestHandler = &manifest.Handler{Scheme: k8sManager.GetScheme()}
 		})
 
+		AfterAll(func() {
+			err := os.RemoveAll(chartUpdatePath)
+			Expect(err).To(BeNil())
+			err = os.RemoveAll(resourcesUpdatePath)
+			Expect(err).To(BeNil())
+
+			ChartPath = defaultChartPath
+			ResourcesPath = defaultResourcesPath
+		})
+
 		BeforeEach(func() {
 			cr = createBtpOperator()
 			Expect(k8sClient.Create(ctx, cr)).To(Succeed())

--- a/controllers/btpoperator_controller_test.go
+++ b/controllers/btpoperator_controller_test.go
@@ -348,7 +348,7 @@ var _ = Describe("BTP Operator controller", Ordered, func() {
 		})
 
 		When("update some resources names and bump chart version", Label("test-update"), func() {
-			It("resources with new names should be created, resources with old names should be deleted, unchanged resources should stay and receive new chart version", func() {
+			It("all applied resources should receive new chart version, resources with new names should replace the ones with old names", func() {
 				updateManifestsNum := 3
 				err := moveOrCopyNFilesFromDirToDir(updateManifestsNum, false, getApplyPath(), getTempPath())
 				Expect(err).To(BeNil())
@@ -389,12 +389,13 @@ var _ = Describe("BTP Operator controller", Ordered, func() {
 
 		When("remove some manifests and bump chart version", Label("test-update"), func() {
 			It("resources without manifests should be removed, unchanged resources should stay and receive new chart version", func() {
-				allManifests := 99 // higher number than number of manifests
-				err = moveOrCopyNFilesFromDirToDir(allManifests, true, getApplyPath(), getTempPath())
+				allManifests, err := manifestHandler.GetManifestsFromDir(getApplyPath())
+				Expect(err).To(BeNil())
+				err = moveOrCopyNFilesFromDirToDir(len(allManifests), true, getApplyPath(), getTempPath())
 				Expect(err).To(BeNil())
 
 				remainingManifestsNum := 4
-				err := moveOrCopyNFilesFromDirToDir(remainingManifestsNum, true, getTempPath(), getApplyPath())
+				err = moveOrCopyNFilesFromDirToDir(remainingManifestsNum, true, getTempPath(), getApplyPath())
 				Expect(err).To(BeNil())
 
 				expectedDeleteObjs, err := manifestHandler.CollectObjectsFromDir(getTempPath())

--- a/controllers/btpoperator_controller_test.go
+++ b/controllers/btpoperator_controller_test.go
@@ -333,7 +333,6 @@ var _ = Describe("BTP Operator controller", Ordered, func() {
 					Name:      cr.Name,
 				}})
 				Expect(err).To(BeNil())
-				Eventually(updateCh).Should(Receive(matchReadyCondition(types.StateReady, metav1.ConditionTrue, ReconcileSucceeded)))
 
 				actualNumOfOldResources, err := countResourcesForGivenChartVer(gvks, initChartVersion)
 				Expect(err).To(BeNil())
@@ -372,7 +371,6 @@ var _ = Describe("BTP Operator controller", Ordered, func() {
 					Name:      cr.Name,
 				}})
 				Expect(err).To(BeNil())
-				Eventually(updateCh).Should(Receive(matchReadyCondition(types.StateReady, metav1.ConditionTrue, ReconcileSucceeded)))
 
 				actualNumOfOldResources, err := countResourcesForGivenChartVer(gvks, initChartVersion)
 				Expect(err).To(BeNil())
@@ -415,7 +413,6 @@ var _ = Describe("BTP Operator controller", Ordered, func() {
 					Name:      cr.Name,
 				}})
 				Expect(err).To(BeNil())
-				Eventually(updateCh).Should(Receive(matchReadyCondition(types.StateReady, metav1.ConditionTrue, ReconcileSucceeded)))
 
 				actualNumOfOldResources, err := countResourcesForGivenChartVer(gvks, initChartVersion)
 				Expect(err).To(BeNil())
@@ -438,7 +435,6 @@ var _ = Describe("BTP Operator controller", Ordered, func() {
 					Name:      cr.Name,
 				}})
 				Expect(err).To(BeNil())
-				Eventually(updateCh).Should(Receive(matchReadyCondition(types.StateReady, metav1.ConditionTrue, ReconcileSucceeded)))
 
 				actualNumOfResourcesWithOldChartVer, err := countResourcesForGivenChartVer(gvks, initChartVersion)
 				Expect(err).To(BeNil())

--- a/controllers/btpoperator_controller_test.go
+++ b/controllers/btpoperator_controller_test.go
@@ -328,6 +328,7 @@ var _ = Describe("BTP Operator controller", Ordered, func() {
 				err = ymlutils.UpdateChartVersion(chartUpdatePath, newChartVersion)
 				Expect(err).To(BeNil())
 
+				Eventually(reconciler.workqueueSize).WithTimeout(time.Second * 5).WithPolling(time.Millisecond * 100).Should(Equal(0))
 				_, err = reconciler.Reconcile(ctx, controllerruntime.Request{NamespacedName: apimachienerytypes.NamespacedName{
 					Namespace: cr.Namespace,
 					Name:      cr.Name,
@@ -366,6 +367,7 @@ var _ = Describe("BTP Operator controller", Ordered, func() {
 				err = ymlutils.UpdateChartVersion(chartUpdatePath, newChartVersion)
 				Expect(err).To(BeNil())
 
+				Eventually(reconciler.workqueueSize).WithTimeout(time.Second * 5).WithPolling(time.Millisecond * 100).Should(Equal(0))
 				_, err = reconciler.Reconcile(ctx, controllerruntime.Request{NamespacedName: apimachienerytypes.NamespacedName{
 					Namespace: cr.Namespace,
 					Name:      cr.Name,
@@ -408,6 +410,7 @@ var _ = Describe("BTP Operator controller", Ordered, func() {
 				err = ymlutils.UpdateChartVersion(chartUpdatePath, newChartVersion)
 				Expect(err).To(BeNil())
 
+				Eventually(reconciler.workqueueSize).WithTimeout(time.Second * 5).WithPolling(time.Millisecond * 100).Should(Equal(0))
 				_, err = reconciler.Reconcile(ctx, controllerruntime.Request{NamespacedName: apimachienerytypes.NamespacedName{
 					Namespace: cr.Namespace,
 					Name:      cr.Name,
@@ -430,6 +433,7 @@ var _ = Describe("BTP Operator controller", Ordered, func() {
 				err = ymlutils.UpdateChartVersion(chartUpdatePath, newChartVersion)
 				Expect(err).To(BeNil())
 
+				Eventually(reconciler.workqueueSize).WithTimeout(time.Second * 5).WithPolling(time.Millisecond * 100).Should(Equal(0))
 				_, err = reconciler.Reconcile(ctx, controllerruntime.Request{NamespacedName: apimachienerytypes.NamespacedName{
 					Namespace: cr.Namespace,
 					Name:      cr.Name,

--- a/controllers/btpoperator_controller_test.go
+++ b/controllers/btpoperator_controller_test.go
@@ -254,6 +254,7 @@ var _ = Describe("BTP Operator controller", Ordered, func() {
 		var initApplyObjs []runtime.Object
 		var gvks []schema.GroupVersionKind
 		var initResourcesNum int
+		var actualWorkqueueSize func() int
 		var err error
 
 		BeforeAll(func() {
@@ -265,6 +266,7 @@ var _ = Describe("BTP Operator controller", Ordered, func() {
 			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
 
 			manifestHandler = &manifest.Handler{Scheme: k8sManager.GetScheme()}
+			actualWorkqueueSize = func() int { return reconciler.workqueueSize }
 		})
 
 		AfterAll(func() {
@@ -305,6 +307,7 @@ var _ = Describe("BTP Operator controller", Ordered, func() {
 			cr = &v1alpha1.BtpOperator{}
 			Expect(k8sClient.Get(ctx, client.ObjectKey{Namespace: defaultNamespace, Name: btpOperatorName}, cr)).Should(Succeed())
 			Expect(k8sClient.Delete(ctx, cr)).Should(Succeed())
+			Eventually(updateCh).Should(Receive(matchState(types.StateReady)))
 			Eventually(updateCh).Should(Receive(matchDeleted()))
 			Expect(isCrNotFound()).To(BeTrue())
 
@@ -328,7 +331,7 @@ var _ = Describe("BTP Operator controller", Ordered, func() {
 				err = ymlutils.UpdateChartVersion(chartUpdatePath, newChartVersion)
 				Expect(err).To(BeNil())
 
-				Eventually(reconciler.workqueueSize).WithTimeout(time.Second * 5).WithPolling(time.Millisecond * 100).Should(Equal(0))
+				Eventually(actualWorkqueueSize).WithTimeout(time.Second * 5).WithPolling(time.Millisecond * 100).Should(Equal(0))
 				_, err = reconciler.Reconcile(ctx, controllerruntime.Request{NamespacedName: apimachienerytypes.NamespacedName{
 					Namespace: cr.Namespace,
 					Name:      cr.Name,
@@ -367,7 +370,7 @@ var _ = Describe("BTP Operator controller", Ordered, func() {
 				err = ymlutils.UpdateChartVersion(chartUpdatePath, newChartVersion)
 				Expect(err).To(BeNil())
 
-				Eventually(reconciler.workqueueSize).WithTimeout(time.Second * 5).WithPolling(time.Millisecond * 100).Should(Equal(0))
+				Eventually(actualWorkqueueSize).WithTimeout(time.Second * 5).WithPolling(time.Millisecond * 100).Should(Equal(0))
 				_, err = reconciler.Reconcile(ctx, controllerruntime.Request{NamespacedName: apimachienerytypes.NamespacedName{
 					Namespace: cr.Namespace,
 					Name:      cr.Name,
@@ -410,7 +413,7 @@ var _ = Describe("BTP Operator controller", Ordered, func() {
 				err = ymlutils.UpdateChartVersion(chartUpdatePath, newChartVersion)
 				Expect(err).To(BeNil())
 
-				Eventually(reconciler.workqueueSize).WithTimeout(time.Second * 5).WithPolling(time.Millisecond * 100).Should(Equal(0))
+				Eventually(actualWorkqueueSize).WithTimeout(time.Second * 5).WithPolling(time.Millisecond * 100).Should(Equal(0))
 				_, err = reconciler.Reconcile(ctx, controllerruntime.Request{NamespacedName: apimachienerytypes.NamespacedName{
 					Namespace: cr.Namespace,
 					Name:      cr.Name,
@@ -433,7 +436,7 @@ var _ = Describe("BTP Operator controller", Ordered, func() {
 				err = ymlutils.UpdateChartVersion(chartUpdatePath, newChartVersion)
 				Expect(err).To(BeNil())
 
-				Eventually(reconciler.workqueueSize).WithTimeout(time.Second * 5).WithPolling(time.Millisecond * 100).Should(Equal(0))
+				Eventually(actualWorkqueueSize).WithTimeout(time.Second * 5).WithPolling(time.Millisecond * 100).Should(Equal(0))
 				_, err = reconciler.Reconcile(ctx, controllerruntime.Request{NamespacedName: apimachienerytypes.NamespacedName{
 					Namespace: cr.Namespace,
 					Name:      cr.Name,

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -24,13 +24,12 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/zap/zapcore"
-
 	. "github.com/onsi/ginkgo/v2"
 	ginkgotypes "github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	gomegatypes "github.com/onsi/gomega/types"
+	"go.uber.org/zap/zapcore"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -115,7 +114,6 @@ func matchDeleted() gomegatypes.GomegaMatcher {
 }
 
 func TestAPIs(t *testing.T) {
-
 	RegisterFailHandler(Fail)
 
 	suiteCfg, reporterCfg := GinkgoConfiguration()

--- a/internal/manifest/handler.go
+++ b/internal/manifest/handler.go
@@ -1,7 +1,6 @@
 package manifest
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -70,7 +69,7 @@ func (h *Handler) GetManifestsFromYaml(yamlFile string) ([]string, error) {
 		manifests = append(manifests, part)
 	}
 	if len(manifests) == 0 {
-		return nil, errors.New(fmt.Sprintf("%s does not contain manifests", yamlFile))
+		return nil, nil
 	}
 
 	return manifests, nil

--- a/internal/ymlutils/extractor.go
+++ b/internal/ymlutils/extractor.go
@@ -115,22 +115,28 @@ func ExtractStringValueFromYamlForGivenKey(filePath string, key string) (string,
 
 func CopyManifestsFromYamlsIntoOneYaml(sourceManifestsDir, targetYaml string) error {
 	if err := filepath.Walk(sourceManifestsDir, func(path string, info os.FileInfo, err error) error {
+		if info.IsDir() {
+			return nil
+		}
 		if !strings.HasSuffix(info.Name(), ".yml") && !strings.HasSuffix(info.Name(), ".yaml") {
 			return nil
 		}
 
-		filename := fmt.Sprintf("%s/%s", path, info.Name())
+		filename := fmt.Sprintf(path)
 		input, err := os.ReadFile(filename)
 		if err != nil {
 			return err
 		}
 
-		manifestSeparator := "---\n"
-		err = os.WriteFile(targetYaml, []byte(manifestSeparator), 0644)
+		targetFile, err := os.OpenFile(targetYaml, os.O_RDWR|os.O_APPEND, 0666)
 		if err != nil {
 			return err
 		}
-		err = os.WriteFile(targetYaml, []byte(input), 0644)
+		_, err = targetFile.Write(input)
+		if err != nil {
+			return err
+		}
+		err = targetFile.Close()
 		if err != nil {
 			return err
 		}

--- a/internal/ymlutils/extractor.go
+++ b/internal/ymlutils/extractor.go
@@ -112,3 +112,33 @@ func ExtractStringValueFromYamlForGivenKey(filePath string, key string) (string,
 
 	return "", nil
 }
+
+func CopyManifestsFromYamlsIntoOneYaml(sourceManifestsDir, targetYaml string) error {
+	if err := filepath.Walk(sourceManifestsDir, func(path string, info os.FileInfo, err error) error {
+		if !strings.HasSuffix(info.Name(), ".yml") && !strings.HasSuffix(info.Name(), ".yaml") {
+			return nil
+		}
+
+		filename := fmt.Sprintf("%s/%s", path, info.Name())
+		input, err := os.ReadFile(filename)
+		if err != nil {
+			return err
+		}
+
+		manifestSeparator := "---\n"
+		err = os.WriteFile(targetYaml, []byte(manifestSeparator), 0644)
+		if err != nil {
+			return err
+		}
+		err = os.WriteFile(targetYaml, []byte(input), 0644)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/ymlutils/renamer.go
+++ b/internal/ymlutils/renamer.go
@@ -69,7 +69,7 @@ func UpdateChartVersion(chartPath, newVersion string) error {
 		}
 	}
 	output := strings.Join(lines, "\n")
-	err = os.WriteFile(filename, []byte(output), 0644)
+	err = os.WriteFile(filename, []byte(output), 0700)
 	if err != nil {
 		return err
 	}

--- a/internal/ymlutils/renamer.go
+++ b/internal/ymlutils/renamer.go
@@ -13,17 +13,32 @@ func AddSuffixToNameInManifests(manifestsDir, suffix string) error {
 			return nil
 		}
 
-		filename := fmt.Sprintf("%s/%s", path, info.Name())
+		filename := fmt.Sprintf(path)
 		input, err := os.ReadFile(filename)
 		if err != nil {
 			return err
 		}
 
+		reachedMetadata, reachedSpec := false, false
 		lines := strings.Split(string(input), "\n")
 		for i, line := range lines {
-			line = strings.TrimSpace(line)
-			if strings.HasPrefix(line, "name:") {
+			if strings.HasPrefix(line, "metadata:") {
+				reachedMetadata = true
+				continue
+			}
+			if strings.HasPrefix(line, "spec:") {
+				reachedSpec = true
+				continue
+			}
+			if reachedMetadata && strings.HasPrefix(strings.TrimSpace(line), "name:") {
 				lines[i] = lines[i] + suffix
+				reachedMetadata = false
+				continue
+			}
+			if reachedSpec && strings.HasPrefix(strings.TrimSpace(line), "group:") {
+				lines[i] = lines[i] + suffix
+				reachedSpec = false
+				continue
 			}
 		}
 		output := strings.Join(lines, "\n")

--- a/internal/ymlutils/renamer.go
+++ b/internal/ymlutils/renamer.go
@@ -7,14 +7,13 @@ import (
 	"strings"
 )
 
-func TransformCharts(chartPath string, suffix string) error {
-	root := fmt.Sprintf("%s/templates/", chartPath)
-	if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+func AddSuffixToNameInManifests(manifestsDir, suffix string) error {
+	if err := filepath.Walk(manifestsDir, func(path string, info os.FileInfo, err error) error {
 		if !strings.HasSuffix(info.Name(), ".yml") {
 			return nil
 		}
 
-		filename := fmt.Sprintf("%s/%s", root, info.Name())
+		filename := fmt.Sprintf("%s/%s", path, info.Name())
 		input, err := os.ReadFile(filename)
 		if err != nil {
 			return err
@@ -41,7 +40,7 @@ func TransformCharts(chartPath string, suffix string) error {
 	return nil
 }
 
-func UpdateVersion(chartPath, newVersion string) error {
+func UpdateChartVersion(chartPath, newVersion string) error {
 	filename := fmt.Sprintf("%s/%s", chartPath, "Chart.yaml")
 	input, err := os.ReadFile(filename)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -45,6 +46,7 @@ var (
 func init() {
 
 	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
 
 	//+kubebuilder:scaffold:scheme
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

Continuation of #98.

This pull request introduces changes in the provisioning and update workflows. It replaces module-manager dependency in favour of a new solution based on manifests rendered from the chart. The reconciler deletes outdated resources listed in `module-resources/delete/to-delete.yml` and applies objects fetched from manifests in `module-resources/apply`. The reconciler ensures that specs between manifests and cluster resources stay consistent and doesn't allow any difference between them.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Closes #148.