### PR TITLE
Change the module name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ BTP Manager is an operator for [SAP BTP Service Operator](https://github.com/SAP
 
 ## Installation
 
-To enable the BTP Operator module from the latest release, you must install BTP Manager and SAP BTP Service Operator.
+To enable the SAP BTP Operator module from the latest release, you must install BTP Manager and SAP BTP Service Operator.
 
 ### Prerequisites
 
@@ -71,4 +71,4 @@ If you want to provide new features for BTP Manager, visit the [`contributor`](.
 - [informer's cache](./docs/contributor/07-10-informer-cache.md)
 - [metrics](./docs/contributor/08-10-metrics.md)
 
-Visit the [`user`](./docs/user) folder if you want to know more about [BTP Operator](./docs/user/README.md), and [how to use the module](./docs/user/02-10-usage.md).
+Visit the [`user`](./docs/user) folder if you want to know more about [SAP BTP Operator](./docs/user/README.md), and [how to use the module](./docs/user/02-10-usage.md).

--- a/docs/contributor/01-10-installation.md
+++ b/docs/contributor/01-10-installation.md
@@ -91,8 +91,8 @@ It results in:
 - downloading and using Kyma CLI to provision the k3d cluster
 - deploying Lifecycle Manager
 - applying the BTP Manager `template.yaml` provided by the user
-- enabling the BTP Operator module
-- displaying the BTP Manager and BTP Operator status
+- enabling the SAP BTP Operator module
+- displaying the BTP Manager and SAP BTP Operator status
 
 ### Delete k3d cluster
 

--- a/docs/contributor/02-10-operations.md
+++ b/docs/contributor/02-10-operations.md
@@ -76,9 +76,9 @@ condition that allows the reconciler to set the CR in the `Ready` state.
    kubectl delete btpoperator {BTPOPERATOR_CR_NAME}
    ```
 
-   The command triggers the deletion of the module resources in the cluster. By default, the existing ServiceInstances or ServiceBindings block the deletion. To unblock it, you must remove the existing ServiceInstances and ServiceBindings. Then, after the reconciliation, the BTP Operator resource is gone.
+   The command triggers the deletion of the module resources in the cluster. By default, the existing ServiceInstances or ServiceBindings block the deletion. To unblock it, you must remove the existing ServiceInstances and ServiceBindings. Then, after the reconciliation, the SAP BTP Operator resource is gone.
 
-   You can force the deletion by adding this label to the BTP Operator resource:
+   You can force the deletion by adding this label to the SAP BTP Operator resource:
    ```
    force-delete: "true"
    ```
@@ -96,7 +96,7 @@ condition that allows the reconciler to set the CR in the `Ready` state.
 11. Regardless of the mode, all SAP BTP Service Operator resources marked with the `app.kubernetes.io/managed-by:btp-manager` label are deleted. The deletion of module resources is based on resources GVKs (GroupVersionKinds) found in [manifests](../../module-resources). If the process succeeds, the finalizer on BtpOperator CR itself is removed, and the resource is deleted. If an error occurs during the deprovisioning (11a), the state of BtpOperator CR is set to `Error`.
 
 ## Conditions
-The state of BTP Operator CR is represented by [**Status**](https://github.com/kyma-project/module-manager/blob/main/pkg/declarative/v2/object.go#L23) that comprises State
+The state of SAP BTP Operator CR is represented by [**Status**](https://github.com/kyma-project/module-manager/blob/main/pkg/declarative/v2/object.go#L23) that comprises State
 and Conditions.
 Only one Condition of type `Ready` is used.
 

--- a/docs/user/README.md
+++ b/docs/user/README.md
@@ -1,8 +1,8 @@
-# BTP Operator module
+# SAP BTP Operator module
 
 ## Overview
 
-Within the BTP Operator module, [BTP Manager](https://github.com/kyma-project/btp-manager) installs [SAP BTP Service Operator](https://github.com/SAP/sap-btp-service-operator/blob/main/README.md).
+Within the SAP BTP Operator module, [BTP Manager](https://github.com/kyma-project/btp-manager) installs [SAP BTP Service Operator](https://github.com/SAP/sap-btp-service-operator/blob/main/README.md).
 
 ### BTP Manager
 
@@ -12,7 +12,7 @@ BTP Manager is an operator based on the [Kubebuilder](https://github.com/kuberne
 
 SAP BTP Service Operator allows you to connect SAP BTP services to your cluster and then manage them using Kubernetes-native tools.
 
-## How BTP Operator module works
+## How SAP BTP Operator module works
 
 BTP Manager provisions, updates, and deprovisions SAP BTP Service Operator along with its resources, ServiceInstances, and ServiceBindings. SAP BTP Service Operator manages SAP BTP services in your cluster.
 
@@ -20,5 +20,5 @@ Read [BTP Manager operations](../contributor/02-10-operations.md) and the [SAP B
 
 ## Read more
 
-This directory contains the end user documentation of the BTP Operator module.  
+This directory contains the end user documentation of the SAP BTP Operator module.  
 For the module's usage details, read the [Use BTP Manager to manage SAP BTP Service Operator](02-10-usage.md) document.

--- a/docs/user/_sidebar.md
+++ b/docs/user/_sidebar.md
@@ -1,3 +1,3 @@
 - [Home](/)
-- [BTP Operator module](README.md)
+- [SAP BTP Operator module](README.md)
 - [Use BTP Manager to manage SAP BTP Service Operator](02-10-usage.md)


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Change the module name from "BTP Operator" to "SAP BTP Operator" to comply with SAP's naming rules.

