### PR TITLE
rbac-proxy removed, BtpOperator spec nullable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ Dockerfile.cross
 /controllers/testdata/test-module-resources/
 /downloaded_module/
 /temp/
+/charts/

--- a/api/v1alpha1/btpoperator_types.go
+++ b/api/v1alpha1/btpoperator_types.go
@@ -35,6 +35,7 @@ type BtpOperator struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
+	//+nullable
 	Spec   BtpOperatorSpec `json:"spec,omitempty"`
 	Status types.Status    `json:"status,omitempty"`
 }

--- a/config/crd/bases/operator.kyma-project.io_btpoperators.yaml
+++ b/config/crd/bases/operator.kyma-project.io_btpoperators.yaml
@@ -38,6 +38,7 @@ spec:
             type: object
           spec:
             description: BtpOperatorSpec defines the desired state of BtpOperator
+            nullable: true
             type: object
           status:
             description: Status defines the observed state of CustomObject.

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -34,7 +34,7 @@ patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
+#- manager_auth_proxy_patch.yaml
 
 
 

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -12,7 +12,7 @@ resources:
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
-- auth_proxy_service.yaml
-- auth_proxy_role.yaml
-- auth_proxy_role_binding.yaml
-- auth_proxy_client_clusterrole.yaml
+#- auth_proxy_service.yaml
+#- auth_proxy_role.yaml
+#- auth_proxy_role_binding.yaml
+#- auth_proxy_client_clusterrole.yaml

--- a/config/samples/operator_v1alpha1_btpoperator.yaml
+++ b/config/samples/operator_v1alpha1_btpoperator.yaml
@@ -9,6 +9,3 @@ metadata:
     app.kubernetes.io/created-by: btp-manager
   name: btpoperator-sample
 spec:
-  # TODO(user): Add fields here
-  # spec must not be empty
-  anything: goes

--- a/hack/create_module_image.sh
+++ b/hack/create_module_image.sh
@@ -30,3 +30,6 @@ echo "MODULE_VERSION ${MODULE_VERSION}"
 echo "IMAGE_REFERENCE ${IMAGE_REFERENCE}"
 
 MODULE_VERSION=${MODULE_VERSION} IMG=${IMAGE_REFERENCE} make module-build
+
+echo "Generated template.yaml:"
+cat template.yaml


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- rbac-proxy image removed from BTP Manager deployment
- BtpOperator spec is now nullable

**Related issue(s)**

- `Resolves #221`,
- `Resolves #218`,
