### PR TITLE
Script extraction for building images locally

### DIFF
--- a/scripts/build_and_push_locally.sh
+++ b/scripts/build_and_push_locally.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# The script uses the following environment variables (if not provided script defines default values):
+#                       LOCAL_REGISTRY
+#                       K3D_REGISTRY
+#                       PR_NAME
+#                       MODULE_PREFIX
+# and returns local reference to the created module to stdout
+# ./build_and_push_locally.sh
+
+# standard bash error handling
+set -o nounset  # treat unset variables as an error and exit immediately.
+set -o errexit  # exit immediately when a command fails.
+set -E          # needs to be set if we want the ERR trap
+set -o pipefail # prevents errors in a pipeline from being maskedPORT=5001
+
+# registry access from local machine
+LOCAL_REGISTRY=${LOCAL_REGISTRY:-localhost:5001}
+
+#registry access from k3d cluster
+K3D_REGISTRY=${K3D_REGISTRY:-k3d-kyma-registry:5000}
+
+PR_NAME=${PR_NAME:-PR-undefined}
+IMG_NAME=btp-manager:${PR_NAME}
+
+MODULE_PREFIX=${MODULE_PREFIX:-0.0.0}
+MODULE_VERSION=${MODULE_PREFIX}-${PR_NAME}
+EXTENDED_MODULE_VERSION=v${MODULE_VERSION}
+MODULE_NAME=component-descriptors/kyma.project.io/module/btp-operator
+
+echo "Creating binary image and pushing to registry: ${LOCAL_REGISTRY}"
+make module-image LOCAL_REGISTRY=${LOCAL_REGISTRY} IMG=${LOCAL_REGISTRY}/${IMG_NAME}
+
+echo "Creating OCI module image and pushing to registry (no security scanning configuration in module template): ${LOCAL_REGISTRY}"
+make module-build IMG=${K3D_REGISTRY}/${IMG_NAME} MODULE_REGISTRY=${LOCAL_REGISTRY} MODULE_VERSION=${MODULE_VERSION}
+
+MODULE_REFERENCE=${LOCAL_REGISTRY}/${MODULE_NAME}:${EXTENDED_MODULE_VERSION}
+
+


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

To easier separate building from running E2E tests.

Changes proposed in this pull request:

- Extracted part to build binary image and module locally and push both images to the local registry.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
