### PR TITLE
Removal of Recursive Invocation

### DIFF
--- a/ui/src/components/View.tsx
+++ b/ui/src/components/View.tsx
@@ -2,7 +2,7 @@ import ServiceOfferings from "./ServiceOfferingsView";
 import ServiceInstancesView from "./ServiceInstancesView";
 import * as ui5 from "@ui5/webcomponents-react";
 import Secrets from "./SecretsView";
-import React from "react";
+import React, { useEffect } from "react";
 
 function Overview(props: any) {
     const [secret, setSecret] = React.useState(null);
@@ -10,8 +10,11 @@ function Overview(props: any) {
 
     function handler(s: any) {
         setSecret(s);
-        setPageContent(<ServiceOfferings secret={s}/>);
     }
+    
+    useEffect(() => {
+        setPageContent(<ServiceOfferings secret={secret}/>)
+    }, [secret]);
     
     return (
         <>
@@ -43,6 +46,7 @@ function Overview(props: any) {
                         >
                             <ui5.SideNavigationItem
                                 text="Marketplace"
+                                selected
                                 onClick={() => {
                                     setPageContent(<ServiceOfferings secret={secret}/>);
                                 }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Method `setPageContent` invoked from a handler method caused recursive rendering of a given component. Initial rendering of `ServiceOferrings` view makes an API call to load available secrets after which handler method is invoked. The later forces rendering `ServiceOferrings` and `Secrets` closing the loop going back to API call again.

Changes proposed in this pull request:
- moved setPageContent method to `useEffect` with dependency to the `secret` state,
- setting `Marketplace` page as selected by default since that is the default view.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#442 
