### PR TITLE
Reconcile resources while BtpOperator CR is in Deleting state

### DIFF
--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -718,21 +718,12 @@ func (r *BtpOperatorReconciler) HandleDeletingState(ctx context.Context, cr *v1a
 	}
 
 	if err := r.handleDeprovisioning(ctx, cr); err != nil {
-		logger.Error(err, "deprovisioning failed")
+		logger.Error(err, "deprovisioning failed. Restoring resources")
+		r.reconcileResourcesWithoutChangingCrState(ctx, &logger)
 		return err
 	}
 	if cr.IsReasonStringEqual(string(conditions.ServiceInstancesAndBindingsNotCleaned)) {
-		// reconcile resources to keep them up to date while CR is in Deleting state
-		secret, errWithReason := r.getAndVerifyRequiredSecret(ctx)
-		if errWithReason != nil {
-			logger.Error(errWithReason, "secret verification failed")
-		}
-		if err := r.deleteOutdatedResources(ctx); err != nil {
-			logger.Error(err, "outdated resources deletion failed")
-		}
-		if err := r.reconcileResources(ctx, secret); err != nil {
-			logger.Error(err, "resources reconciliation failed")
-		}
+		r.reconcileResourcesWithoutChangingCrState(ctx, &logger)
 
 		numberOfBindings, err := r.numberOfResources(ctx, bindingGvk)
 		if err != nil {
@@ -2000,5 +1991,18 @@ func (r *BtpOperatorReconciler) buildSecretWithDataAndLabels(name string, data m
 			Labels:    labels,
 		},
 		Data: data,
+	}
+}
+
+func (r *BtpOperatorReconciler) reconcileResourcesWithoutChangingCrState(ctx context.Context, logger *logr.Logger) {
+	secret, errWithReason := r.getAndVerifyRequiredSecret(ctx)
+	if errWithReason != nil {
+		logger.Error(errWithReason, "secret verification failed")
+	}
+	if err := r.deleteOutdatedResources(ctx); err != nil {
+		logger.Error(err, "outdated resources deletion failed")
+	}
+	if err := r.reconcileResources(ctx, secret); err != nil {
+		logger.Error(err, "resources reconciliation failed")
 	}
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- add module resources reconciliation when BtpOperator CR is in Deleting state

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See https://github.com/kyma-project/btp-manager/issues/566