### PR TITLE
Use gopher group in CODEOWNERS instead of enumerating its members

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owners of the repository
-* @PK85 @jaroslaw-pieszka @piotrmiskiewicz @ralikio @szwedm @ukff @wozniakjan @MarekMichali
+* @kyma-project/gopher
 
 # Owners of all .md files in the repository
-*.md @IwonaLanger @grego952 @NHingerl @mmitoraj @nataliasitko
+*.md @kyma-project/technical-writers


### PR DESCRIPTION
https://github.com/orgs/kyma-project/teams/gopher/members
https://github.com/orgs/kyma-project/teams/technical-writers/members