### PR TITLE
Remove the Promoting BTP Manager to release channel section

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -2,14 +2,6 @@
 title: GitHub Action workflows
 ---
 
-## Promoting BTP Manager to release channel
-
-The goal of the workflow is to register a module using the BTP Manager template file. The workflow takes a tag and downloads the module template file from the release on GitHub, and places it in the relevant subfolder in the module folder in the Kyma repository by creating a pull request. The pull request needs to be approved manually.
-
-If you want to control the workflow, you can set the following inputs in the GitHub UI:
-- Release tag - If not specified, the workflow takes a tag from the latest available release on GitHub and uses it. The tag can also be specified directly. The workflow validates if a given tag exists on any release and if it does, then uses it. Otherwise, the workflow breaks the execution.
-- Channel - There are three release channels to choose from: beta, fast, and regular. The options correspond to the subfolders in the module folder at the Kyma repository. 
-
 ## Auto update chart and resources
 
 The goal of the workflow is to update the chart (module-chart/chart) to the newest version, render resource templates from the newest chart, and create a PR with the changes. The workflow works on two shell scripts:


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Move the `Promoting BTP Manager to release channel` section from the `workflows.md` file to github.tools.sap

**Related issue(s)**

