### PR TITLE
Fix BtpOperator Status update

### DIFF
--- a/api/v1alpha1/btpoperator_types.go
+++ b/api/v1alpha1/btpoperator_types.go
@@ -120,6 +120,15 @@ func (o *BtpOperator) IsReasonStringEqual(reason string) bool {
 	return false
 }
 
+func (o *BtpOperator) IsMsgForGivenReasonEqual(reason, message string) bool {
+	for _, cnd := range o.Status.Conditions {
+		if cnd != nil && cnd.Reason == reason && cnd.Message == message {
+			return true
+		}
+	}
+	return false
+}
+
 //+kubebuilder:object:root=true
 
 // BtpOperatorList contains a list of BtpOperator

--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -296,7 +296,7 @@ func (r *BtpOperatorReconciler) UpdateBtpOperatorStatus(ctx context.Context, cr 
 			if k8serrors.IsNotFound(err) {
 				return nil
 			}
-			logger.Error(err, "cannot get the BtpOperator to update the status. Retrying in 500 ms...")
+			logger.Error(err, fmt.Sprintf("cannot get the BtpOperator to update the status. Retrying in %s...", StatusUpdateCheckInterval.String()))
 			time.Sleep(StatusUpdateCheckInterval)
 			continue
 		}
@@ -309,13 +309,13 @@ func (r *BtpOperatorReconciler) UpdateBtpOperatorStatus(ctx context.Context, cr 
 			conditions.SetStatusCondition(&cr.Status.Conditions, *newCondition)
 		}
 		if err = r.Status().Update(ctx, cr); err != nil {
-			logger.Error(err, "cannot update the status of the BtpOperator. Retrying in 500 ms...")
+			logger.Error(err, fmt.Sprintf("cannot update the status of the BtpOperator. Retrying in %s...", StatusUpdateCheckInterval.String()))
 			time.Sleep(StatusUpdateCheckInterval)
 			continue
 		}
 		time.Sleep(StatusUpdateCheckInterval)
 	}
-	logger.Error(err, "timed out while waiting for the BtpOperator status change.")
+	logger.Error(err, fmt.Sprintf("timed out while waiting %s for the BtpOperator status change.", StatusUpdateTimeout.String()))
 
 	return err
 }

--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -72,6 +72,8 @@ var (
 	HardDeleteTimeout              = time.Minute * 20
 	HardDeleteCheckInterval        = time.Second * 10
 	DeleteRequestTimeout           = time.Minute * 5
+	StatusUpdateTimeout            = time.Second * 10
+	StatusUpdateCheckInterval      = time.Millisecond * 500
 	ChartPath                      = "./module-chart/chart"
 	ResourcesPath                  = "./module-resources"
 )

--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -292,6 +292,9 @@ func (r *BtpOperatorReconciler) UpdateBtpOperatorStatus(ctx context.Context, cr 
 	timeout := time.Now().Add(StatusUpdateTimeout)
 
 	if err := r.Get(ctx, client.ObjectKeyFromObject(cr), currentCr); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
 		logger.Error(err, "cannot get the current BtpOperator for status update.")
 		return err
 	}
@@ -308,6 +311,9 @@ func (r *BtpOperatorReconciler) UpdateBtpOperatorStatus(ctx context.Context, cr 
 
 	for now := time.Now(); now.Before(timeout); now = time.Now() {
 		if err := r.Get(ctx, client.ObjectKeyFromObject(cr), currentCr); err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil
+			}
 			logger.Error(err, "cannot get the current BtpOperator after status update. Retrying in 500 ms...")
 			time.Sleep(StatusUpdateCheckInterval)
 			continue

--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -300,7 +300,7 @@ func (r *BtpOperatorReconciler) UpdateBtpOperatorStatus(ctx context.Context, cr 
 			time.Sleep(StatusUpdateCheckInterval)
 			continue
 		}
-		if cr.Status.State == newState && cr.IsReasonStringEqual(string(reason)) {
+		if cr.Status.State == newState && cr.IsMsgForGivenReasonEqual(string(reason), message) {
 			return nil
 		}
 		cr.Status.WithState(newState)

--- a/controllers/btpoperator_controller_test.go
+++ b/controllers/btpoperator_controller_test.go
@@ -1,0 +1,11 @@
+package controllers
+
+import (
+	"testing"
+)
+
+func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
+	t.Run("", func(t *testing.T) {
+
+	})
+}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -51,18 +51,20 @@ import (
 var logger = logf.Log.WithName("suite_test")
 
 const (
-	hardDeleteTimeoutForAllTests    = time.Second * 1
-	deleteRequestTimeoutForAllTests = time.Millisecond * 200
-	testRsaKeyBits                  = 512
-	resourceAdded                   = "added"
-	resourceUpdated                 = "updated"
-	resourceDeleted                 = "deleted"
-	defaultNamespace                = "default"
-	kymaNamespace                   = "kyma-system"
-	defaultChartPath                = "./testdata/test-module-chart"
-	defaultResourcesPath            = "./testdata/test-module-resources"
-	chartUpdatePath                 = "./testdata/module-chart-update"
-	resourcesUpdatePath             = "./testdata/module-resources-update"
+	hardDeleteTimeoutForAllTests         = time.Second * 1
+	deleteRequestTimeoutForAllTests      = time.Millisecond * 200
+	statusUpdateTimeoutForAllTests       = time.Millisecond * 200
+	statusUpdateCheckIntervalForAllTests = time.Millisecond * 20
+	testRsaKeyBits                       = 512
+	resourceAdded                        = "added"
+	resourceUpdated                      = "updated"
+	resourceDeleted                      = "deleted"
+	defaultNamespace                     = "default"
+	kymaNamespace                        = "kyma-system"
+	defaultChartPath                     = "./testdata/test-module-chart"
+	defaultResourcesPath                 = "./testdata/test-module-resources"
+	chartUpdatePath                      = "./testdata/module-chart-update"
+	resourcesUpdatePath                  = "./testdata/module-resources-update"
 )
 
 var (
@@ -185,6 +187,12 @@ var _ = SynchronizedBeforeSuite(func() {
 	ResourcesPath = defaultResourcesPath
 	certs.SetRsaKeyBits(testRsaKeyBits)
 
+	useExistingClusterEnv := os.Getenv("USE_EXISTING_CLUSTER")
+	if useExistingClusterEnv != "true" {
+		StatusUpdateTimeout = statusUpdateTimeoutForAllTests
+		StatusUpdateCheckInterval = statusUpdateCheckIntervalForAllTests
+	}
+
 	err = reconciler.SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -205,7 +213,6 @@ var _ = SynchronizedBeforeSuite(func() {
 		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
 	}()
 
-	useExistingClusterEnv := os.Getenv("USE_EXISTING_CLUSTER")
 	if useExistingClusterEnv != "true" {
 		deploymentController := newDeploymentController(cfg, k8sManager)
 		ctxForDeploymentController, cancelDeploymentController = context.WithCancel(ctx)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- try to get the most current BtpOperator CR before updating its Status,
- update BtpOperator CR Status when it doesn't match expected Status,
- retry BtpOperator CR Status update procedure for 10 sec in case of failure.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Resolves #347 
