### PR TITLE
Test multiple btpOperators reconciliation

### DIFF
--- a/hack/multiple_btpoperators_exist.sh
+++ b/hack/multiple_btpoperators_exist.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# standard bash error handling
+set -o nounset  # treat unset variables as an error and exit immediately.
+set -o errexit  # exit immediately when a command fails.
+set -E          # needs to be set if we want the ERR trap
+set -o pipefail # prevents errors in a pipeline from being masked
+
+apply_btp_operator() {
+    local namespace=$1
+    kubectl apply -f https://github.com/kyma-project/btp-manager/releases/latest/download/btp-operator-default-cr.yaml -n $namespace
+}
+
+wait_for_condition() {
+    local condition=$1
+    local namespace=$2
+    local message=$3
+    while [[ $(kubectl get btpoperators btpoperator -n $namespace -ojson| jq '.status.conditions[] | select(.type=="Ready") |.status+.reason'|xargs)  != $condition ]];
+    do
+        echo -e "\n---Waiting for BTP Operator in $namespace namespace to be $message"; sleep 5;
+    done
+}
+
+delete_and_patch_btp_operator() {
+    local namespace=$1
+    kubectl delete btpoperators btpoperator -n $namespace &
+    kubectl patch btpoperator btpoperator -n $namespace -p '{"metadata":{"finalizers":[]}}' --type=merge &
+    wait
+}
+
+iterations=$1
+
+kubectl apply -f deployments/prerequisites.yaml  
+kubectl apply -f examples/btp-manager-secret.yaml
+kubectl apply -f https://github.com/kyma-project/btp-manager/releases/latest/download/btp-manager.yaml
+apply_btp_operator "default"
+wait_for_condition "TrueReconcileSucceeded" "default" "ready and reconciled"
+
+export SI_NAME="test"
+envsubst < scripts/testing/yaml/e2e-test-service-instance.yaml | kubectl apply -f -
+export SB_NAME="test"
+envsubst < scripts/testing/yaml/e2e-test-service-binding.yaml | kubectl apply -f -
+
+for ((i=1; i<=$iterations; i++))
+do        
+    apply_btp_operator "kyma-system"
+    wait_for_condition "FalseOlderCRExists" "kyma-system" "ready and in error OlderCRExists"
+    delete_and_patch_btp_operator "default"
+    wait_for_condition "TrueReconcileSucceeded" "kyma-system" "ready and reconciled"
+    apply_btp_operator "default"
+    wait_for_condition "FalseOlderCRExists" "default" "ready and in error OlderCRExists"
+    delete_and_patch_btp_operator "kyma-system"
+    wait_for_condition "TrueReconcileSucceeded" "default" "ready and reconciled"
+done
+
+count=$(kubectl get serviceinstances -o json | jq '.items | length')
+if [[ $count -ne 1 ]]; then
+    echo "Error: Expected 1 service instance, but found $count"
+    exit 1
+fi
+
+count=$(kubectl get servicebindings -o json | jq '.items | length')
+if [[ $count -ne 1 ]]; then
+    echo "Error: Expected 1 service binding, but found $count"
+    exit 1
+fi
+
+echo "Test finished successfully"

--- a/scripts/testing/multiple_btpoperators_exist.sh
+++ b/scripts/testing/multiple_btpoperators_exist.sh
@@ -1,55 +1,62 @@
 #!/usr/bin/env bash
 
+# This script has the following arguments:
+#     - number of iterations of switching between which btpOperator is reconciled
+# ./multiple_btpoperators_exist.sh 10
+
 # standard bash error handling
 set -o nounset  # treat unset variables as an error and exit immediately.
 set -o errexit  # exit immediately when a command fails.
 set -E          # needs to be set if we want the ERR trap
 set -o pipefail # prevents errors in a pipeline from being masked
 
+iterations=$1
+YAML_DIR="scripts/testing/yaml"
+
 apply_btp_operator() {
     local namespace=$1
-    kubectl apply -f https://github.com/kyma-project/btp-manager/releases/latest/download/btp-operator-default-cr.yaml -n $namespace
+    echo -e "\n---Creating BTP Operator in $namespace namespace"
+    kubectl apply -f ${YAML_DIR}/e2e-test-btpoperator.yaml -n $namespace
 }
 
 wait_for_condition() {
     local condition=$1
     local namespace=$2
     local message=$3
-    while [[ $(kubectl get btpoperators btpoperator -n $namespace -ojson| jq '.status.conditions[] | select(.type=="Ready") |.status+.reason'|xargs)  != $condition ]];
+    while [[ $(kubectl get btpoperators/e2e-test-btpoperator -n $namespace -ojson| jq '.status.conditions[] | select(.type=="Ready") |.status+.reason'|xargs)  != $condition ]];
     do
         echo -e "\n---Waiting for BTP Operator in $namespace namespace to be $message"; sleep 5;
     done
 }
 
