### PR TITLE
Possibility to Load Test Data Based on Env Variable

### DIFF
--- a/ui/.env.development
+++ b/ui/.env.development
@@ -1,0 +1,1 @@
+REACT_APP_USE_TEST_DATA=true

--- a/ui/.env.production
+++ b/ui/.env.production
@@ -1,0 +1,1 @@
+REACT_APP_USE_TEST_DATA=false

--- a/ui/src/components/ServiceInstancesView.tsx
+++ b/ui/src/components/ServiceInstancesView.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState, useRef } from "react";
 import { createPortal } from "react-dom";
 import api from "../shared/api";
 import Ok from "../shared/validator";
+import serviceInstancesData from '../test-data/serivce-instances.json';
 
 function ServiceInstancesView() {
   const [serviceInstances, setServiceInstances] = useState<ServiceInstances>();
@@ -37,25 +38,7 @@ function ServiceInstancesView() {
       setLoading(false)
     } else {
       setLoading(true)
-      setServiceInstances({
-        items: [
-          {
-            id: "1",
-            name: "Test Service Instance 1",
-            context: [],
-            serviceBindings: [],
-            namespace: "",
-          },
-          {
-            id: "2",
-            name: "Test Service Instance 2",
-            context: [],
-            serviceBindings: [],
-            namespace: "",
-          }
-
-        ]
-      })
+      setServiceInstances(serviceInstancesData)
       setLoading(false);
     }
   }, []);

--- a/ui/src/components/ServiceInstancesView.tsx
+++ b/ui/src/components/ServiceInstancesView.tsx
@@ -21,18 +21,43 @@ function ServiceInstancesView() {
   };
 
   useEffect(() => {
-    setLoading(true)
-    axios
-      .get<ServiceInstances>(api("service-instances"))
-      .then((response) => {
+    var useTestData = process.env.REACT_APP_USE_TEST_DATA
+    if (!useTestData) {
+      setLoading(true)
+      axios
+        .get<ServiceInstances>(api("service-instances"))
+        .then((response) => {
           setLoading(false);
           setServiceInstances(response.data);
-      })
-      .catch((error) => {
+        })
+        .catch((error) => {
           setLoading(false);
           setError(error);
-      });
+        });
       setLoading(false)
+    } else {
+      setLoading(true)
+      setServiceInstances({
+        items: [
+          {
+            id: "1",
+            name: "Test Service Instance 1",
+            context: [],
+            serviceBindings: [],
+            namespace: "",
+          },
+          {
+            id: "2",
+            name: "Test Service Instance 2",
+            context: [],
+            serviceBindings: [],
+            namespace: "",
+          }
+
+        ]
+      })
+      setLoading(false);
+    }
   }, []);
 
   if (loading) {

--- a/ui/src/test-data/serivce-instances.json
+++ b/ui/src/test-data/serivce-instances.json
@@ -1,0 +1,18 @@
+{
+    "items": [
+        {
+            "id": "1",
+            "name": "Test Service Instance 1",
+            "context": [],
+            "serviceBindings": [],
+            "namespace": ""
+        },
+        {
+            "id": "1",
+            "name": "Test Service Instance 1",
+            "context": [],
+            "serviceBindings": [],
+            "namespace": ""
+        }
+    ]
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

The following PR introduces environment files with environment variable called `REACT_APP_USE_TEST_DATA` that enables to switch from API calls to usage of test data when testing and demoing BTP Manager UI. See [React Docs](https://create-react-app.dev/docs/adding-custom-environment-variables/#what-other-env-files-can-be-used) for detailed description of the mechanism.

Changes proposed in this pull request:
- new environment variable called `REACT_APP_USE_TEST_DATA`,
- conditional API call if `REACT_APP_USE_TEST_DATA` is set to false,
- test data in separate file.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#442 