### PR TITLE
Add certs.md to the list of docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,4 +14,3 @@ For general information on BTP Manager, see the overarching [documentation](../R
 - [GitHub Actions workflow](workflows.md)
 - [Install BTP Manager using Lifecycle Manager](lifecycle_manager.md)
 - [Certification management](certs.md)
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,3 +13,5 @@ For general information on BTP Manager, see the overarching [documentation](../R
 - [Run E2E tests](e2e_tests.md)
 - [GitHub Actions workflow](workflows.md)
 - [Install BTP Manager using Lifecycle Manager](lifecycle_manager.md)
+- [Certification management](certs.md)
+


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Add the Certification management document to the list in the documentation folder Readme file.


