### PR TITLE
Handle skipping final step in E2E tests

### DIFF
--- a/.github/workflows/run-e2e-tests-reusable.yaml
+++ b/.github/workflows/run-e2e-tests-reusable.yaml
@@ -90,9 +90,26 @@ jobs:
       - name: Run tests
         run: "./scripts/testing/run_e2e_module_tests.sh ${{ inputs.credentials-mode }} ci"
 
-  finish-e2e-tests:
+  confirm-matrix-tests-succeeded:
     runs-on: ubuntu-latest
     needs: run-e2e-matrix
+    if: success()
+    outputs:
+      success: ${{ steps.set-output.outputs.success }}
     steps:
-      - name: Final step
-        run: echo "All finished"
+      - name: Confirm that matrix tests succeeded
+        id: set-output
+        run: echo "success=true" >> "${GITHUB_OUTPUT}"
+
+  finish-e2e-tests:
+    runs-on: ubuntu-latest
+    needs: confirm-matrix-tests-succeeded
+    if: always()
+    steps:
+      - name: Final decision
+        run: |
+          if [ "${{ needs.confirm-matrix-tests-succeeded.outputs.success }}" != "true" ]; then
+            echo "E2E tests failed"
+            exit 1
+          fi
+          echo "E2E tests passed"

--- a/.github/workflows/run-e2e-tests-reusable.yaml
+++ b/.github/workflows/run-e2e-tests-reusable.yaml
@@ -108,8 +108,5 @@ jobs:
     steps:
       - name: Final decision
         run: |
-          if [ "${{ needs.confirm-matrix-tests-succeeded.outputs.success }}" != "true" ]; then
-            echo "E2E tests failed"
-            exit 1
-          fi
+          [[ "${{ needs.confirm-matrix-tests-succeeded.outputs.success }}" != "true"  ]] && echo "E2E tests failed" && exit 1
           echo "E2E tests passed"

--- a/scripts/testing/run_e2e_module_tests.sh
+++ b/scripts/testing/run_e2e_module_tests.sh
@@ -5,7 +5,7 @@
 #     - credentials mode, allowed values (required):
 #         dummy - dummy credentials passed
 #         real - real credentials passed
-# ./run_e2e_module_tests.sh real ci
+# ./run_e2e_module_tests.sh real
 #
 # The script requires the following environment variable set - these values are used to create unique SI and SB names:
 #      GITHUB_RUN_ID - a unique number for each workflow run within a repository

--- a/scripts/testing/run_e2e_module_tests.sh
+++ b/scripts/testing/run_e2e_module_tests.sh
@@ -5,7 +5,6 @@
 #     - credentials mode, allowed values (required):
 #         dummy - dummy credentials passed
 #         real - real credentials passed
-#     - ci to indicate call from CI pipeline (optional)
 # ./run_e2e_module_tests.sh real ci
 #
 # The script requires the following environment variable set - these values are used to create unique SI and SB names:
@@ -17,13 +16,14 @@
 #      SM_URL - service manager url
 #      SM_TOKEN_URL - token url
 
-CI=${2-manual}  # if called from any workflow "ci" is expected here
-
 # standard bash error handling
 set -o nounset  # treat unset variables as an error and exit immediately.
 set -o errexit  # exit immediately when a command fails.
 set -E          # needs to be set if we want the ERR trap
 set -o pipefail # prevents errors in a pipeline from being masked
+
+# TODO remove after test
+exit 1
 
 CREDENTIALS=$1
 YAML_DIR="scripts/testing/yaml"

--- a/scripts/testing/run_e2e_module_tests.sh
+++ b/scripts/testing/run_e2e_module_tests.sh
@@ -22,9 +22,6 @@ set -o errexit  # exit immediately when a command fails.
 set -E          # needs to be set if we want the ERR trap
 set -o pipefail # prevents errors in a pipeline from being masked
 
-# TODO remove after test
-exit 1
-
 CREDENTIALS=$1
 YAML_DIR="scripts/testing/yaml"
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

If matrix test fails, GitHub skips all subsequent jobs and branch protection interprets skipped job as non failure.


Changes proposed in this pull request:

- Additional step as a RV point for matrix test sending result to final step
- Obsolete variable removed from the script, comments updated

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
