### PR TITLE
Increase RSA key size

### DIFF
--- a/internal/certs/certs.go
+++ b/internal/certs/certs.go
@@ -13,7 +13,7 @@ import (
 )
 
 var (
-	rsaKeyBits = 1024
+	rsaKeyBits = 4096
 	randMax    = 10000
 )
 

--- a/module-chart/overrides.yaml
+++ b/module-chart/overrides.yaml
@@ -9,3 +9,5 @@ manager:
   kubernetesMatchLabels:
     enabled: true
   enable_limited_cache: false
+  memory_limit: 500Mi
+  cpu_limit: 1

--- a/module-chart/overrides.yaml
+++ b/module-chart/overrides.yaml
@@ -1,6 +1,8 @@
 manager:
   annotations:
     sidecar.istio.io/inject: "false"
+  memory_limit: 500Mi
+  cpu_limit: 1
   req_cpu_limit: 10m
   replica_count: 1
   enable_leader_election: false
@@ -9,5 +11,3 @@ manager:
   kubernetesMatchLabels:
     enabled: true
   enable_limited_cache: false
-  memory_limit: 500Mi
-  cpu_limit: 1

--- a/module-resources/apply/deployment.yml
+++ b/module-resources/apply/deployment.yml
@@ -73,8 +73,8 @@ spec:
             periodSeconds: 10
           resources:
             limits:
-              cpu: 250m
-              memory: 200Mi
+              cpu: 1
+              memory: 500Mi
             requests:
               cpu: 10m
               memory: 20Mi


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- increase RSA key size to 4096,
- bump deployment limit memory to 500MB,
- bump deployment limit CPU to 1.

**Related issue(s)**
See also #791
