### PR TITLE
Remove 'v' prefix from module-tag in workflows

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -53,7 +53,7 @@ jobs:
           BTP_OPERATOR_REPO: ${{ env.MODULE_REPO }}
           BTP_MANAGER_REPO: ${{ env.IMAGE_REPO }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: "./scripts/check_artifacts_existence.sh ${{ inputs.name }} v${{ inputs.name }}"
+        run: "./scripts/check_artifacts_existence.sh ${{ inputs.name }} ${{ inputs.name }}"
 
       - name: Validate Labels
         env:
@@ -190,11 +190,11 @@ jobs:
           BTP_OPERATOR_REPO: ${{ env.MODULE_REPO }}
           BTP_MANAGER_REPO: ${{ env.IMAGE_REPO }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: "./scripts/await_artifacts.sh ${{ inputs.name }} v${{ inputs.name }}"
+        run: "./scripts/await_artifacts.sh ${{ inputs.name }} ${{ inputs.name }}"
 
       - name: Install BTP operator
         timeout-minutes: 2
-        run: "./scripts/testing/install.sh $MODULE_REPO:v${{ inputs.name }} dummy ci"
+        run: "./scripts/testing/install.sh $MODULE_REPO:${{ inputs.name }} dummy ci"
 
       - name: BTP Manager controller resources usage
         run: "kubectl top pod -l app.kubernetes.io/component=btp-manager.kyma-project.io -n kyma-system --containers"

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -167,7 +167,7 @@ jobs:
     secrets: inherit
     with:
       image-tag: ${{ github.event.inputs.name }}
-      module-tag: v${{ github.event.inputs.name }}
+      module-tag: ${{ github.event.inputs.name }}
       image-repo: europe-docker.pkg.dev/kyma-project/prod/btp-manager
       module-repo: europe-docker.pkg.dev/kyma-project/prod/unsigned/component-descriptors/kyma.project.io/module/btp-operator
       credentials-mode: ${{ github.event.inputs.credentials }}
@@ -227,7 +227,7 @@ jobs:
     uses: "./.github/workflows/run-e2e-upgrade-tests-reusable.yaml"
     with:
       image-tag: ${{ github.event.inputs.name }}
-      module-tag: v${{ github.event.inputs.name }}
+      module-tag: ${{ github.event.inputs.name }}
       image-repo: europe-docker.pkg.dev/kyma-project/prod/btp-manager
       module-repo: europe-docker.pkg.dev/kyma-project/prod/unsigned/component-descriptors/kyma.project.io/module/btp-operator
 

--- a/.github/workflows/promote_to_module-manifests.yaml
+++ b/.github/workflows/promote_to_module-manifests.yaml
@@ -118,7 +118,7 @@ jobs:
           cat <<EOF | tee module-config.yaml
           name: ${FULL_MODULE_NAME}
           channel: ${CHANNEL}
-          version: v${TAG}
+          version: ${TAG}
           manifest: ${MANIFEST_FILENAME}
           defaultCR: ${DEFAULT_CR_FILENAME}
           annotations:

--- a/scripts/build_and_push_locally.sh
+++ b/scripts/build_and_push_locally.sh
@@ -25,7 +25,7 @@ IMG_NAME=btp-manager:${PR_NAME}
 
 MODULE_PREFIX=${MODULE_PREFIX:-0.0.0}
 MODULE_VERSION=${MODULE_PREFIX}-${PR_NAME}
-EXTENDED_MODULE_VERSION=v${MODULE_VERSION}
+EXTENDED_MODULE_VERSION=${MODULE_VERSION}
 MODULE_NAME=component-descriptors/kyma.project.io/module/btp-operator
 
 echo "Creating binary image and pushing to registry: ${LOCAL_REGISTRY}"

--- a/scripts/testing/run_e2e_module_upgrade_tests.sh
+++ b/scripts/testing/run_e2e_module_upgrade_tests.sh
@@ -34,7 +34,7 @@ elif [[ $# -eq 2 ]]; then
   GITHUB_URL=https://api.github.com/repos/${REPOSITORY}
   LATEST_RELEASE=$(curl -sS "${GITHUB_URL}/releases/latest" | jq -r '.tag_name')
   NEW_MODULE_IMAGE_NAME=$1
-  OLD_MODULE_IMAGE_NAME=${NEW_MODULE_IMAGE_NAME/:*/:v$LATEST_RELEASE}
+  OLD_MODULE_IMAGE_NAME=${NEW_MODULE_IMAGE_NAME/:*/:$LATEST_RELEASE}
   CI=${2-manual} # if called from any workflow "ci" is expected here
 else
   echo "wrong number of arguments" && exit 1


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

The prefix 'v' was removed from module name

Changes proposed in this pull request:

- Remove 'v' prefix from module-tag in promotion workflow
- Remove 'v' prefix from module-tag in release workflow

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
