### PR TITLE
Default Bindings Value if No Content API Response

### DIFF
--- a/ui/src/components/ServiceBindingsList.tsx
+++ b/ui/src/components/ServiceBindingsList.tsx
@@ -8,7 +8,7 @@ import serviceInstancesData from '../test-data/service-bindings.json';
 import StatusMessage from "./StatusMessage";
 
 const ServiceBindingsList= forwardRef((props: any, ref) => {
-  const [bindings, setServiceInstanceBindings] = useState<ServiceInstanceBindings>();
+  const [bindings, setServiceInstanceBindings] = useState<ServiceInstanceBindings>(new ServiceInstanceBindings());
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<ApiError>();
@@ -59,7 +59,9 @@ const ServiceBindingsList= forwardRef((props: any, ref) => {
           { params: { service_instance_id: props.instance.id } }
         )
         .then((response) => {
-          setServiceInstanceBindings(response.data);
+          if (Ok(response.data)) {
+            setServiceInstanceBindings(response.data);
+          }
           setLoading(false);
           setError(undefined);
         })


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Adjustment to changes introduced in https://github.com/kyma-project/btp-manager/pull/812/files#diff-5b9b550fff634f1fd5596893d63ceeb6afa6a355427db919a644a21f097b7834R200 that made API return `no content` for empty bindings lists.

Changes proposed in this pull request:

- setting default service bindings list value when `no-content` API response received.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#442 