### PR TITLE
Restore 'v' in module tag for upgrade test

### DIFF
--- a/scripts/testing/run_e2e_module_upgrade_tests.sh
+++ b/scripts/testing/run_e2e_module_upgrade_tests.sh
@@ -34,7 +34,7 @@ elif [[ $# -eq 2 ]]; then
   GITHUB_URL=https://api.github.com/repos/${REPOSITORY}
   LATEST_RELEASE=$(curl -sS "${GITHUB_URL}/releases/latest" | jq -r '.tag_name')
   NEW_MODULE_IMAGE_NAME=$1
-  OLD_MODULE_IMAGE_NAME=${NEW_MODULE_IMAGE_NAME/:*/:$LATEST_RELEASE}
+  OLD_MODULE_IMAGE_NAME=${NEW_MODULE_IMAGE_NAME/:*/:v$LATEST_RELEASE}
   CI=${2-manual} # if called from any workflow "ci" is expected here
 else
   echo "wrong number of arguments" && exit 1


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Old image has still v in tag so the upgrade test fails

Changes proposed in this pull request:


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
