### PR TITLE
Setup test build cache

### DIFF
--- a/.github/workflows/make-test.yaml
+++ b/.github/workflows/make-test.yaml
@@ -17,7 +17,7 @@ jobs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-          ~/btp-manager/bin
+          /home/runner/work/btp-manager/btp-manager/bin
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

Path kubebuilder `bin` was incorrect and as a result, `bin` didn't get uploaded to the cache and tests were installing `sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2`, `sigs.k8s.io/kustomize/kustomize/v4@v4.5.6`, `sigs.k8s.io/controller-runtime/tools/setup-envtest@latest` every execution, taking ~2 minutes.

```
Tue, 14 Feb 2023 11:28:00 GMT Run make test
Tue, 14 Feb 2023 11:28:00 GMT mkdir -p /home/runner/work/btp-manager/btp-manager/bin
Tue, 14 Feb 2023 11:28:00 GMT GOBIN=/home/runner/work/btp-manager/btp-manager/bin go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2
Tue, 14 Feb 2023 11:28:02 GMT /home/runner/work/btp-manager/btp-manager/bin/controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
Tue, 14 Feb 2023 11:28:05 GMT GOBIN=/home/runner/work/btp-manager/btp-manager/bin go install sigs.k8s.io/kustomize/kustomize/v4@v4.5.6
Tue, 14 Feb 2023 11:28:20 GMT /home/runner/work/btp-manager/btp-manager/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
Tue, 14 Feb 2023 11:28:22 GMT go fmt ./...
Tue, 14 Feb 2023 11:28:22 GMT go vet ./...
Tue, 14 Feb 2023 11:29:38 GMT GOBIN=/home/runner/work/btp-manager/btp-manager/bin go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
Tue, 14 Feb 2023 11:29:39 GMT go: downloading sigs.k8s.io/controller-runtime v0.14.4
Tue, 14 Feb 2023 11:29:39 GMT go: downloading sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20230214070730-08dce9f0bfdc
Tue, 14 Feb 2023 11:29:40 GMT . ./testing/set-env-vars.sh; go test ./... -timeout 30s -coverprofile cover.out -v
Tue, 14 Feb 2023 11:29:55 GMT ?   	github.com/kyma-project/btp-manager	[no test files]
Tue, 14 Feb 2023 11:29:55 GMT ?   	github.com/kyma-project/btp-manager/api/v1alpha1	[no test files]
Tue, 14 Feb 2023 11:30:16 GMT === RUN   TestNewConditionForReason
...
```
With absolute path to kubebuilder `bin` cache, the test time is ~35 seconds.

closes: https://github.com/kyma-project/btp-manager/issues/156