### PR TITLE
Illustrated Message Placement and Size Corrections

### DIFF
--- a/ui/src/components/ServiceBindingsList.tsx
+++ b/ui/src/components/ServiceBindingsList.tsx
@@ -127,6 +127,10 @@ const ServiceBindingsList= forwardRef((props: any, ref) => {
     });
   };
 
+  if (!Ok(bindings) || !Ok(bindings.items)) {
+    return <ui5.IllustratedMessage name="NoEntries" size="Dot"/>
+  }
+
   return (
     <>
       <ui5.Form>


### PR DESCRIPTION
Previously the message was displayed inside of a table resulting in its unatural placement with "Auto" size making it too big. Now the message is smaller and centered in the view.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Previously, the message was displayed inside of a table resulting in its unnatural placement with "Auto" size making it too big. Now the message is smaller and centred in the view.
@ralikio

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#442 
