### PR TITLE
Show secret connection status to SM

### DIFF
--- a/ui/src/components/SecretsView.tsx
+++ b/ui/src/components/SecretsView.tsx
@@ -59,17 +59,23 @@ function SecretsView({ onSecretChanged }: { onSecretChanged: (secret: string) =>
                 setLoading(false);
                 setSecrets(response.data);
                 if (Ok(response.data) && Ok(response.data.items)) {
-                    const secret = formatSecretText(selectedSecretName, selectedSecretNamespace)                
-                    onSecretChanged(secret);
-                    setSelectedSecret(secret);
-                    axios
-                        .get<ServiceOfferings>(api(`service-offerings/${selectedSecretNamespace}/${selectedSecretName}`))
-                        .then(() => {
-                            setSecretConnection(true);
-                        })
-                        .catch(() => {
-                            setSecretConnection(false);
-                        });
+                    const secret = formatSecretText(selectedSecretName, selectedSecretNamespace);
+                    const containsSelectedSecret = response.data.items.some(item => item.name === selectedSecretName && item.namespace === selectedSecretNamespace);
+                    if (containsSelectedSecret) {
+                        onSecretChanged(secret);
+                        setSelectedSecret(secret);
+                        axios
+                            .get<ServiceOfferings>(api(`service-offerings/${selectedSecretNamespace}/${selectedSecretName}`))
+                            .then(() => {
+                                setSecretConnection(true);
+                            })
+                            .catch(() => {
+                                setSecretConnection(false);
+                            });
+                    } else {
+                        onSecretChanged(formatSecretText("", ""));
+                    }                
+                    
                 } else {
                     onSecretChanged(formatSecretText("", ""));
                 }
@@ -84,7 +90,6 @@ function SecretsView({ onSecretChanged }: { onSecretChanged: (secret: string) =>
             setLoading(false);
     }, [onSecretChanged]);
     
-
     const fetchSecrets = () => {
         setLoading(true);
         axios

--- a/ui/src/components/SecretsView.tsx
+++ b/ui/src/components/SecretsView.tsx
@@ -5,12 +5,16 @@ import { Secrets } from "../shared/models";
 import Ok from "../shared/validator";
 import api from "../shared/api";
 import { Button, DynamicPageTitle, Menu, ObjectStatus } from "@ui5/webcomponents-react";
+import { ServiceOfferings } from "../shared/models";
 
 function SecretsView({ onSecretChanged }: { onSecretChanged: (secret: string) => void }) {
     const [secrets, setSecrets] = useState<Secrets>();
     const [selectedSecret, setSelectedSecret] = useState("btp-operator");
+    const [selectedSecretNamespace, setSelectedSecretNamespace] = useState("kyma-system");
+    const [selectedSecretName, setSelectedSecretName] = useState("sap-btp-service-operator");
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
+    const [secretConnection, setSecretConnection] = useState(false);
     const [isOpen, setIsOpen] = useState(false);
 
     useEffect(() => {
@@ -22,9 +26,50 @@ function SecretsView({ onSecretChanged }: { onSecretChanged: (secret: string) =>
                 setLoading(false);
                 setSecrets(response.data);
                 if (Ok(response.data) && Ok(response.data.items)) {
-                    const secret = formatSecretText(response.data.items[0].name, response.data.items[0].namespace)
+                    const secret = formatSecretText(response.data.items[0].name, response.data.items[0].namespace)                
                     onSecretChanged(secret);
                     setSelectedSecret(secret);
+                    axios
+                        .get<ServiceOfferings>(api(`service-offerings/${response.data.items[0].namespace}/${response.data.items[0].name}`))
+                        .then(() => {
+                            setSecretConnection(true);
+                        })
+                        .catch(() => {
+                            setSecretConnection(false);
+                        });
+                } else {
+                    onSecretChanged(formatSecretText("", ""));
+                }
+            })
+            .catch((error) => {
+                setLoading(false);
+                setError(error);
+                setSecrets(undefined);
+                onSecretChanged(formatSecretText("", ""));
+            });    
+            setLoading(false);
+    }, []);
+
+    useEffect(() => {
+
+        setLoading(true);
+        axios
+            .get<Secrets>(api("secrets"))
+            .then((response) => {
+                setLoading(false);
+                setSecrets(response.data);
+                if (Ok(response.data) && Ok(response.data.items)) {
+                    const secret = formatSecretText(selectedSecretName, selectedSecretNamespace)                
+                    onSecretChanged(secret);
+                    setSelectedSecret(secret);
+                    axios
+                        .get<ServiceOfferings>(api(`service-offerings/${selectedSecretNamespace}/${selectedSecretName}`))
+                        .then(() => {
+                            setSecretConnection(true);
+                        })
+                        .catch(() => {
+                            setSecretConnection(false);
+                        });
                 } else {
                     onSecretChanged(formatSecretText("", ""));
                 }
@@ -35,8 +80,10 @@ function SecretsView({ onSecretChanged }: { onSecretChanged: (secret: string) =>
                 setSecrets(undefined);
                 onSecretChanged(formatSecretText("", ""));
             });
+        
             setLoading(false);
     }, [onSecretChanged]);
+    
 
     const fetchSecrets = () => {
         setLoading(true);
@@ -107,6 +154,8 @@ function SecretsView({ onSecretChanged }: { onSecretChanged: (secret: string) =>
                             const secretNamespace = event.detail.item.dataset.secretNamespace;                           
                             if (secretName && secretNamespace) {
                                 setSelectedSecret(formatSecretText(secretName, secretNamespace));
+                                setSelectedSecretName(secretName);
+                                setSelectedSecretNamespace(secretNamespace);
                                 onSecretChanged(formatSecretText(secretName, secretNamespace));
                             }
                             setIsOpen(false);
@@ -120,8 +169,10 @@ function SecretsView({ onSecretChanged }: { onSecretChanged: (secret: string) =>
             }
 
                 header={selectedSecret}
-                subHeader="Currently you are connected to service manager that the above secret points to. To select other environment, use `select` button on the right.">
-                <ObjectStatus state="Success">connected</ObjectStatus>
+                subHeader={`Currently you are ${secretConnection ? "connected" : "not connected"} to service manager that the above secret points to. To select other environment, use 'select' button on the right.`}>
+                <ObjectStatus state={secretConnection ? ui5.ValueState.Success : ui5.ValueState.Error}>
+                    {secretConnection ? "connected" : "not connected"}
+                </ObjectStatus>
             </DynamicPageTitle>
         </>
     );

--- a/ui/src/components/SecretsView.tsx
+++ b/ui/src/components/SecretsView.tsx
@@ -27,7 +27,6 @@ function SecretsView({ onSecretChanged }: { onSecretChanged: (secret: string) =>
                 setSecrets(response.data);
                 if (Ok(response.data) && Ok(response.data.items)) {
                     const secret = formatSecretText(response.data.items[0].name, response.data.items[0].namespace)                
-                    onSecretChanged(secret);
                     setSelectedSecret(secret);
                     axios
                         .get<ServiceOfferings>(api(`service-offerings/${response.data.items[0].namespace}/${response.data.items[0].name}`))
@@ -37,15 +36,12 @@ function SecretsView({ onSecretChanged }: { onSecretChanged: (secret: string) =>
                         .catch(() => {
                             setSecretConnection(false);
                         });
-                } else {
-                    onSecretChanged(formatSecretText("", ""));
-                }
+                } 
             })
             .catch((error) => {
                 setLoading(false);
                 setError(error);
                 setSecrets(undefined);
-                onSecretChanged(formatSecretText("", ""));
             });    
             setLoading(false);
     }, []);
@@ -88,7 +84,7 @@ function SecretsView({ onSecretChanged }: { onSecretChanged: (secret: string) =>
             });
         
             setLoading(false);
-    }, [onSecretChanged]);
+    }, [onSecretChanged, selectedSecretName, selectedSecretNamespace]);
     
     const fetchSecrets = () => {
         setLoading(true);

--- a/ui/src/components/ServiceInstancesView.tsx
+++ b/ui/src/components/ServiceInstancesView.tsx
@@ -47,6 +47,7 @@ function ServiceInstancesView(props: any) {
               .get<ServiceInstances>(api("service-instances"))
               .then((response) => {
                 setServiceInstances(response.data);
+                setError(null);
                 if (id) {
                   const instance = response.data.items.find((instance) => instance.id === id);
                   if (instance) {
@@ -113,9 +114,9 @@ function ServiceInstancesView(props: any) {
     if (!Ok(serviceInstances) || !Ok(serviceInstances.items)) {
       return <ui5.IllustratedMessage name="NoEntries" />
     }
-
-
-
+    if (error) {
+      return <ui5.IllustratedMessage name="NoEntries"/>
+    }
     return serviceInstances?.items.map((instance, index) => {
 
 

--- a/ui/src/components/ServiceOfferingsView.tsx
+++ b/ui/src/components/ServiceOfferingsView.tsx
@@ -42,6 +42,7 @@ function ServiceOfferingsView(props: any) {
                 )
                 .then((response) => {
                     setLoading(false);
+                    setError(null);
                     setOfferings(response.data);
                 })
                 .catch((error) => {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Display message if connection to SM is established or not with selected secret
- Fix a bug to not always set the 1st returned secret from the api as the current one, set only on page load


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #442 