### PR TITLE
Use internal docker registry in k3s-setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22.6 as builder
+FROM golang:1.22.6-alpine3.20 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Dockerfile.ga
+++ b/Dockerfile.ga
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22.6 as builder
+FROM golang:1.22.6-alpine3.20 as builder
 
 WORKDIR /btp-manager-workspace
 # Copy the Go Modules manifests

--- a/scripts/testing/k3s-setup.sh
+++ b/scripts/testing/k3s-setup.sh
@@ -25,7 +25,7 @@ docker run -d \
 --restart=always \
 --name registry.localhost \
 -v "$PWD/registry:/var/lib/registry" \
-registry:2
+europe-docker.pkg.dev/kyma-project/prod/external/registry:2.8.3
 
 echo "Starting K3s cluster (K3s version: ${K3S_VERSION})"
 curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION=${K3S_VERSION} K3S_KUBECONFIG_MODE=777 INSTALL_K3S_EXEC="server --disable traefik" sh -


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- use internal docker registry in k3s-setup,
- update golang images.

**Related issue(s)**
See also [#1014](https://github.com/kyma-project/kyma-environment-broker/issues/1014)
