### PR TITLE
Corrected Export Command Placement

### DIFF
--- a/docs/contributor/09-10-ui.md
+++ b/docs/contributor/09-10-ui.md
@@ -44,7 +44,7 @@ Follow the steps below to run BTP Manager with UI:
     ```
     Error creating: admission webhook "validation.webhook.warden.kyma-project.io" denied the request: Pod images europe-docker.pkg.dev/kyma-project/dev/btp-manager:PR-779 validation failed
     ```
-    you must scale the BTP Manager deployment to 0 replicas, delete the webhook, and the scale the deployment back to 1 replica.
+    you must scale the BTP Manager deployment to 0 replicas, delete the webhook, and then scale the deployment back to 1 replica.
     ```shell
     kubectl scale deployment -n kyma-system btp-manager-controller-manager --replicas=0
     kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io validation.webhook.warden.kyma-project.io

--- a/docs/contributor/09-10-ui.md
+++ b/docs/contributor/09-10-ui.md
@@ -9,7 +9,7 @@
     export KUBECONFIG=<path-to-kubeconfig>
     ```
 
-2. For clusters different from Kyma (for example, k3d) you need to install the [prerequisites](../../deployments/prerequisites.yaml).
+2. For clusters different from Kyma (for example, k3d), you must install the [prerequisites](../../deployments/prerequisites.yaml).
     ```shell
     kubectl apply -f deployments/prerequisites.yaml
     ```

--- a/docs/contributor/09-10-ui.md
+++ b/docs/contributor/09-10-ui.md
@@ -2,7 +2,6 @@
 
 > [!WARNING]
 > This feature is in the experimental stage and is not yet available in the main branch or official releases.
-> Use the latest development image to test the UI: europe-docker.pkg.dev/kyma-project/dev/btp-manager:PR-786
 
 ## Prerequisites
 1. Connect `kubectl` to your cluster by setting the **KUBECONFIG** environment variable.
@@ -11,9 +10,9 @@
     ```
 
 2. For clusters different from Kyma (for example, k3d) you need to install the [prerequisites](../../deployments/prerequisites.yaml).
-```shell
-kubectl apply -f deployments/prerequisites.yaml
-```
+    ```shell
+    kubectl apply -f deployments/prerequisites.yaml
+    ```
 
 ## Run BTP Manager with UI
 Follow the steps below to run BTP Manager with UI:
@@ -31,7 +30,7 @@ Follow the steps below to run BTP Manager with UI:
     ```
 3. Set the **IMG** environment variable to the image of BTP Manager with UI.
     ```shell
-    export IMG=europe-docker.pkg.dev/kyma-project/dev/btp-manager:PR-786
+    export IMG=europe-docker.pkg.dev/kyma-project/dev/btp-manager:PR-779
     ```
 4. Run `deploy` makefile rule to deploy BTP Manager with UI.
     ```shell
@@ -43,7 +42,7 @@ Follow the steps below to run BTP Manager with UI:
     ```
     If you encounter the following error during Pod creation due to Warden's admission webhook:
     ```
-    Error creating: admission webhook "validation.webhook.warden.kyma-project.io" denied the request: Pod images europe-docker.pkg.dev/kyma-project/dev/btp-manager:PR-786 validation failed
+    Error creating: admission webhook "validation.webhook.warden.kyma-project.io" denied the request: Pod images europe-docker.pkg.dev/kyma-project/dev/btp-manager:PR-779 validation failed
     ```
     you must scale the BTP Manager deployment to 0 replicas, delete the webhook, and the scale the deployment back to 1 replica.
     ```shell

--- a/docs/contributor/09-10-ui.md
+++ b/docs/contributor/09-10-ui.md
@@ -5,37 +5,39 @@
 > Use the latest development image to test the UI: europe-docker.pkg.dev/kyma-project/dev/btp-manager:PR-786
 
 ## Prerequisites
-For clusters different from Kyma (for example, k3d) you need to install the [prerequisites](../../deployments/prerequisites.yaml).
+1. Connect `kubectl` to your cluster by setting the **KUBECONFIG** environment variable.
+    ```shell
+    export KUBECONFIG=<path-to-kubeconfig>
+    ```
+
+2. For clusters different from Kyma (for example, k3d) you need to install the [prerequisites](../../deployments/prerequisites.yaml).
 ```shell
 kubectl apply -f deployments/prerequisites.yaml
 ```
 
 ## Run BTP Manager with UI
 Follow the steps below to run BTP Manager with UI:
-1. Connect `kubectl` to your cluster by setting the **KUBECONFIG** environment variable.
-    ```shell
-    export KUBECONFIG=<path-to-kubeconfig>
-    ```
-2. Make sure the `btp-operator` module is disabled and there are no existing BtpOperator custom resources (CRs) and deployments of BTP Manager and the SAP BTP service operator.
+
+1. Make sure the `btp-operator` module is disabled and there are no existing BtpOperator custom resources (CRs) and deployments of BTP Manager and the SAP BTP service operator.
     ```shell
     kubectl get btpoperators -A
     kubectl get deployment -n kyma-system btp-manager-controller-manager
     kubectl get deployment -n kyma-system sap-btp-operator-controller-manager
     ```
-3. Clone the `btp-manager` repository and checkout to the `sm-integration` branch.
+2. Clone the `btp-manager` repository and checkout to the `sm-integration` branch.
     ```shell
     git clone https://github.com/kyma-project/btp-manager.git
     git checkout sm-integration
     ```
-4. Set the **IMG** environment variable to the image of BTP Manager with UI.
+3. Set the **IMG** environment variable to the image of BTP Manager with UI.
     ```shell
     export IMG=europe-docker.pkg.dev/kyma-project/dev/btp-manager:PR-786
     ```
-5. Run `deploy` makefile rule to deploy BTP Manager with UI.
+4. Run `deploy` makefile rule to deploy BTP Manager with UI.
     ```shell
     make deploy
     ```
-6. Check if BTP Manager deployment is running.
+5. Check if BTP Manager deployment is running.
     ```shell
     kubectl get deployment -n kyma-system btp-manager-controller-manager
     ```
@@ -49,15 +51,15 @@ Follow the steps below to run BTP Manager with UI:
     kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io validation.webhook.warden.kyma-project.io
     kubectl scale deployment -n kyma-system btp-manager-controller-manager --replicas=1
     ```
