### PR TITLE
Nil Check when Removing Secrets

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -324,6 +324,32 @@ func TestAPI(t *testing.T) {
 		err = fakeSM.RestoreDefaults()
 		require.NoError(t, err)
 	})
+
+	t.Run("DELETE Service Binding by ID when no secrets are present", func(t *testing.T) {
+		// given
+		sbID := "318a16c3-7c80-485f-b55c-918629012c9a"
+
+		// when
+		req, err := http.NewRequest(http.MethodDelete, apiAddr+"/api/service-bindings/"+sbID, nil)
+		resp, err := apiClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		// then
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		// when
+		req, err = http.NewRequest(http.MethodGet, apiAddr+"/api/service-bindings/"+sbID, nil)
+		resp, err = apiClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		// then
+		require.Equal(t, http.StatusInternalServerError, resp.StatusCode) // change to 404 after error handling refactoring
+
+		err = fakeSM.RestoreDefaults()
+		require.NoError(t, err)
+	})
 }
 
 func defaultServiceInstances() responses.ServiceInstances {

--- a/internal/cluster-object/secret_manager.go
+++ b/internal/cluster-object/secret_manager.go
@@ -201,6 +201,9 @@ func (p *SecretManager) Delete(ctx context.Context, secret *corev1.Secret) error
 }
 
 func (p *SecretManager) DeleteList(ctx context.Context, secrets *corev1.SecretList) error {
+	if (secrets == nil) {
+		return nil;
+	}
 	p.logger.Info(fmt.Sprintf("deleting %d secrets", len(secrets.Items)))
 	for _, secret := range secrets.Items {
 		if err := p.Client.Delete(ctx, &secret); err != nil {

--- a/internal/cluster-object/secret_manager.go
+++ b/internal/cluster-object/secret_manager.go
@@ -201,7 +201,7 @@ func (p *SecretManager) Delete(ctx context.Context, secret *corev1.Secret) error
 }
 
 func (p *SecretManager) DeleteList(ctx context.Context, secrets *corev1.SecretList) error {
-	if (secrets == nil) {
+	if (secrets == nil || len(secrets.Items) == 0) {
 		return nil;
 	}
 	p.logger.Info(fmt.Sprintf("deleting %d secrets", len(secrets.Items)))

--- a/internal/cluster-object/secret_manager.go
+++ b/internal/cluster-object/secret_manager.go
@@ -201,8 +201,8 @@ func (p *SecretManager) Delete(ctx context.Context, secret *corev1.Secret) error
 }
 
 func (p *SecretManager) DeleteList(ctx context.Context, secrets *corev1.SecretList) error {
-	if (secrets == nil || len(secrets.Items) == 0) {
-		return nil;
+	if secrets == nil || len(secrets.Items) == 0 {
+		return nil
 	}
 	p.logger.Info(fmt.Sprintf("deleting %d secrets", len(secrets.Items)))
 	for _, secret := range secrets.Items {

--- a/ui/src/components/ServiceBindingsList.tsx
+++ b/ui/src/components/ServiceBindingsList.tsx
@@ -1,5 +1,5 @@
 import * as ui5 from "@ui5/webcomponents-react";
-import { ApiError, ServiceInstanceBinding, ServiceInstanceBindings } from "../shared/models";
+import { ApiError, ServiceInstanceBindings } from "../shared/models";
 import axios from "axios";
 import { useEffect, useState } from "react";
 import api from "../shared/api";
@@ -13,7 +13,7 @@ function ServiceBindingsList(props: any) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<ApiError>();
   const [portal] = useState<JSX.Element>();
-  const [success, setSuccess] = useState("");
+  const [success] = useState("");
 
   function deleteBinding(id: string): boolean {
     setLoading(true);

--- a/ui/src/components/ServiceInstancesDetailsView.tsx
+++ b/ui/src/components/ServiceInstancesDetailsView.tsx
@@ -12,7 +12,7 @@ import CreateBindingForm from "./CreateBindingForm";
 
 function ServiceInstancesDetailsView(props: any) {
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<ApiError>();
+  const [error] = useState<ApiError>();
 
   const [instance, setInstance] = useState<ServiceInstance>();
   const dialogRef = useRef(null);


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

When tried to delete a binding with no secrets the process results in the following error:
```
net/http.(*conn).serve.func1()
	/usr/local/Cellar/go/1.22.3/libexec/src/net/http/server.go:1898 +0xbe
panic({0xab4a800?, 0xb8c82b0?})
	/usr/local/Cellar/go/1.22.3/libexec/src/runtime/panic.go:770 +0x132
github.com/kyma-project/btp-manager/internal/cluster-object.(*SecretManager).DeleteList(0xc0003cd890, {0xad38940, 0xb959580}, 0x0)
	/Users/I542535/newProjects/btp-manager/internal/cluster-object/secret_manager.go:204 +0x3d
github.com/kyma-project/btp-manager/internal/api.(*API).DeleteServiceBinding(0xc000528b40, {0xad2f660, 0xc0006e62a0}, 0xc0006f25a0)
	/Users/I542535/newProjects/btp-manager/internal/api/api.go:253 +0x1b6
net/http.HandlerFunc.ServeHTTP(0xc0001a5c70?, {0xad2f660?, 0xc0006e62a0?}, 0x819f3ba?)
	/usr/local/Cellar/go/1.22.3/libexec/src/net/http/server.go:2166 +0x29
net/http.(*ServeMux).ServeHTTP(0x7e315d9?, {0xad2f660, 0xc0006e62a0}, 0xc0006f25a0)
	/usr/local/Cellar/go/1.22.3/libexec/src/net/http/server.go:2683 +0x1ad
net/http.serverHandler.ServeHTTP({0xc000536630?}, {0xad2f660?, 0xc0006e62a0?}, 0x6?)
	/usr/local/Cellar/go/1.22.3/libexec/src/net/http/server.go:3137 +0x8e
net/http.(*conn).serve(0xc0003b37a0, {0xad38860, 0xc0003cdf20})
	/usr/local/Cellar/go/1.22.3/libexec/src/net/http/server.go:2039 +0x5e8
created by net/http.(*Server).Serve in goroutine 69
	/usr/local/Cellar/go/1.22.3/libexec/src/net/http/server.go:3285 +0x4b4
```

Changes proposed in this pull request:

- Added nil check that allows to remove binding that does not have any secrets associated with it.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

#442 
