### PR TITLE
Fix unit tests caching

### DIFF
--- a/.github/workflows/run-unit-tests-reusable.yaml
+++ b/.github/workflows/run-unit-tests-reusable.yaml
@@ -12,21 +12,10 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
-    - name: Set up cache
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-          /home/runner/work/btp-manager/btp-manager/bin
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-
     - name: Set up go environment
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
-        go-version: 1.19
+        go-version-file: 'go.mod'
 
     - name: Run make test
       run: make test


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

The new `actions/setup-go@v4` has caching enabled by default. It allows to drop the manual cache set up.
We can also use the Go version defined in `go.mod` so we don't have to remember to bump in the workflow definition.


Changes proposed in this pull request:

- Bump `actions/setup-go`
- Remove redundant `actions/cache`
- Use for unit test Go version defined in `go.mod`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
