### PR TITLE
Get Secrets for Service Manager

### DIFF
--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -108,7 +108,7 @@ var (
 		Version: btpOperatorApiVer,
 		Kind:    btpOperatorServiceBinding,
 	}
-	instanceGvk = schema.GroupVersionKind{
+	InstanceGvk = schema.GroupVersionKind{
 		Group:   btpOperatorGroup,
 		Version: btpOperatorApiVer,
 		Kind:    btpOperatorServiceInstance,
@@ -729,7 +729,7 @@ func (r *BtpOperatorReconciler) HandleDeletingState(ctx context.Context, cr *v1a
 		if err != nil {
 			return err
 		}
-		numberOfInstances, err := r.numberOfResources(ctx, instanceGvk)
+		numberOfInstances, err := r.numberOfResources(ctx, InstanceGvk)
 		if err != nil {
 			return err
 		}
@@ -777,7 +777,7 @@ func (r *BtpOperatorReconciler) handleDeprovisioning(ctx context.Context, cr *v1
 		if err != nil {
 			return err
 		}
-		numberOfInstances, err := r.numberOfResources(ctx, instanceGvk)
+		numberOfInstances, err := r.numberOfResources(ctx, InstanceGvk)
 		if err != nil {
 			return err
 		}
@@ -874,13 +874,13 @@ func (r *BtpOperatorReconciler) handleHardDelete(ctx context.Context, namespaces
 		}
 	}
 
-	siCrdExists, err := r.crdExists(ctx, instanceGvk)
+	siCrdExists, err := r.crdExists(ctx, InstanceGvk)
 	if err != nil {
-		logger.Error(err, "while checking CRD existence", "GVK", instanceGvk.String())
+		logger.Error(err, "while checking CRD existence", "GVK", InstanceGvk.String())
 		errs = append(errs, err)
 	}
 	if siCrdExists {
-		if err := r.hardDelete(ctx, instanceGvk, namespaces); err != nil {
+		if err := r.hardDelete(ctx, InstanceGvk, namespaces); err != nil {
 			logger.Error(err, "while deleting Service Instances")
 			if !errors.Is(err, context.DeadlineExceeded) {
 				errs = append(errs, err)
@@ -911,7 +911,7 @@ func (r *BtpOperatorReconciler) handleHardDelete(ctx context.Context, namespaces
 		}
 
 		if siCrdExists {
-			siResourcesLeft, err = r.resourcesExist(ctx, namespaces, instanceGvk)
+			siResourcesLeft, err = r.resourcesExist(ctx, namespaces, InstanceGvk)
 			if err != nil {
 				logger.Error(err, "ServiceInstance leftover resources check failed")
 				hardDeleteSucceededCh <- false
@@ -1067,9 +1067,9 @@ func (r *BtpOperatorReconciler) handleSoftDelete(ctx context.Context, namespaces
 		return err
 	}
 
-	siCrdExists, err := r.crdExists(ctx, instanceGvk)
+	siCrdExists, err := r.crdExists(ctx, InstanceGvk)
 	if err != nil {
-		logger.Error(err, "while checking CRD existence", "GVK", instanceGvk.String())
+		logger.Error(err, "while checking CRD existence", "GVK", InstanceGvk.String())
 		return err
 	}
 
@@ -1087,11 +1087,11 @@ func (r *BtpOperatorReconciler) handleSoftDelete(ctx context.Context, namespaces
 
 	if siCrdExists {
 		logger.Info("Removing finalizers in Service Instances")
-		if err := r.softDelete(ctx, instanceGvk); err != nil {
+		if err := r.softDelete(ctx, InstanceGvk); err != nil {
 			logger.Error(err, "while deleting Service Instances")
 			return err
 		}
-		if err := r.ensureResourcesDontExist(ctx, instanceGvk); err != nil {
+		if err := r.ensureResourcesDontExist(ctx, InstanceGvk); err != nil {
 			logger.Error(err, "Service Instances still exist")
 			return err
 		}

--- a/controllers/btpoperator_controller_cr_rotation_test.go
+++ b/controllers/btpoperator_controller_cr_rotation_test.go
@@ -110,8 +110,8 @@ var _ = Describe("BTP Operator CR leader replacement", func() {
 				Eventually(func() error { return k8sClient.Create(ctx, btpOperator1) }).WithTimeout(k8sOpsTimeout).WithPolling(k8sOpsPollingInterval).Should(Succeed())
 				Eventually(updateCh).Should(Receive(matchState(v1alpha1.StateReady)))
 
-				siUnstructured := createResource(instanceGvk, kymaNamespace, instanceName)
-				ensureResourceExists(instanceGvk)
+				siUnstructured := createResource(InstanceGvk, kymaNamespace, instanceName)
+				ensureResourceExists(InstanceGvk)
 
 				sbUnstructured := createResource(bindingGvk, kymaNamespace, bindingName)
 				ensureResourceExists(bindingGvk)

--- a/controllers/btpoperator_controller_deprovisioning_test.go
+++ b/controllers/btpoperator_controller_deprovisioning_test.go
@@ -49,8 +49,8 @@ var _ = Describe("BTP Operator controller - deprovisioning", func() {
 		})
 
 		It("Delete should fail because of existing instances and bindings", func() {
-			_ = createResource(instanceGvk, kymaNamespace, instanceName)
-			ensureResourceExists(instanceGvk)
+			_ = createResource(InstanceGvk, kymaNamespace, instanceName)
+			ensureResourceExists(InstanceGvk)
 
 			_ = createResource(bindingGvk, kymaNamespace, bindingName)
 			ensureResourceExists(bindingGvk)
@@ -78,8 +78,8 @@ var _ = Describe("BTP Operator controller - deprovisioning", func() {
 			btpServiceOperatorDeployment := &appsv1.Deployment{}
 			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: DeploymentName, Namespace: kymaNamespace}, btpServiceOperatorDeployment)).Should(Succeed())
 
-			siUnstructured = createResource(instanceGvk, kymaNamespace, instanceName)
-			ensureResourceExists(instanceGvk)
+			siUnstructured = createResource(InstanceGvk, kymaNamespace, instanceName)
+			ensureResourceExists(InstanceGvk)
 
 			sbUnstructured = createResource(bindingGvk, kymaNamespace, bindingName)
 			ensureResourceExists(bindingGvk)

--- a/controllers/serviceinstance_controller.go
+++ b/controllers/serviceinstance_controller.go
@@ -42,7 +42,7 @@ func (r *ServiceInstanceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	logger.Info("SI reconcile triggered")
 
 	list := &unstructured.UnstructuredList{}
-	list.SetGroupVersionKind(instanceGvk)
+	list.SetGroupVersionKind(InstanceGvk)
 	err := r.List(ctx, list, client.InNamespace(corev1.NamespaceAll))
 	if err != nil {
 		return ctrl.Result{}, err
@@ -89,7 +89,7 @@ func (r *ServiceInstanceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.Config = mgr.GetConfig()
 
 	si := &unstructured.Unstructured{}
-	si.SetGroupVersionKind(instanceGvk)
+	si.SetGroupVersionKind(InstanceGvk)
 	sb := &unstructured.Unstructured{}
 	sb.SetGroupVersionKind(bindingGvk)
 

--- a/controllers/serviceinstance_controller_test.go
+++ b/controllers/serviceinstance_controller_test.go
@@ -65,8 +65,8 @@ var _ = Describe("Service Instance and Bindings controller", Ordered, func() {
 				Eventually(updateCh).Should(Receive(matchState(v1alpha1.StateReady)))
 
 				//  - create Service Instance
-				siUnstructured := createResource(instanceGvk, kymaNamespace, serviceInstanceName)
-				ensureResourceExists(instanceGvk)
+				siUnstructured := createResource(InstanceGvk, kymaNamespace, serviceInstanceName)
+				ensureResourceExists(InstanceGvk)
 
 				//  - trigger BTP operator deletion
 				Expect(k8sClient.Delete(ctx, btpOperatorResource)).To(Succeed())

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -77,7 +77,7 @@ func newTimeoutK8sClient(c client.Client) *timeoutK8sClient {
 
 func (c *timeoutK8sClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
 	kind := obj.GetObjectKind().GroupVersionKind().Kind
-	if kind == instanceGvk.Kind || kind == bindingGvk.Kind {
+	if kind == InstanceGvk.Kind || kind == bindingGvk.Kind {
 		deleteAllOfCtx, cancel := context.WithTimeout(ctx, time.Millisecond*100)
 		defer cancel()
 		return c.Client.DeleteAllOf(deleteAllOfCtx, obj, opts...)
@@ -96,7 +96,7 @@ func newErrorK8sClient(c client.Client) *errorK8sClient {
 
 func (c *errorK8sClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
 	kind := obj.GetObjectKind().GroupVersionKind().Kind
-	if kind == instanceGvk.Kind || kind == bindingGvk.Kind {
+	if kind == InstanceGvk.Kind || kind == bindingGvk.Kind {
 		deleteAllOfCtx, cancel := context.WithTimeout(ctx, time.Millisecond*100)
 		defer cancel()
 		_ = c.Client.DeleteAllOf(deleteAllOfCtx, obj, opts...)
@@ -467,7 +467,7 @@ func createResource(gvk schema.GroupVersionKind, namespace string, name string) 
 	object.SetNamespace(namespace)
 	object.SetName(name)
 	kind := object.GetObjectKind().GroupVersionKind().Kind
-	if kind == instanceGvk.Kind {
+	if kind == InstanceGvk.Kind {
 		populateServiceInstanceFields(object)
 	} else if kind == bindingGvk.Kind {
 		populateServiceBindingFields(object)

--- a/internal/cluster-object/namespace_provider.go
+++ b/internal/cluster-object/namespace_provider.go
@@ -16,10 +16,10 @@ type NamespaceProvider struct {
 	logger *slog.Logger
 }
 
-func NewNamespaceProvider(reader client.Reader, logger *slog.Logger) *SecretProvider {
+func NewNamespaceProvider(reader client.Reader, logger *slog.Logger) *NamespaceProvider {
 	logger = logger.With(logComponentNameKey, namespaceProviderName)
 
-	return &SecretProvider{
+	return &NamespaceProvider{
 		Reader: reader,
 		logger: logger,
 	}

--- a/internal/cluster-object/namespace_provider.go
+++ b/internal/cluster-object/namespace_provider.go
@@ -1,1 +1,44 @@
 package clusterobject
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const namespaceProviderName = "NamespaceProvider"
+
+type NamespaceProvider struct {
+	client.Reader
+	logger *slog.Logger
+}
+
+func NewNamespaceProvider(reader client.Reader, logger *slog.Logger) *SecretProvider {
+	logger = logger.With(logComponentNameKey, namespaceProviderName)
+
+	return &SecretProvider{
+		Reader: reader,
+		logger: logger,
+	}
+}
+
+func (p *NamespaceProvider) All(ctx context.Context) (v1.NamespaceList, error) {
+	p.logger.Info("fetching all namespaces")
+
+	namespaces := v1.NamespaceList{}
+	if err := p.Reader.List(ctx, &namespaces); err != nil {
+		p.logger.Error("failed to fetch all namespaces", "error", err)
+		return v1.NamespaceList{}, err
+	}
+
+	if len(namespaces.Items) == 0 {
+		err := errors.New("no namespaces found")
+		p.logger.Error(err.Error())
+		return v1.NamespaceList{}, err
+	}
+
+	return namespaces, nil
+}

--- a/internal/cluster-object/namespace_provider.go
+++ b/internal/cluster-object/namespace_provider.go
@@ -25,19 +25,19 @@ func NewNamespaceProvider(reader client.Reader, logger *slog.Logger) *SecretProv
 	}
 }
 
-func (p *NamespaceProvider) All(ctx context.Context) (v1.NamespaceList, error) {
+func (p *NamespaceProvider) All(ctx context.Context) (*v1.NamespaceList, error) {
 	p.logger.Info("fetching all namespaces")
 
-	namespaces := v1.NamespaceList{}
-	if err := p.Reader.List(ctx, &namespaces); err != nil {
+	namespaces := &v1.NamespaceList{}
+	if err := p.Reader.List(ctx, namespaces); err != nil {
 		p.logger.Error("failed to fetch all namespaces", "error", err)
-		return v1.NamespaceList{}, err
+		return nil, err
 	}
 
 	if len(namespaces.Items) == 0 {
 		err := errors.New("no namespaces found")
 		p.logger.Error(err.Error())
-		return v1.NamespaceList{}, err
+		return nil, err
 	}
 
 	return namespaces, nil

--- a/internal/cluster-object/namespace_provider.go
+++ b/internal/cluster-object/namespace_provider.go
@@ -1,0 +1,1 @@
+package clusterobject

--- a/internal/cluster-object/namespace_provider_test.go
+++ b/internal/cluster-object/namespace_provider_test.go
@@ -1,1 +1,71 @@
 package clusterobject
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestNamespaceProvider(t *testing.T) {
+	// given
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	t.Run("should fetch all namespaces", func(t *testing.T) {
+		// given
+		namespaces := initNamespaces()
+		k8sClient := fake.NewClientBuilder().WithLists(namespaces).Build()
+		nsProvider := NewNamespaceProvider(k8sClient, logger)
+
+		// when
+		nsList, err := nsProvider.All(context.TODO())
+
+		// then
+		if err != nil {
+			t.Errorf("Error while fetching namespaces: %s", err)
+		}
+		if len(nsList.Items) != 3 {
+			t.Errorf("Expected 3 namespaces, got %d", len(nsList.Items))
+		}
+	})
+
+	t.Run("should return error when no namespaces found", func(t *testing.T) {
+		// given
+		k8sClient := fake.NewClientBuilder().Build()
+		nsProvider := NewNamespaceProvider(k8sClient, logger)
+
+		// when
+		_, err := nsProvider.All(context.TODO())
+
+		// then
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+	})
+}
+
+func initNamespaces() *corev1.NamespaceList {
+	return &corev1.NamespaceList{
+		Items: []corev1.Namespace{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "kube-system",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test",
+				},
+			},
+		},
+	}
+}

--- a/internal/cluster-object/namespace_provider_test.go
+++ b/internal/cluster-object/namespace_provider_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -28,9 +30,7 @@ func TestNamespaceProvider(t *testing.T) {
 		if err != nil {
 			t.Errorf("Error while fetching namespaces: %s", err)
 		}
-		if len(nsList.Items) != 3 {
-			t.Errorf("Expected 3 namespaces, got %d", len(nsList.Items))
-		}
+		assert.Len(t, nsList.Items, 3)
 	})
 
 	t.Run("should return error when no namespaces found", func(t *testing.T) {
@@ -42,9 +42,7 @@ func TestNamespaceProvider(t *testing.T) {
 		_, err := nsProvider.All(context.TODO())
 
 		// then
-		if err == nil {
-			t.Error("Expected error, got nil")
-		}
+		require.Error(t, err)
 	})
 }
 

--- a/internal/cluster-object/namespace_provider_test.go
+++ b/internal/cluster-object/namespace_provider_test.go
@@ -1,0 +1,1 @@
+package clusterobject

--- a/internal/cluster-object/object_provider.go
+++ b/internal/cluster-object/object_provider.go
@@ -8,11 +8,6 @@ import (
 
 const logComponentNameKey = "component"
 
-type Provider[T client.Object | client.ObjectList] interface {
-	ClusterScopedProvider[T]
-	NamespacedProvider[T]
-}
-
 type ClusterScopedProvider[T client.ObjectList] interface {
 	All(ctx context.Context) (T, error)
 }

--- a/internal/cluster-object/object_provider.go
+++ b/internal/cluster-object/object_provider.go
@@ -1,6 +1,8 @@
 package clusterobject
 
 import (
+	"context"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -12,9 +14,9 @@ type Provider[T client.Object | client.ObjectList] interface {
 }
 
 type ClusterScopedProvider[T client.ObjectList] interface {
-	All() (T, error)
+	All(ctx context.Context) (T, error)
 }
 
 type NamespacedProvider[T client.Object] interface {
-	GetByNameAndNamespace(name, namespace string) (T, error)
+	GetByNameAndNamespace(ctx context.Context, name, namespace string) (T, error)
 }

--- a/internal/cluster-object/object_provider.go
+++ b/internal/cluster-object/object_provider.go
@@ -1,0 +1,10 @@
+package clusterobject
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Provider interface {
+	All() (client.ObjectList, error)
+	ByNameAndNamespace(name, namespace string) (client.Object, error)
+}

--- a/internal/cluster-object/object_provider.go
+++ b/internal/cluster-object/object_provider.go
@@ -4,7 +4,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type Provider interface {
-	All() (client.ObjectList, error)
-	ByNameAndNamespace(name, namespace string) (client.Object, error)
+const logComponentNameKey = "component"
+
+type Provider[T client.Object | client.ObjectList] interface {
+	ClusterScopedProvider[T]
+	NamespacedProvider[T]
+}
+
+type ClusterScopedProvider[T client.ObjectList] interface {
+	All() (T, error)
+}
+
+type NamespacedProvider[T client.Object] interface {
+	GetByNameAndNamespace(name, namespace string) (T, error)
 }

--- a/internal/cluster-object/secret_provider.go
+++ b/internal/cluster-object/secret_provider.go
@@ -1,0 +1,88 @@
+package clusterobject
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/kyma-project/btp-manager/controllers"
+	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	secretProviderName           = "SecretProvider"
+	btpServiceOperatorSecretName = "sap-btp-service-operator"
+)
+
+type SecretProvider struct {
+	client.Reader
+	namespaceProvider *NamespaceProvider
+	logger            *slog.Logger
+}
+
+func NewSecretProvider(reader client.Reader, nsProvider *NamespaceProvider, logger *slog.Logger) *SecretProvider {
+	logger = logger.With(logComponentNameKey, secretProviderName)
+
+	return &SecretProvider{
+		Reader:            reader,
+		namespaceProvider: nsProvider,
+		logger:            logger,
+	}
+}
+
+func (p *SecretProvider) All(ctx context.Context) (*v1.SecretList, error) {
+	p.logger.Info("fetching all btp operator secrets")
+	secrets := &v1.SecretList{}
+	if err := p.getAllSapBtpServiceOperatorSecrets(ctx, secrets); err != nil {
+		return nil, err
+	}
+
+	namespaces, err := p.namespaceProvider.All(ctx)
+	if err != nil {
+		p.logger.Error("while fetching namespaces", "error", err)
+		return nil, err
+	}
+	nsnames := p.getNamespacesNames(namespaces)
+
+	if err := p.getAllSecretsWithNamespacePrefix(ctx, secrets, nsnames); err != nil {
+		return nil, err
+	}
+
+	return secrets, err
+}
+
+func (p *SecretProvider) getAllSapBtpServiceOperatorSecrets(ctx context.Context, secrets *v1.SecretList) error {
+	if err := p.Reader.List(ctx, secrets, client.MatchingFields{"metadata.name": btpServiceOperatorSecretName}); err != nil {
+		p.logger.Error(fmt.Sprintf("failed to fetch all \"%s\" secrets", btpServiceOperatorSecretName), "error", err)
+		return err
+	}
+	return nil
+}
+
+func (p *SecretProvider) getNamespacesNames(namespaces v1.NamespaceList) []string {
+	names := make([]string, len(namespaces.Items))
+	for i, ns := range namespaces.Items {
+		names[i] = ns.Name
+	}
+	return names
+}
+
+func (p *SecretProvider) getAllSecretsWithNamespacePrefix(ctx context.Context, secrets *v1.SecretList, nsnames []string) error {
+	for _, nsname := range nsnames {
+		secret := &v1.Secret{}
+		secretName := fmt.Sprintf("%s-%s", nsname, btpServiceOperatorSecretName)
+		if err := p.Get(ctx, client.ObjectKey{Namespace: controllers.ChartNamespace, Name: secretName}, secret); err != nil {
+			if k8serrors.IsNotFound(err) {
+				p.logger.Info(fmt.Sprintf("secret \"%s\" not found in \"%s\" namespace", secretName, controllers.ChartNamespace))
+				continue
+			}
+			p.logger.Error(fmt.Sprintf("failed to fetch \"%s\" secret", secretName), "error", err)
+			return err
+		}
+		secrets.Items = append(secrets.Items, *secret)
+	}
+
+	return nil
+}

--- a/internal/cluster-object/secret_provider.go
+++ b/internal/cluster-object/secret_provider.go
@@ -63,6 +63,11 @@ func (p *SecretProvider) All(ctx context.Context) (*corev1.SecretList, error) {
 		return nil, err
 	}
 
+	if len(secrets.Items) == 0 {
+		p.logger.Warn(fmt.Sprintf("no btp operator secrets found"))
+		return nil, err
+	}
+
 	return secrets, err
 }
 

--- a/internal/cluster-object/secret_provider.go
+++ b/internal/cluster-object/secret_provider.go
@@ -18,17 +18,19 @@ const (
 
 type SecretProvider struct {
 	client.Reader
-	namespaceProvider *NamespaceProvider
-	logger            *slog.Logger
+	namespaceProvider       *NamespaceProvider
+	serviceInstanceProvider *ServiceInstanceProvider
+	logger                  *slog.Logger
 }
 
-func NewSecretProvider(reader client.Reader, nsProvider *NamespaceProvider, logger *slog.Logger) *SecretProvider {
+func NewSecretProvider(reader client.Reader, nsProvider *NamespaceProvider, siProvider *ServiceInstanceProvider, logger *slog.Logger) *SecretProvider {
 	logger = logger.With(logComponentNameKey, secretProviderName)
 
 	return &SecretProvider{
-		Reader:            reader,
-		namespaceProvider: nsProvider,
-		logger:            logger,
+		Reader:                  reader,
+		namespaceProvider:       nsProvider,
+		serviceInstanceProvider: siProvider,
+		logger:                  logger,
 	}
 }
 

--- a/internal/cluster-object/secret_provider.go
+++ b/internal/cluster-object/secret_provider.go
@@ -35,7 +35,7 @@ func NewSecretProvider(reader client.Reader, nsProvider *NamespaceProvider, logg
 func (p *SecretProvider) All(ctx context.Context) (*v1.SecretList, error) {
 	p.logger.Info("fetching all btp operator secrets")
 	secrets := &v1.SecretList{}
-	if err := p.getAllSapBtpServiceOperatorSecrets(ctx, secrets); err != nil {
+	if err := p.getAllSapBtpServiceOperatorNamedSecrets(ctx, secrets); err != nil {
 		return nil, err
 	}
 
@@ -46,14 +46,14 @@ func (p *SecretProvider) All(ctx context.Context) (*v1.SecretList, error) {
 	}
 	nsnames := p.getNamespacesNames(namespaces)
 
-	if err := p.getAllSecretsWithNamespacePrefix(ctx, secrets, nsnames); err != nil {
+	if err := p.getAllSecretsWithNamespaceNamePrefix(ctx, secrets, nsnames); err != nil {
 		return nil, err
 	}
 
 	return secrets, err
 }
 
-func (p *SecretProvider) getAllSapBtpServiceOperatorSecrets(ctx context.Context, secrets *v1.SecretList) error {
+func (p *SecretProvider) getAllSapBtpServiceOperatorNamedSecrets(ctx context.Context, secrets *v1.SecretList) error {
 	if err := p.Reader.List(ctx, secrets, client.MatchingFields{"metadata.name": btpServiceOperatorSecretName}); err != nil {
 		p.logger.Error(fmt.Sprintf("failed to fetch all \"%s\" secrets", btpServiceOperatorSecretName), "error", err)
 		return err
@@ -61,7 +61,7 @@ func (p *SecretProvider) getAllSapBtpServiceOperatorSecrets(ctx context.Context,
 	return nil
 }
 
-func (p *SecretProvider) getNamespacesNames(namespaces v1.NamespaceList) []string {
+func (p *SecretProvider) getNamespacesNames(namespaces *v1.NamespaceList) []string {
 	names := make([]string, len(namespaces.Items))
 	for i, ns := range namespaces.Items {
 		names[i] = ns.Name
@@ -69,7 +69,7 @@ func (p *SecretProvider) getNamespacesNames(namespaces v1.NamespaceList) []strin
 	return names
 }
 
-func (p *SecretProvider) getAllSecretsWithNamespacePrefix(ctx context.Context, secrets *v1.SecretList, nsnames []string) error {
+func (p *SecretProvider) getAllSecretsWithNamespaceNamePrefix(ctx context.Context, secrets *v1.SecretList, nsnames []string) error {
 	for _, nsname := range nsnames {
 		secret := &v1.Secret{}
 		secretName := fmt.Sprintf("%s-%s", nsname, btpServiceOperatorSecretName)

--- a/internal/cluster-object/secret_provider_test.go
+++ b/internal/cluster-object/secret_provider_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 
 	"github.com/kyma-project/btp-manager/controllers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,11 +19,11 @@ import (
 func TestSecretProvider(t *testing.T) {
 	// given
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
-	ns := initNamespaces()
-	sis := initServiceInstances(t)
 
 	t.Run("should fetch all secrets - from the module's namespace, with a namespace prefix, with an arbitrary name", func(t *testing.T) {
 		// given
+		ns := initNamespaces()
+		sis := initServiceInstances(t)
 		additionalNamespaces := createAdditionalNamespaces()
 		expectedSecrets := []corev1.Secret{
 			{
@@ -83,9 +85,7 @@ func TestSecretProvider(t *testing.T) {
 
 		// when
 		actualSecrets, err := secretProvider.All(context.TODO())
-		if err != nil {
-			t.Errorf("Error while fetching secrets: %s", err)
-		}
+		require.NoError(t, err)
 
 		// then
 		compareSecretSlices(t, expectedSecrets, actualSecrets.Items)
@@ -93,6 +93,8 @@ func TestSecretProvider(t *testing.T) {
 
 	t.Run("should fetch module's secret only", func(t *testing.T) {
 		// given
+		ns := initNamespaces()
+		sis := initServiceInstances(t)
 		additionalNamespaces := createAdditionalNamespaces()
 		expectedSecrets := []corev1.Secret{
 			{
@@ -120,9 +122,7 @@ func TestSecretProvider(t *testing.T) {
 
 		// when
 		actualSecrets, err := secretProvider.All(context.TODO())
-		if err != nil {
-			t.Errorf("Error while fetching secrets: %s", err)
-		}
+		require.NoError(t, err)
 
 		// then
 		compareSecretSlices(t, expectedSecrets, actualSecrets.Items)
@@ -130,6 +130,8 @@ func TestSecretProvider(t *testing.T) {
 
 	t.Run("should fetch namespace prefixed secret only", func(t *testing.T) {
 		// given
+		ns := initNamespaces()
+		sis := initServiceInstances(t)
 		additionalNamespaces := createAdditionalNamespaces()
 		expectedSecrets := []corev1.Secret{
 			{
@@ -157,9 +159,7 @@ func TestSecretProvider(t *testing.T) {
 
 		// when
 		actualSecrets, err := secretProvider.All(context.TODO())
-		if err != nil {
-			t.Errorf("Error while fetching secrets: %s", err)
-		}
+		require.NoError(t, err)
 
 		// then
 		compareSecretSlices(t, expectedSecrets, actualSecrets.Items)
@@ -167,6 +167,8 @@ func TestSecretProvider(t *testing.T) {
 
 	t.Run("should fetch only secrets referenced in service instances", func(t *testing.T) {
 		// given
+		ns := initNamespaces()
+		sis := initServiceInstances(t)
 		additionalNamespaces := createAdditionalNamespaces()
 		expectedSecrets := []corev1.Secret{
 			{
@@ -203,9 +205,7 @@ func TestSecretProvider(t *testing.T) {
 
 		// when
 		actualSecrets, err := secretProvider.All(context.TODO())
-		if err != nil {
-			t.Errorf("Error while fetching secrets: %s", err)
-		}
+		require.NoError(t, err)
 
 		// then
 		compareSecretSlices(t, expectedSecrets, actualSecrets.Items)
@@ -213,6 +213,8 @@ func TestSecretProvider(t *testing.T) {
 
 	t.Run("should return nil when there are no btp operator secrets", func(t *testing.T) {
 		// given
+		ns := initNamespaces()
+		sis := initServiceInstances(t)
 		additionalNamespaces := createAdditionalNamespaces()
 		additionalSecrets := createAdditionalSecrets()
 		secrets := &corev1.SecretList{Items: additionalSecrets}
@@ -228,14 +230,10 @@ func TestSecretProvider(t *testing.T) {
 
 		// when
 		actualSecrets, err := secretProvider.All(context.TODO())
-		if err != nil {
-			t.Errorf("Error while fetching secrets: %s", err)
-		}
+		require.NoError(t, err)
 
 		// then
-		if actualSecrets != nil {
-			t.Errorf("Expected nil, got %T", actualSecrets)
-		}
+		assert.Nil(t, actualSecrets)
 	})
 }
 
@@ -293,10 +291,7 @@ func secretNameIndexer(obj client.Object) []string {
 }
 
 func compareSecretSlices(t *testing.T, expected, actual []corev1.Secret) {
-	if len(expected) != len(actual) {
-		t.Errorf("Expected %d secrets, got %d", len(expected), len(actual))
-		return
-	}
+	assert.Equal(t, len(expected), len(actual))
 
 	for _, expectedSecret := range expected {
 		if !containsSecret(actual, expectedSecret) {

--- a/internal/cluster-object/secret_provider_test.go
+++ b/internal/cluster-object/secret_provider_test.go
@@ -1,1 +1,315 @@
 package clusterobject
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/kyma-project/btp-manager/controllers"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestSecretProvider(t *testing.T) {
+	// given
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	ns := initNamespaces()
+	sis := initServiceInstances(t)
+
+	t.Run("should fetch all secrets - from the module's namespace, with a namespace prefix, with an arbitrary name", func(t *testing.T) {
+		// given
+		additionalNamespaces := createAdditionalNamespaces()
+		expectedSecrets := []corev1.Secret{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      btpServiceOperatorSecretName,
+					Namespace: controllers.ChartNamespace,
+				},
+				StringData: map[string]string{
+					"foo": "bar",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      btpServiceOperatorSecretName,
+					Namespace: "test1",
+				},
+				StringData: map[string]string{
+					"foo": "bar",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("test2-%s", btpServiceOperatorSecretName),
+					Namespace: controllers.ChartNamespace,
+				},
+				StringData: map[string]string{
+					"foo": "bar",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret1",
+					Namespace: controllers.ChartNamespace,
+				},
+				StringData: map[string]string{
+					"foo": "bar",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret2",
+					Namespace: controllers.ChartNamespace,
+				},
+				StringData: map[string]string{
+					"foo": "bar",
+				},
+			},
+		}
+		secrets := &corev1.SecretList{Items: expectedSecrets}
+		ns.Items = append(ns.Items, additionalNamespaces...)
+
+		k8sClient := fake.NewClientBuilder().
+			WithLists(ns, sis, secrets).
+			WithIndex(&corev1.Secret{}, "metadata.name", secretNameIndexer).
+			Build()
+		nsProvider := NewNamespaceProvider(k8sClient, logger)
+		siProvider := NewServiceInstanceProvider(k8sClient, logger)
+		secretProvider := NewSecretProvider(k8sClient, nsProvider, siProvider, logger)
+
+		// when
+		actualSecrets, err := secretProvider.All(context.TODO())
+		if err != nil {
+			t.Errorf("Error while fetching secrets: %s", err)
+		}
+
+		// then
+		compareSecretSlices(t, expectedSecrets, actualSecrets.Items)
+	})
+
+	t.Run("should fetch module's secret only", func(t *testing.T) {
+		// given
+		additionalNamespaces := createAdditionalNamespaces()
+		expectedSecrets := []corev1.Secret{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      btpServiceOperatorSecretName,
+					Namespace: controllers.ChartNamespace,
+				},
+				StringData: map[string]string{
+					"foo": "bar",
+				},
+			},
+		}
+		additionalSecrets := createAdditionalSecrets()
+		secrets := &corev1.SecretList{Items: expectedSecrets}
+		secrets.Items = append(secrets.Items, additionalSecrets...)
+		ns.Items = append(ns.Items, additionalNamespaces...)
+
+		k8sClient := fake.NewClientBuilder().
+			WithLists(ns, sis, secrets).
+			WithIndex(&corev1.Secret{}, "metadata.name", secretNameIndexer).
+			Build()
+		nsProvider := NewNamespaceProvider(k8sClient, logger)
+		siProvider := NewServiceInstanceProvider(k8sClient, logger)
+		secretProvider := NewSecretProvider(k8sClient, nsProvider, siProvider, logger)
+
+		// when
+		actualSecrets, err := secretProvider.All(context.TODO())
+		if err != nil {
+			t.Errorf("Error while fetching secrets: %s", err)
+		}
+
+		// then
+		compareSecretSlices(t, expectedSecrets, actualSecrets.Items)
+	})
+
+	t.Run("should fetch namespace prefixed secret only", func(t *testing.T) {
+		// given
+		additionalNamespaces := createAdditionalNamespaces()
+		expectedSecrets := []corev1.Secret{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fmt.Sprintf("test2-%s", btpServiceOperatorSecretName),
+					Namespace: controllers.ChartNamespace,
+				},
+				StringData: map[string]string{
+					"foo": "bar",
+				},
+			},
+		}
+		additionalSecrets := createAdditionalSecrets()
+		secrets := &corev1.SecretList{Items: expectedSecrets}
+		secrets.Items = append(secrets.Items, additionalSecrets...)
+		ns.Items = append(ns.Items, additionalNamespaces...)
+
+		k8sClient := fake.NewClientBuilder().
+			WithLists(ns, sis, secrets).
+			WithIndex(&corev1.Secret{}, "metadata.name", secretNameIndexer).
+			Build()
+		nsProvider := NewNamespaceProvider(k8sClient, logger)
+		siProvider := NewServiceInstanceProvider(k8sClient, logger)
+		secretProvider := NewSecretProvider(k8sClient, nsProvider, siProvider, logger)
+
+		// when
+		actualSecrets, err := secretProvider.All(context.TODO())
+		if err != nil {
+			t.Errorf("Error while fetching secrets: %s", err)
+		}
+
+		// then
+		compareSecretSlices(t, expectedSecrets, actualSecrets.Items)
+	})
+
+	t.Run("should fetch only secrets referenced in service instances", func(t *testing.T) {
+		// given
+		additionalNamespaces := createAdditionalNamespaces()
+		expectedSecrets := []corev1.Secret{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret1",
+					Namespace: controllers.ChartNamespace,
+				},
+				StringData: map[string]string{
+					"foo": "bar",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret2",
+					Namespace: controllers.ChartNamespace,
+				},
+				StringData: map[string]string{
+					"foo": "bar",
+				},
+			},
+		}
+		additionalSecrets := createAdditionalSecrets()
+		secrets := &corev1.SecretList{Items: expectedSecrets}
+		secrets.Items = append(secrets.Items, additionalSecrets...)
+		ns.Items = append(ns.Items, additionalNamespaces...)
+
+		k8sClient := fake.NewClientBuilder().
+			WithLists(ns, sis, secrets).
+			WithIndex(&corev1.Secret{}, "metadata.name", secretNameIndexer).
+			Build()
+		nsProvider := NewNamespaceProvider(k8sClient, logger)
+		siProvider := NewServiceInstanceProvider(k8sClient, logger)
+		secretProvider := NewSecretProvider(k8sClient, nsProvider, siProvider, logger)
+
+		// when
+		actualSecrets, err := secretProvider.All(context.TODO())
+		if err != nil {
+			t.Errorf("Error while fetching secrets: %s", err)
+		}
+
+		// then
+		compareSecretSlices(t, expectedSecrets, actualSecrets.Items)
+	})
+
+	t.Run("should return nil when there are no btp operator secrets", func(t *testing.T) {
+		// given
+		additionalNamespaces := createAdditionalNamespaces()
+		additionalSecrets := createAdditionalSecrets()
+		secrets := &corev1.SecretList{Items: additionalSecrets}
+		ns.Items = append(ns.Items, additionalNamespaces...)
+
+		k8sClient := fake.NewClientBuilder().
+			WithLists(ns, sis, secrets).
+			WithIndex(&corev1.Secret{}, "metadata.name", secretNameIndexer).
+			Build()
+		nsProvider := NewNamespaceProvider(k8sClient, logger)
+		siProvider := NewServiceInstanceProvider(k8sClient, logger)
+		secretProvider := NewSecretProvider(k8sClient, nsProvider, siProvider, logger)
+
+		// when
+		actualSecrets, err := secretProvider.All(context.TODO())
+		if err != nil {
+			t.Errorf("Error while fetching secrets: %s", err)
+		}
+
+		// then
+		if actualSecrets != nil {
+			t.Errorf("Expected nil, got %T", actualSecrets)
+		}
+	})
+}
+
+func createAdditionalNamespaces() []corev1.Namespace {
+	return []corev1.Namespace{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: controllers.ChartNamespace,
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test1",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test2",
+			},
+		},
+	}
+}
+
+func createAdditionalSecrets() []corev1.Secret {
+	return []corev1.Secret{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "unrelated-additional-secret1",
+				Namespace: controllers.ChartNamespace,
+			},
+			StringData: map[string]string{
+				"foo": "bar",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "unrelated-additional-secret2",
+				Namespace: "test1",
+			},
+			StringData: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+}
+
+func secretNameIndexer(obj client.Object) []string {
+	secret, ok := obj.(*corev1.Secret)
+	if !ok {
+		panic(fmt.Errorf("indexer function for type %T's metadata.name field received"+
+			" object of type %T, this should never happen", corev1.Secret{}, obj))
+	}
+
+	return []string{secret.Name}
+}
+
+func compareSecretSlices(t *testing.T, expected, actual []corev1.Secret) {
+	if len(expected) != len(actual) {
+		t.Errorf("Expected %d secrets, got %d", len(expected), len(actual))
+		return
+	}
+
+	for _, expectedSecret := range expected {
+		if !containsSecret(actual, expectedSecret) {
+			t.Errorf("Expected secret %s not found in the actual list", expectedSecret.Name)
+		}
+	}
+}
+
+func containsSecret(secrets []corev1.Secret, secret corev1.Secret) bool {
+	for _, s := range secrets {
+		if s.Name == secret.Name && s.Namespace == secret.Namespace {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cluster-object/secret_provider_test.go
+++ b/internal/cluster-object/secret_provider_test.go
@@ -1,0 +1,1 @@
+package clusterobject

--- a/internal/cluster-object/service_instance_provider.go
+++ b/internal/cluster-object/service_instance_provider.go
@@ -1,0 +1,84 @@
+package clusterobject
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/kyma-project/btp-manager/controllers"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	serviceInstanceProviderName = "ServiceInstanceProvider"
+	secretRefKey                = "btpAccessCredentialsSecret"
+)
+
+type ServiceInstanceProvider struct {
+	client.Reader
+	logger *slog.Logger
+}
+
+func NewServiceInstanceProvider(reader client.Reader, logger *slog.Logger) *SecretProvider {
+	logger = logger.With(logComponentNameKey, serviceInstanceProviderName)
+
+	return &SecretProvider{
+		Reader: reader,
+		logger: logger,
+	}
+}
+
+func (p *ServiceInstanceProvider) AllWithSecretRef(ctx context.Context) (unstructured.UnstructuredList, error) {
+	filtered, err := p.All(ctx)
+	if err != nil {
+		p.logger.Error("while fetching filtered service instances", "error", err)
+		return unstructured.UnstructuredList{}, err
+	}
+
+	if err := p.filterBySecretRef(&filtered); err != nil {
+		p.logger.Error("while filtering service instances by secret ref", "error", err)
+		return unstructured.UnstructuredList{}, err
+	}
+
+	return filtered, nil
+}
+
+func (p *ServiceInstanceProvider) All(ctx context.Context) (unstructured.UnstructuredList, error) {
+	list := unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(controllers.InstanceGvk)
+	if err := p.List(ctx, &list); err != nil {
+		p.logger.Error("failed to list all service instances", "error", err)
+		return unstructured.UnstructuredList{}, err
+	}
+	if len(list.Items) == 0 {
+		p.logger.Info("no service instances found")
+		return unstructured.UnstructuredList{}, nil
+	}
+
+	return list, nil
+}
+
+func (p *ServiceInstanceProvider) filterBySecretRef(all *unstructured.UnstructuredList) error {
+	for i, item := range all.Items {
+		found, err := p.hasSecretRef(item)
+		if err != nil {
+			return err
+		}
+		if !found {
+			all.Items = append(all.Items[:i], all.Items[i+1:]...)
+		}
+	}
+
+	return nil
+}
+
+func (p *ServiceInstanceProvider) hasSecretRef(item unstructured.Unstructured) (bool, error) {
+	_, found, err := unstructured.NestedString(item.Object, secretRefKey)
+	if err != nil {
+		p.logger.Error(fmt.Sprintf("while traversing \"%s\" unstructured object to find \"%s\" key", item.GetName(), secretRefKey), "error", err)
+		return false, err
+	}
+
+	return found, nil
+}

--- a/internal/cluster-object/service_instance_provider.go
+++ b/internal/cluster-object/service_instance_provider.go
@@ -20,10 +20,10 @@ type ServiceInstanceProvider struct {
 	logger *slog.Logger
 }
 
-func NewServiceInstanceProvider(reader client.Reader, logger *slog.Logger) *SecretProvider {
+func NewServiceInstanceProvider(reader client.Reader, logger *slog.Logger) *ServiceInstanceProvider {
 	logger = logger.With(logComponentNameKey, serviceInstanceProviderName)
 
-	return &SecretProvider{
+	return &ServiceInstanceProvider{
 		Reader: reader,
 		logger: logger,
 	}

--- a/internal/cluster-object/service_instance_provider.go
+++ b/internal/cluster-object/service_instance_provider.go
@@ -29,31 +29,31 @@ func NewServiceInstanceProvider(reader client.Reader, logger *slog.Logger) *Secr
 	}
 }
 
-func (p *ServiceInstanceProvider) AllWithSecretRef(ctx context.Context) (unstructured.UnstructuredList, error) {
+func (p *ServiceInstanceProvider) AllWithSecretRef(ctx context.Context) (*unstructured.UnstructuredList, error) {
 	filtered, err := p.All(ctx)
 	if err != nil {
 		p.logger.Error("while fetching filtered service instances", "error", err)
-		return unstructured.UnstructuredList{}, err
+		return nil, err
 	}
 
-	if err := p.filterBySecretRef(&filtered); err != nil {
+	if err := p.filterBySecretRef(filtered); err != nil {
 		p.logger.Error("while filtering service instances by secret ref", "error", err)
-		return unstructured.UnstructuredList{}, err
+		return nil, err
 	}
 
 	return filtered, nil
 }
 
-func (p *ServiceInstanceProvider) All(ctx context.Context) (unstructured.UnstructuredList, error) {
-	list := unstructured.UnstructuredList{}
+func (p *ServiceInstanceProvider) All(ctx context.Context) (*unstructured.UnstructuredList, error) {
+	list := &unstructured.UnstructuredList{}
 	list.SetGroupVersionKind(controllers.InstanceGvk)
-	if err := p.List(ctx, &list); err != nil {
+	if err := p.List(ctx, list); err != nil {
 		p.logger.Error("failed to list all service instances", "error", err)
-		return unstructured.UnstructuredList{}, err
+		return nil, err
 	}
 	if len(list.Items) == 0 {
 		p.logger.Info("no service instances found")
-		return unstructured.UnstructuredList{}, nil
+		return list, nil
 	}
 
 	return list, nil

--- a/internal/cluster-object/service_instance_provider.go
+++ b/internal/cluster-object/service_instance_provider.go
@@ -60,21 +60,23 @@ func (p *ServiceInstanceProvider) All(ctx context.Context) (*unstructured.Unstru
 }
 
 func (p *ServiceInstanceProvider) filterBySecretRef(all *unstructured.UnstructuredList) error {
-	for i, item := range all.Items {
-		found, err := p.hasSecretRef(item)
+	for i := 0; i < len(all.Items); {
+		found, err := p.hasSecretRef(all.Items[i])
 		if err != nil {
 			return err
 		}
 		if !found {
 			all.Items = append(all.Items[:i], all.Items[i+1:]...)
+			continue
 		}
+		i++
 	}
 
 	return nil
 }
 
 func (p *ServiceInstanceProvider) hasSecretRef(item unstructured.Unstructured) (bool, error) {
-	_, found, err := unstructured.NestedString(item.Object, secretRefKey)
+	_, found, err := unstructured.NestedString(item.Object, "spec", secretRefKey)
 	if err != nil {
 		p.logger.Error(fmt.Sprintf("while traversing \"%s\" unstructured object to find \"%s\" key", item.GetName(), secretRefKey), "error", err)
 		return false, err

--- a/internal/cluster-object/service_instance_provider_test.go
+++ b/internal/cluster-object/service_instance_provider_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/kyma-project/btp-manager/controllers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -25,12 +27,8 @@ func TestServiceInstanceProvider(t *testing.T) {
 		sis, err := siProvider.All(context.TODO())
 
 		// then
-		if err != nil {
-			t.Errorf("Error while fetching service instances: %s", err)
-		}
-		if len(sis.Items) != 4 {
-			t.Errorf("Expected 4 service instances, got %d", len(sis.Items))
-		}
+		require.NoError(t, err)
+		assert.Len(t, sis.Items, 4)
 	})
 
 	t.Run("should fetch service instances with secret reference", func(t *testing.T) {
@@ -43,20 +41,12 @@ func TestServiceInstanceProvider(t *testing.T) {
 		sis, err := siProvider.AllWithSecretRef(context.TODO())
 
 		// then
-		if err != nil {
-			t.Errorf("Error while fetching service instances: %s", err)
-		}
-		if len(sis.Items) != 2 {
-			t.Errorf("Expected 2 service instances, got %d", len(sis.Items))
-		}
+		require.NoError(t, err)
+		assert.Len(t, sis.Items, 2)
 		for _, si := range sis.Items {
 			secretRef, _, err := unstructured.NestedString(si.Object, "spec", secretRefKey)
-			if err != nil {
-				t.Errorf("Error while fetching secret ref from service instance: %s", err)
-			}
-			if secretRef == "" {
-				t.Error("Expected secret ref, got empty value")
-			}
+			require.NoError(t, err)
+			assert.NotEmpty(t, secretRef)
 		}
 	})
 }

--- a/internal/cluster-object/service_instance_provider_test.go
+++ b/internal/cluster-object/service_instance_provider_test.go
@@ -1,1 +1,89 @@
 package clusterobject
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/kyma-project/btp-manager/controllers"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestServiceInstanceProvider(t *testing.T) {
+	// given
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+
+	t.Run("should fetch all service instances", func(t *testing.T) {
+		// given
+		givenSiList := initServiceInstances(t)
+		k8sClient := fake.NewClientBuilder().WithLists(givenSiList).Build()
+		siProvider := NewServiceInstanceProvider(k8sClient, logger)
+
+		// when
+		sis, err := siProvider.All(context.TODO())
+
+		// then
+		if err != nil {
+			t.Errorf("Error while fetching service instances: %s", err)
+		}
+		if len(sis.Items) != 4 {
+			t.Errorf("Expected 4 service instances, got %d", len(sis.Items))
+		}
+	})
+
+	t.Run("should fetch service instances with secret reference", func(t *testing.T) {
+		// given
+		givenSiList := initServiceInstances(t)
+		k8sClient := fake.NewClientBuilder().WithLists(givenSiList).Build()
+		siProvider := NewServiceInstanceProvider(k8sClient, logger)
+
+		// when
+		sis, err := siProvider.AllWithSecretRef(context.TODO())
+
+		// then
+		if err != nil {
+			t.Errorf("Error while fetching service instances: %s", err)
+		}
+		if len(sis.Items) != 2 {
+			t.Errorf("Expected 2 service instances, got %d", len(sis.Items))
+		}
+		for _, si := range sis.Items {
+			secretRef, _, err := unstructured.NestedString(si.Object, "spec", secretRefKey)
+			if err != nil {
+				t.Errorf("Error while fetching secret ref from service instance: %s", err)
+			}
+			if secretRef == "" {
+				t.Error("Expected secret ref, got empty value")
+			}
+		}
+	})
+}
+
+func initServiceInstances(t *testing.T) *unstructured.UnstructuredList {
+	siList := &unstructured.UnstructuredList{}
+	siList.SetGroupVersionKind(controllers.InstanceGvk)
+	siList.Items = []unstructured.Unstructured{
+		initServiceInstance(t, "si1", "namespace1"),
+		initServiceInstance(t, "si2", "namespace2"),
+		initServiceInstance(t, "si3", "namespace3", "secret1"),
+		initServiceInstance(t, "si4", "namespace3", "secret2"),
+	}
+
+	return siList
+}
+
+func initServiceInstance(t *testing.T, name, namespace string, secretRef ...string) unstructured.Unstructured {
+	si := unstructured.Unstructured{}
+	si.SetGroupVersionKind(controllers.InstanceGvk)
+	si.SetName(name)
+	si.SetNamespace(namespace)
+	if len(secretRef) > 0 {
+		err := unstructured.SetNestedField(si.Object, secretRef[0], "spec", secretRefKey)
+		if err != nil {
+			t.Errorf("error while setting secret ref: %s", err)
+		}
+	}
+	return si
+}

--- a/internal/cluster-object/service_instance_provider_test.go
+++ b/internal/cluster-object/service_instance_provider_test.go
@@ -1,0 +1,1 @@
+package clusterobject


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

BTP Manager should be able to display information about existing Service Instances and Service Bindings connected to various Service Manager credentials. Credentials are stored in secrets created for SAP BTP Service Operator.

Changes proposed in this pull request:

- add SecretProvider which fetches secrets related to SAP BTP Service Operator
- add NamespaceProvider to fetch namespace name prefixed secrets
- add ServiceInstanceProvider to fetch Service Instances with references to secrets
- add unit tests for providers

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #442 