### PR TITLE
Remove reason of conflicting settings message from Ginkgo library

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -127,7 +127,6 @@ func TestAPIs(t *testing.T) {
 	} else {
 		SetDefaultEventuallyTimeout(time.Second * 5)
 	}
-	reporterCfg.Verbose = true
 	RunSpecs(t, "Controller Suite", suiteCfg, reporterCfg)
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

We set verbosity for Ginkgo library in ReconfigureGinkgo based on env variable setting.
Additional assignment allows to set verbosity to two different levels and that causes Ginkgo library to report conflicting settings.

Changes proposed in this pull request:

- removal of accidentally added assignment

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
