### PR TITLE
Include manifests from modue-resources/delete in the deprovisioning

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -84,7 +84,7 @@ Service Bindings and Service Instances across all Namespaces. The time limit for
 After this time, or in case of an error, the process goes into soft delete mode, which runs deletion of finalizers from Service Instances and Service Bindings.
 In order to delete finalizers the reconciler deletes module deployment and webhooks.
 Regardless of mode, in the next step, all SAP BTP Service Operator resources marked with the `app.kubernetes.io/managed-by:btp-manager`
-label are deleted. The deletion process of module resources is based on resources GVKs (GroupVersionKinds) found in [manifests](../module-resources/apply).
+label are deleted. The deletion process of module resources is based on resources GVKs (GroupVersionKinds) found in [manifests](../module-resources).
 If the process succeeds, the finalizer on BtpOperator CR itself is removed and the resource is deleted.
 If an error occurs during the deprovisioning, state of BtpOperator CR is set to `Error`.
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Addition to PR #193. The deprovisioning process should try to remove resources based on manifests from module-resources/delete in case outdated resources are present in the cluster and the deprovisioning preempts the update process.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #186.