### PR TITLE
Add annotations in pod template to bypass Istio sidecar for metrics

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
+        traffic.sidecar.istio.io/includeInboundPorts: '*'
+        traffic.sidecar.istio.io/excludeInboundPorts: "8080"
       labels:
         app.kubernetes.io/component: btp-manager.kyma-project.io
     spec:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

Add annotations for Istio sidecar to forward metrics endpoint:
- `traffic.sidecar.istio.io/includeInboundPorts`
- `traffic.sidecar.istio.io/excludeInboundPorts`
Ref: https://istio.io/latest/docs/reference/config/annotations/

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
