### PR TITLE
Set BtpOperator CR status to ready when module deployment is ready

### DIFF
--- a/controllers/btpoperator_controller_certificates_test.go
+++ b/controllers/btpoperator_controller_certificates_test.go
@@ -36,6 +36,7 @@ var _ = Describe("BTP Operator controller - certificates", func() {
 	}
 
 	certBeforeEach := func(opts *certificationsTimeOpts) {
+		GinkgoWriter.Println("--- PROCESS:", GinkgoParallelProcess(), "---")
 		secret, err := createCorrectSecretFromYaml()
 		Expect(err).To(BeNil())
 		Expect(k8sClient.Patch(ctx, secret, client.Apply, client.ForceOwnership, client.FieldOwner(operatorName))).To(Succeed())

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -196,7 +196,7 @@ var _ = SynchronizedBeforeSuite(func() {
 	}()
 
 	useExistingClusterEnv := os.Getenv("USE_EXISTING_CLUSTER")
-	if useExistingClusterEnv == "false" || useExistingClusterEnv == "" {
+	if useExistingClusterEnv != "true" {
 		apiServerAddressAndPort := fmt.Sprintf("%s:%s", testEnv.ControlPlane.APIServer.Address, testEnv.ControlPlane.APIServer.Port)
 		etcdAddressAndPort := testEnv.ControlPlane.Etcd.URL.Host
 		ginkgoProcessInfoMsg := fmt.Sprintf("Process: %d, ApiServer: %s, etcd: %s", GinkgoParallelProcess(), apiServerAddressAndPort, etcdAddressAndPort)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

Set BtpOperator CR status to ready when SAP BTP Service Operator deployment is ready.
Add deployment controller in test suite to update the deployment status after it is created.
Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#complete-deployment

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Resolves #216