### PR TITLE
Add additional scan config option to script

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Update sec-scanners-config.yaml
         if: ${{ inputs.sec-scanners-config }}
-        run: scripts/create_scan_config.sh ${{ inputs.name }} "sec-scanners-config.yaml"
+        run: scripts/create_scan_config.sh ${{env.IMAGE_REPO}}:${{ inputs.name }} "sec-scanners-config.yaml" ${{ inputs.name }}
 
       - name: Create PR if anything changed
         if: ${{ inputs.sec-scanners-config }}

--- a/scripts/create_scan_config.sh
+++ b/scripts/create_scan_config.sh
@@ -3,9 +3,12 @@
 # This script has the following arguments:
 #                       binary image reference (mandatory)
 #                       filename of file to be created (optional)
-# ./create_scan_config image temp_scan_config.yaml
+#                       release tag (optional)
+# ./create_scan_config image temp_scan_congitfig.yaml           - use when building module image
+# ./create_scan_config image temp_scan_congitfig.yaml tag      - use when bumping the config on the main branch
 
 FILENAME=${2-../sec-scanners-config.yaml}
+TAG=${3:-}
 
 # standard bash error handling
 set -o nounset  # treat unset variables as an error and exit immediately.
@@ -13,19 +16,31 @@ set -o errexit  # exit immediately when a command fails.
 set -E          # needs to be set if we want the ERR trap
 set -o pipefail # prevents errors in a pipeline from being maskedPORT=5001
 
-# Expected variables passed (passed from CI):
-#   IMAGE_REPO                     - Repository with image to be scanned
-
-TAG=${1}
+IMAGE=${1}
 echo "Creating security scan configuration file:"
-cat <<EOF | tee ${FILENAME}
+
+# add rc-tag when creating the config on the main branch
+if [ -n "${TAG}" ]; then
+  cat <<EOF | tee ${FILENAME}
 module-name: btp-operator
 rc-tag: ${TAG}
 protecode:
-  - ${IMAGE_REPO}:${TAG}
+  - ${IMAGE}
 whitesource:
   language: golang-mod
   subprojects: false
   exclude:
     - "**/*_test.go"
 EOF
+else
+  cat <<EOF | tee ${FILENAME}
+module-name: btp-operator
+protecode:
+  - ${IMAGE}
+whitesource:
+  language: golang-mod
+  subprojects: false
+  exclude:
+    - "**/*_test.go"
+EOF
+fi

--- a/scripts/create_scan_config.sh
+++ b/scripts/create_scan_config.sh
@@ -4,7 +4,7 @@
 #                       binary image reference (mandatory)
 #                       filename of file to be created (optional)
 #                       release tag (optional)
-# ./create_scan_config image temp_scan_congitfig.yaml           - use when building module image
+# ./create_scan_config image temp_scan_congitfig.yaml          - use when building module image
 # ./create_scan_config image temp_scan_congitfig.yaml tag      - use when bumping the config on the main branch
 
 FILENAME=${2-../sec-scanners-config.yaml}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Adds the option missing in #426 to run the script for the module build command.

Changes proposed in this pull request:

- Script can be used to build sec scanner config for main branch
- Script can be used to build sec scanner config for release image

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
