### PR TITLE
404 on Refresh Fix

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -76,20 +76,20 @@ func (a *API) AttachRoutes(router *http.ServeMux) {
 	router.HandleFunc("GET /api/service-bindings/{id}", a.GetServiceBinding)
 	router.HandleFunc("POST /api/service-bindings", a.CreateServiceBinding)
 	router.HandleFunc("DELETE /api/service-bindings/{id}", a.DeleteServiceBinding)
-	
-    router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-        if r.URL.Path != "/" {
-            fullPath := strings.TrimPrefix(path.Clean(r.URL.Path), "/")
-            _, err := a.frontendFS.Open(fullPath)
-            if err != nil {
-                if !os.IsNotExist(err) {
-                    panic(err)
-                }
-                r.URL.Path = "/"
-            }
-        }
-        http.FileServer(a.frontendFS).ServeHTTP(w, r)
-    })
+
+	router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			fullPath := strings.TrimPrefix(path.Clean(r.URL.Path), "/")
+			_, err := a.frontendFS.Open(fullPath)
+			if err != nil {
+				if !os.IsNotExist(err) {
+					panic(err)
+				}
+				r.URL.Path = "/"
+			}
+		}
+		http.FileServer(a.frontendFS).ServeHTTP(w, r)
+	})
 }
 
 func (a *API) Address() string {


### PR DESCRIPTION


<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

The following solution is adaption of https://stackoverflow.com/a/64687181 to provide default route to ui app if the file server does not contain given path. The file server returns 404 path if requested path does not correspond to any files in its filesystem. Because of that while routing request to our single page app (e.g. path "/instances/{id}") the request was handled by file server and not by the app itself (which corresponds to `index.html`). The solution routes existing paths, like "/static/*", to the file server and non existing, like "/instances/{id}", to the app frontend.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

#442 