### PR TITLE
Make go linter timeout configurable

### DIFF
--- a/.github/workflows/run-go-linter.yaml
+++ b/.github/workflows/run-go-linter.yaml
@@ -50,9 +50,6 @@ jobs:
 
       - name: Go linter
         if: steps.changed-files-specific.outputs.any_modified == 'true'
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.55.2
-          skip-cache: true
-          only-new-issues: true
-          args: --timeout 2m0s
+        env:
+          GOLINT_TIMEOUT: ${{ vars.GOLINT_TIMEOUT }}
+        run: make go-lint

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 GOLINT_VER = v1.55.2
+ifeq (,$(GOLINT_TIMEOUT))
+GOLINT_TIMEOUT=2m
+endif
 
 .PHONY: all
 all: build
@@ -190,7 +193,7 @@ go-lint-install: ## linter config in file at root of project -> '.golangci.yaml'
 
 .PHONY: go-lint
 go-lint: go-lint-install ## linter config in file at root of project -> '.golangci.yaml'
-	golangci-lint run
+	golangci-lint run --timeout=$(GOLINT_TIMEOUT)
 
 .PHONY: fix
 fix: go-lint-install ## try to fix automatically issues


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- set default go linter timeout in Makefile,
- use variable defined for repository in GA on main. 

**Related issue(s)**
See [#582](https://github.com/kyma-project/kyma-environment-broker/issues/582)