### PR TITLE
Added Missing Name Substitution

### DIFF
--- a/scripts/testing/yaml/secret.tmpl.yaml
+++ b/scripts/testing/yaml/secret.tmpl.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: sss-002
+  name: ${SECRET_NAME}-000
   namespace: kyma-system
 stringData:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Modified script is used in stress test to populate K8S cluster with secrets. Because of name of the secret had been hardcoded it was impossible to create more than 1 secret.

Changes proposed in this pull request:

- added use of environment variable to set secret name.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
