### PR TITLE
Passing GITHUB_RUN_ID to underlying e2e tests for PRs

### DIFF
--- a/.github/workflows/run-e2e-tests.yaml
+++ b/.github/workflows/run-e2e-tests.yaml
@@ -17,6 +17,8 @@ jobs:
   run-e2e-tests:
     uses: "./.github/workflows/run-e2e-tests-reusable.yaml"
     if: ${{ !github.event.pull_request.draft }}
+    env:
+      RUN_ID: ${{ env.GITHUB_RUN_ID }}
     with:
       image-tag: PR-${{ github.event.number }}
       module-tag: v0.0.0-PR-${{ github.event.number }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
To facilitate unique SIs and SBs names.

Changes proposed in this pull request:

- passing GITHUB_RUN_ID as env

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
