### PR TITLE
Set isOpen to false after closing the menu

### DIFF
--- a/ui/src/components/SecretsView.tsx
+++ b/ui/src/components/SecretsView.tsx
@@ -77,7 +77,7 @@ function SecretsView({ onSecretChanged }: { onSecretChanged: (secret: string) =>
 
                     <Menu
                         opener="openMenu"
-                        onAfterClose={function _a() { }}
+                        onAfterClose={function _a() {setIsOpen(false)}}
                         onAfterOpen={function _a() { }}
                         onBeforeClose={function _a() { }}
                         onBeforeOpen={function _a() { }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

isOpen is not set to false when the menu is closed without using the button. This PR fixes it to set isOpen to false when we close the menu in any way.



**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #442 