### PR TITLE
Set secret name and namespace from create Service Binding request

### DIFF
--- a/internal/api/requests/requests.go
+++ b/internal/api/requests/requests.go
@@ -10,6 +10,8 @@ type CreateServiceBinding struct {
 	Name              string          `json:"name"`
 	ServiceInstanceID string          `json:"service_instance_id"`
 	Parameters        json.RawMessage `json:"parameters"`
+	SecretName        string          `json:"secret_name"`
+	SecretNamespace   string          `json:"secret_namespace"`
 }
 
 type CreateServiceInstance struct {

--- a/internal/service-manager/fake.go
+++ b/internal/service-manager/fake.go
@@ -15,12 +15,14 @@ import (
 )
 
 const (
-	defaultDir               = "service-manager"
-	rootDir                  = "btp-manager"
-	serviceOfferingsJSONPath = "testdata/service_offerings.json"
-	servicePlansJSONPath     = "testdata/service_plans.json"
-	serviceInstancesJSONPath = "testdata/service_instances.json"
-	serviceBindingsJSONPath  = "testdata/service_bindings.json"
+	FakeJSONObjectCredentialsServiceInstanceID = "json-object-in-credentials"
+	testDataServiceInstanceID                  = "a7e240d6-e348-4fc0-a54c-7b7bfe9b9da6"
+	defaultDir                                 = "service-manager"
+	rootDir                                    = "btp-manager"
+	serviceOfferingsJSONPath                   = "testdata/service_offerings.json"
+	servicePlansJSONPath                       = "testdata/service_plans.json"
+	serviceInstancesJSONPath                   = "testdata/service_instances.json"
+	serviceBindingsJSONPath                    = "testdata/service_bindings.json"
 )
 
 type FakeServiceManager struct {
@@ -349,6 +351,9 @@ func (h *fakeSMHandler) getServiceInstance(w http.ResponseWriter, r *http.Reques
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
+	if siID == FakeJSONObjectCredentialsServiceInstanceID {
+		siID = testDataServiceInstanceID
+	}
 
 	var err error
 	data := make([]byte, 0)
@@ -667,7 +672,11 @@ func (h *fakeSMHandler) createServiceBinding(w http.ResponseWriter, r *http.Requ
 	}
 
 	sbCreateRequest.ID = uuid.New().String()
-	sbCreateRequest.Credentials = []byte(`{"username": "user", "password": "pass"}`)
+	if sbCreateRequest.ServiceInstanceID == FakeJSONObjectCredentialsServiceInstanceID {
+		sbCreateRequest.Credentials = []byte(`{"object":{"username":"user","password":"pass"}}`)
+	} else {
+		sbCreateRequest.Credentials = []byte(`{"username": "user", "password": "pass"}`)
+	}
 	h.serviceBindings.Items = append(h.serviceBindings.Items, sbCreateRequest)
 
 	data, err := json.Marshal(sbCreateRequest)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- include secret's name and namespace in create Service Binding request,
- create the secret with the data provided by the user,
- do not create the secret if a namespace is not provided to avoid K8s errors,
- serialize values from Service Binding's credentials,
- add unit test for a case when Service Binding contains credentials with JSON object. 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #442 