-7. Apply BtpOperator CR to create the Secret with credentials to access Service Manager.
+6. Apply BtpOperator CR to create the Secret with credentials to access Service Manager.
     ```shell
     kubectl apply -n kyma-system -f examples/btp-operator.yaml
     ```
-8. Port-forward to BTP Manager deployment.
+7. Port-forward to BTP Manager deployment.
     ```shell
     kubectl port-forward -n kyma-system deployment/btp-manager-controller-manager 8080:8080
     ```
-9. Access the UI by opening `localhost:8080` in your browser.
+8. Access the UI by opening `localhost:8080` in your browser.
 
 ### Cleanup
 After testing the UI, you can delete the BtpOperator CR and BTP Manager deployment.

--- a/docs/contributor/09-10-ui.md
+++ b/docs/contributor/09-10-ui.md
@@ -17,7 +17,7 @@
 ## Run BTP Manager with UI
 Follow the steps below to run BTP Manager with UI:
 
-1. Make sure the `btp-operator` module is disabled and there are no existing BtpOperator custom resources (CRs) and deployments of BTP Manager and the SAP BTP service operator.
+1. Ensure that the SAP BTP Operator module is deleted and verify that there are no existing BtpOperator custom resources (CRs) or deployments of both BTP Manager and the SAP BTP service operator.
     ```shell
     kubectl get btpoperators -A
     kubectl get deployment -n kyma-system btp-manager-controller-manager

--- a/docs/contributor/09-10-ui.md
+++ b/docs/contributor/09-10-ui.md
@@ -23,7 +23,7 @@ Follow the steps below to run BTP Manager with UI:
     kubectl get deployment -n kyma-system btp-manager-controller-manager
     kubectl get deployment -n kyma-system sap-btp-operator-controller-manager
     ```
-2. Clone the `btp-manager` repository and checkout to the `sm-integration` branch.
+2. Clone the `btp-manager` repository and check out to the `sm-integration` branch.
     ```shell
     git clone https://github.com/kyma-project/btp-manager.git
     git checkout sm-integration


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Export `KUBECONFIG` should be placed before any `kubectl` command.

Changes proposed in this pull request:

- corrected export env placement.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

#442 
