### PR TITLE
Ignore PRs not Merged to Main

### DIFF
--- a/scripts/python/release_label_validator.py
+++ b/scripts/python/release_label_validator.py
@@ -27,7 +27,7 @@ all_closed_prs = response.json()
 
 prs_since_last_release = [
     pr for pr in all_closed_prs
-    if pr['merged_at'] is not None and pr['merged_at'] > latest_release_date
+    if pr['base']['ref'] == 'main' and pr['merged_at'] is not None and pr['merged_at'] > latest_release_date
 ]
 
 valid_prs = []


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Release action loads PR to validate `kind` labels with versioning scheme. The scripts used in that process take into account all PRs merged to any branch in repository - not only the main branch. See https://github.com/kyma-project/btp-manager/actions/runs/8753032654. Changelog should not be affected by the same issue, it is generated from a log of a local git clone.

Results from the failed release:
```
Run python3 scripts/python/release_label_validator.py
One of these labels is required on PR: ['kind/feature', 'kind/enhancement', 'kind/bug']

These PRs have exactly one required label:
PR: https://github.com/kyma-project/btp-manager/pull/656
PR: https://github.com/kyma-project/btp-manager/pull/669
PR: https://github.com/kyma-project/btp-manager/pull/650
PR: https://github.com/kyma-project/btp-manager/pull/661
PR: https://github.com/kyma-project/btp-manager/pull/660
PR: https://github.com/kyma-project/btp-manager/pull/655
PR: https://github.com/kyma-project/btp-manager/pull/654
PR: https://github.com/kyma-project/btp-manager/pull/647

These PRs don't have exactly one required label:
PR: https://github.com/kyma-project/btp-manager/pull/662
PR: https://github.com/kyma-project/btp-manager/pull/648
Error: Process completed with exit code 1.
```

Results from local invocation of labels validation script:
```
(venv) ➜  btp-manager git:(bugfixes/validate-release-by-main-only) ✗ python3 ./scripts/python/release_label_validator.py
One of these labels is required on PR: ['kind/feature', 'kind/enhancement', 'kind/bug']

These PRs have exactly one required label:
PR: https://github.com/kyma-project/btp-manager/pull/670
PR: https://github.com/kyma-project/btp-manager/pull/656
PR: https://github.com/kyma-project/btp-manager/pull/669
PR: https://github.com/kyma-project/btp-manager/pull/650
PR: https://github.com/kyma-project/btp-manager/pull/661
PR: https://github.com/kyma-project/btp-manager/pull/660
PR: https://github.com/kyma-project/btp-manager/pull/647

All PRs have exactly one required label

Version name is correct
```

Changes proposed in this pull request:

- Filter loaded pr to only those that got merged to main.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