-delete_and_patch_btp_operator() {
+delete_btp_operator() {
     local namespace=$1
-    kubectl delete btpoperators btpoperator -n $namespace &
-    kubectl patch btpoperator btpoperator -n $namespace -p '{"metadata":{"finalizers":[]}}' --type=merge &
+    echo -e "\n---Deleting BTP Operator in $namespace namespace"
+    kubectl delete btpoperators e2e-test-btpoperator -n $namespace &
+    kubectl patch btpoperator e2e-test-btpoperator -n $namespace -p '{"metadata":{"finalizers":[]}}' --type=merge &
     wait
 }
 
-iterations=$1
-
-kubectl apply -f deployments/prerequisites.yaml  
-kubectl apply -f examples/btp-manager-secret.yaml
-kubectl apply -f https://github.com/kyma-project/btp-manager/releases/latest/download/btp-manager.yaml
-apply_btp_operator "default"
-wait_for_condition "TrueReconcileSucceeded" "default" "ready and reconciled"
+#kubectl apply -f deployments/prerequisites.yaml  
+#kubectl apply -f examples/btp-manager-secret.yaml
+#kubectl apply -f https://github.com/kyma-project/btp-manager/releases/latest/download/btp-manager.yaml
+#apply_btp_operator "default"
+#wait_for_condition "TrueReconcileSucceeded" "default" "ready and reconciled"
 
 export SI_NAME="test"
-envsubst < scripts/testing/yaml/e2e-test-service-instance.yaml | kubectl apply -f -
+envsubst < ${YAML_DIR}/e2e-test-service-instance.yaml | kubectl apply -f -
 export SB_NAME="test"
-envsubst < scripts/testing/yaml/e2e-test-service-binding.yaml | kubectl apply -f -
+envsubst < ${YAML_DIR}//e2e-test-service-binding.yaml | kubectl apply -f -
 
 for ((i=1; i<=$iterations; i++))
 do        
     apply_btp_operator "kyma-system"
     wait_for_condition "FalseOlderCRExists" "kyma-system" "ready and in error OlderCRExists"
-    delete_and_patch_btp_operator "default"
+    delete_btp_operator "default"
     wait_for_condition "TrueReconcileSucceeded" "kyma-system" "ready and reconciled"
     apply_btp_operator "default"
     wait_for_condition "FalseOlderCRExists" "default" "ready and in error OlderCRExists"
-    delete_and_patch_btp_operator "kyma-system"
+    delete_btp_operator "kyma-system"
     wait_for_condition "TrueReconcileSucceeded" "default" "ready and reconciled"
 done
 

--- a/scripts/testing/multiple_btpoperators_exist.sh
+++ b/scripts/testing/multiple_btpoperators_exist.sh
@@ -37,16 +37,7 @@ delete_btp_operator() {
     wait
 }
 
-#kubectl apply -f deployments/prerequisites.yaml  
-#kubectl apply -f examples/btp-manager-secret.yaml
-#kubectl apply -f https://github.com/kyma-project/btp-manager/releases/latest/download/btp-manager.yaml
-#apply_btp_operator "default"
-#wait_for_condition "TrueReconcileSucceeded" "default" "ready and reconciled"
-
-export SI_NAME="test"
-envsubst < ${YAML_DIR}/e2e-test-service-instance.yaml | kubectl apply -f -
-export SB_NAME="test"
-envsubst < ${YAML_DIR}//e2e-test-service-binding.yaml | kubectl apply -f -
+echo -e "\n---Testing multiple BTP Operators handling"
 
 for ((i=1; i<=$iterations; i++))
 do        
@@ -72,4 +63,4 @@ if [[ $count -ne 1 ]]; then
     exit 1
 fi
 
-echo "Test finished successfully"
+echo -e "\n---Multiple BTP Operators handling finished successfully"

--- a/scripts/testing/run_e2e_module_tests.sh
+++ b/scripts/testing/run_e2e_module_tests.sh
@@ -61,6 +61,8 @@ else
   echo -e "\n--- Service binding is not ready due to dummy/invalid credentials (Ready: NotProvisioned, Succeeded: CreateInProgress)"
 fi
 
+./scripts/testing/multiple_btpoperators_exist.sh 10
+
 echo -e "\n---Uninstalling..."
 
 # remove btp-operator (ServiceInstance and ServiceBinding should be deleted as well)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Test scenarios where there are 2 btpOperators and we remove one to check if the second one changes state to Ready and is reconciled.

Changes proposed in this pull request:

- Add test to e2e tests

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
