### PR TITLE
Api State Removal - UI Passing Secret Name and Namespace Params

### DIFF
--- a/docs/contributor/09-10-ui.md
+++ b/docs/contributor/09-10-ui.md
@@ -30,7 +30,7 @@ Follow the steps below to run BTP Manager with UI:
     ```
 3. Set the **IMG** environment variable to the image of BTP Manager with UI.
     ```shell
-    export IMG=europe-docker.pkg.dev/kyma-project/dev/btp-manager:PR-799
+    export IMG=europe-docker.pkg.dev/kyma-project/dev/btp-manager:PR-845
     ```
 4. Run `deploy` makefile rule to deploy BTP Manager with UI.
     ```shell
@@ -42,7 +42,7 @@ Follow the steps below to run BTP Manager with UI:
     ```
     If you encounter the following error during Pod creation due to Warden's admission webhook:
     ```
-    Error creating: admission webhook "validation.webhook.warden.kyma-project.io" denied the request: Pod images europe-docker.pkg.dev/kyma-project/dev/btp-manager:PR-799 validation failed
+    Error creating: admission webhook "validation.webhook.warden.kyma-project.io" denied the request: Pod images europe-docker.pkg.dev/kyma-project/dev/btp-manager:PR-845 validation failed
     ```
     you must scale the BTP Manager deployment to 0 replicas, delete the webhook, and then scale the deployment back to 1 replica.
     ```shell

--- a/ui/src/components/CreateBindingForm.tsx
+++ b/ui/src/components/CreateBindingForm.tsx
@@ -35,12 +35,18 @@ function CreateBindingForm(props: any) {
         service_instance_id: createdBinding.service_instance_id,
         secret_name: createdBinding.secret_name,
         secret_namespace: createdBinding.secret_namespace
+      }, {
+        params:
+        {
+          secret_name: props.secret!!.name,
+          secret_namespace: props.secret!!.namespace
+        }
       })
       .then((response) => {
-        
+
         // propagate the created binding
         props.onCreate(response.data);
-        
+
         // reset binding
         const binding = new ServiceInstanceBinding()
         binding.name = props.instanceName
@@ -72,6 +78,10 @@ function CreateBindingForm(props: any) {
       return;
     }
 
+    if (!Ok(props.secret) || !Ok(props.secret.name) || !Ok(props.secret.namespace)) {
+      return;
+    }
+
     setLoading(true)
 
     setLoading(false)
@@ -82,7 +92,7 @@ function CreateBindingForm(props: any) {
     createdBinding.secret_namespace = "default"
     setCreatedBinding(createdBinding)
 
-  }, [createdBinding, props.instanceId, props.instanceName, props.onCreate]);
+  }, [createdBinding, props.instanceId, props.instanceName, props.onCreate, props.secret]);
 
   const renderData = () => {
 

--- a/ui/src/components/CreateInstanceForm.tsx
+++ b/ui/src/components/CreateInstanceForm.tsx
@@ -37,22 +37,27 @@ function CreateInstanceForm(props: any) {
 
         var createdJson = {
             id: createServiceInstance?.id,
-            name: createServiceInstance?.name, 
-            service_plan_id: createServiceInstance?.service_plan_id, 
-            labels: createServiceInstance?.labels, 
+            name: createServiceInstance?.name,
+            service_plan_id: createServiceInstance?.service_plan_id,
+            labels: createServiceInstance?.labels,
             parameters: {}
         }
 
-        if(createServiceInstance?.parameters !== undefined) {
+        if (createServiceInstance?.parameters !== undefined) {
             createdJson.parameters = JSON.parse(createServiceInstance?.parameters)
         }
 
         axios
-            .post<CreateServiceInstance>(api("service-instances"), createdJson)
+            .post<CreateServiceInstance>(api("service-instances"), createdJson, {
+                params:
+                {
+                    secret_name: props.secret!!.name,
+                    secret_namespace: props.secret!!.namespace
+                }
+            })
             .then((response) => {
                 setLoading(false);
                 setSuccess("Item with id " + response.data.name + " created, redirecting to instances page...");
-                setCreateServiceInstance(new CreateServiceInstance());
 
                 setTimeout(() => {
                     navigate("/instances/" + response.data.id);
@@ -76,6 +81,10 @@ function CreateInstanceForm(props: any) {
             return;
         }
 
+        if (!Ok(props.secret) || !Ok(props.secret.name) || !Ok(props.secret.namespace)) {
+            return;
+        }
+
         var createServiceInstance = new CreateServiceInstance();
         createServiceInstance.name = generateServiceInstanceName(
             props.plan?.name,
@@ -86,7 +95,7 @@ function CreateInstanceForm(props: any) {
 
         setCreateServiceInstance(createServiceInstance);
 
-    }, [props.plan, props.offering]);
+    }, [props.plan, props.offering, props.secret]);
 
     function refresh(addedValue: string[]) {
         var allLabels = [...labels, ...addedValue]

--- a/ui/src/components/SecretsView.tsx
+++ b/ui/src/components/SecretsView.tsx
@@ -29,21 +29,27 @@ function SecretsView({ onSecretChanged }: { onSecretChanged: (secret: string) =>
                     const secret = formatSecretText(response.data.items[0].name, response.data.items[0].namespace)                
                     setSelectedSecret(secret);
                     axios
-                        .get<ServiceOfferings>(api(`service-offerings/${response.data.items[0].namespace}/${response.data.items[0].name}`))
+                        .get<ServiceOfferings>(api(`service-offerings/${response.data.items[0].namespace}/${response.data.items[0].name}`), {
+                            params:
+                            {
+                                secret_name: response.data.items[0].name,
+                                secret_namespace: response.data.items[0].namespace
+                            }
+                        })
                         .then(() => {
                             setSecretConnection(true);
                         })
                         .catch(() => {
                             setSecretConnection(false);
                         });
-                } 
+                }
             })
             .catch((error) => {
                 setLoading(false);
                 setError(error);
                 setSecrets(undefined);
-            });    
-            setLoading(false);
+            });
+        setLoading(false);
     }, []);
 
     useEffect(() => {
@@ -70,8 +76,8 @@ function SecretsView({ onSecretChanged }: { onSecretChanged: (secret: string) =>
                             });
                     } else {
                         onSecretChanged(formatSecretText("", ""));
-                    }                
-                    
+                    }
+
                 } else {
                     onSecretChanged(formatSecretText("", ""));
                 }
@@ -82,10 +88,10 @@ function SecretsView({ onSecretChanged }: { onSecretChanged: (secret: string) =>
                 setSecrets(undefined);
                 onSecretChanged(formatSecretText("", ""));
             });
-        
-            setLoading(false);
+
+        setLoading(false);
     }, [onSecretChanged, selectedSecretName, selectedSecretNamespace]);
-    
+
     const fetchSecrets = () => {
         setLoading(true);
         axios
@@ -100,7 +106,7 @@ function SecretsView({ onSecretChanged }: { onSecretChanged: (secret: string) =>
                 setSecrets(undefined);
                 onSecretChanged(formatSecretText("", ""));
             });
-            setLoading(false);
+        setLoading(false);
     };
 
     if (error) {
@@ -113,7 +119,7 @@ function SecretsView({ onSecretChanged }: { onSecretChanged: (secret: string) =>
     }
 
     const renderData = () => {
-        
+
         // @ts-ignore
         if (!Ok(secrets) || !Ok(secrets.items)) {
             return <ui5.MenuItem text={formatSecretText("", "")} />
@@ -141,18 +147,18 @@ function SecretsView({ onSecretChanged }: { onSecretChanged: (secret: string) =>
                         }}
                         id="openMenu"
                     >
-                    Select a secret
+                        Select a secret
                     </Button>
 
                     <Menu
                         opener="openMenu"
-                        onAfterClose={function _a() {setIsOpen(false)}}
+                        onAfterClose={function _a() { setIsOpen(false) }}
                         onAfterOpen={function _a() { }}
                         onBeforeClose={function _a() { }}
                         onBeforeOpen={function _a() { }}
                         onItemClick={(event) => {
                             const secretName = event.detail.item.dataset.secretName;
-                            const secretNamespace = event.detail.item.dataset.secretNamespace;                           
+                            const secretNamespace = event.detail.item.dataset.secretNamespace;
                             if (secretName && secretNamespace) {
                                 setSelectedSecret(formatSecretText(secretName, secretNamespace));
                                 setSelectedSecretName(secretName);

--- a/ui/src/components/ServiceBindingsList.tsx
+++ b/ui/src/components/ServiceBindingsList.tsx
@@ -7,7 +7,7 @@ import Ok from "../shared/validator";
 import serviceInstancesData from '../test-data/service-bindings.json';
 import StatusMessage from "./StatusMessage";
 
-const ServiceBindingsList= forwardRef((props: any, ref) => {
+const ServiceBindingsList = forwardRef((props: any, ref) => {
   const [bindings, setServiceInstanceBindings] = useState<ServiceInstanceBindings>(new ServiceInstanceBindings());
 
   const [loading, setLoading] = useState(true);
@@ -17,7 +17,7 @@ const ServiceBindingsList= forwardRef((props: any, ref) => {
 
   useImperativeHandle(ref, () => ({
 
-    add(binding : ServiceInstanceBinding) {
+    add(binding: ServiceInstanceBinding) {
       bindings?.items.push(binding);
       console.log(bindings)
       const newbindings = new ServiceInstanceBindings();
@@ -31,9 +31,14 @@ const ServiceBindingsList= forwardRef((props: any, ref) => {
     setLoading(true);
 
     axios
-      .delete(api("service-bindings") + "/" + id)
+      .delete(api("service-bindings") + "/" + id, {
+        params: {
+          secret_name: props.secret.name,
+          secret_namespace: props.secret.namespace
+        }
+      })
       .then((response) => {
-        bindings!!.items = bindings!!.items.filter(instance=> instance.id !== id)
+        bindings!!.items = bindings!!.items.filter(instance => instance.id !== id)
         setServiceInstanceBindings(bindings);
         setLoading(false);
         setError(undefined);
@@ -48,6 +53,12 @@ const ServiceBindingsList= forwardRef((props: any, ref) => {
 
   useEffect(() => {
     setLoading(true)
+
+    if (!Ok(props.secret) || !Ok(props.secret.name) || !Ok(props.secret.namespace)) {
+      setServiceInstanceBindings(new ServiceInstanceBindings());
+      return;
+    }
+
     if (!Ok(props.instance)) {
       setServiceInstanceBindings(new ServiceInstanceBindings());
       return;
@@ -57,18 +68,25 @@ const ServiceBindingsList= forwardRef((props: any, ref) => {
       setServiceInstanceBindings(new ServiceInstanceBindings());
       return;
     }
-
+  
     var useTestData = process.env.REACT_APP_USE_TEST_DATA === "true"
     if (!useTestData) {
       axios
         .get<ServiceInstanceBindings>(api("service-bindings"),
-          { params: { service_instance_id: props.instance.id } }
+          {
+            params:
+            {
+              service_instance_id: props.instance.id,
+              secret_name: props.secret.name,
+              secret_namespace: props.secret.namespace
+            }
+          }
         )
         .then((response) => {
           if (Ok(response.data)) {
             setServiceInstanceBindings(response.data);
           } else {
-            setServiceInstanceBindings(new ServiceInstanceBindings()); 
+            setServiceInstanceBindings(new ServiceInstanceBindings());
           }
           setError(undefined);
           setLoading(false);
@@ -82,7 +100,7 @@ const ServiceBindingsList= forwardRef((props: any, ref) => {
       setServiceInstanceBindings(serviceInstancesData)
       setLoading(false);
     }
-  }, [props.instance]);
+  }, [props.instance, props.instance.id, props.secret]);
 
   if (loading) {
     return <ui5.BusyIndicator
@@ -99,43 +117,43 @@ const ServiceBindingsList= forwardRef((props: any, ref) => {
     }
     return bindings?.items.map((binding, index) => {
       return (
-          <ui5.TableRow>
+        <ui5.TableRow>
 
-            <ui5.TableCell>
-              <ui5.Label>{binding.id}</ui5.Label>
-            </ui5.TableCell>
+          <ui5.TableCell>
+            <ui5.Label>{binding.id}</ui5.Label>
+          </ui5.TableCell>
 
-            <ui5.TableCell>
-              <ui5.Label>{binding.name}</ui5.Label>
-            </ui5.TableCell>
+          <ui5.TableCell>
+            <ui5.Label>{binding.name}</ui5.Label>
+          </ui5.TableCell>
 
-            <ui5.TableCell>
-              <ui5.Label>{binding.secret_name}</ui5.Label>
-            </ui5.TableCell>
+          <ui5.TableCell>
+            <ui5.Label>{binding.secret_name}</ui5.Label>
+          </ui5.TableCell>
 
-            <ui5.TableCell>
-              <ui5.Label>{binding.secret_namespace}</ui5.Label>
-            </ui5.TableCell>
+          <ui5.TableCell>
+            <ui5.Label>{binding.secret_namespace}</ui5.Label>
+          </ui5.TableCell>
 
-            <ui5.TableCell>
-              <ui5.Button
-                design="Default"
-                icon="delete"
-                onClick={function _a(e: any) {
-                  e.stopPropagation();
-                  return deleteBinding(binding.id);
-                }}
-              >
-              </ui5.Button>            
-            </ui5.TableCell>
+          <ui5.TableCell>
+            <ui5.Button
+              design="Default"
+              icon="delete"
+              onClick={function _a(e: any) {
+                e.stopPropagation();
+                return deleteBinding(binding.id);
+              }}
+            >
+            </ui5.Button>
+          </ui5.TableCell>
 
-          </ui5.TableRow>
+        </ui5.TableRow>
       );
     });
   };
 
   if (!Ok(bindings) || !Ok(bindings.items)) {
-    return <ui5.IllustratedMessage name="NoEntries" size="Dot"/>
+    return <ui5.IllustratedMessage name="NoEntries" size="Dot" />
   }
 
   return (

--- a/ui/src/components/ServiceInstancesDetailsView.tsx
+++ b/ui/src/components/ServiceInstancesDetailsView.tsx
@@ -35,7 +35,6 @@ const ServiceInstancesDetailsView = forwardRef((props: any, ref) => {
       // @ts-ignore
       dialogRef.current.close();
       setInstance(undefined);
-      setSecret(undefined);
     }
   };
 

--- a/ui/src/components/ServiceInstancesDetailsView.tsx
+++ b/ui/src/components/ServiceInstancesDetailsView.tsx
@@ -12,6 +12,7 @@ import CreateBindingForm from "./CreateBindingForm";
 
 const ServiceInstancesDetailsView = forwardRef((props: any, ref) => {
   const [loading, setLoading] = useState(true);
+  const [secret, setSecret] = useState();
   const [error] = useState<ApiError>();
 
   const [instance, setInstance] = useState<ServiceInstance>();
@@ -34,6 +35,7 @@ const ServiceInstancesDetailsView = forwardRef((props: any, ref) => {
       // @ts-ignore
       dialogRef.current.close();
       setInstance(undefined);
+      setSecret(undefined);
     }
   };
 
@@ -47,11 +49,16 @@ const ServiceInstancesDetailsView = forwardRef((props: any, ref) => {
       return;
     }
 
+    if (!Ok(props.secret) || !Ok(props.secret.name) || !Ok(props.secret.namespace)) {
+      return;
+    }
+
+    setSecret(props.secret);
     setInstance(props.instance);
 
     setLoading(false)
 
-  }, [props.instance]);
+  }, [props.instance, props.secret]);
 
   const renderData = () => {
 
@@ -104,11 +111,11 @@ const ServiceInstancesDetailsView = forwardRef((props: any, ref) => {
         </ui5.Panel>
 
         <ui5.Panel accessibleRole="Form" headerLevel="H2" headerText="Bindings">
-          <ServiceBindingsList ref={listRef} instance={props.instance} />
+          <ServiceBindingsList secret={secret} ref={listRef} instance={props.instance} />
         </ui5.Panel>
 
         <ui5.Panel headerLevel="H2" headerText="Create Binding">
-          <CreateBindingForm onCreate={(binding: ServiceInstanceBinding) => onBindingAdded(binding) } instanceId={props.instance.id} instanceName={props.instance.name}></CreateBindingForm>
+          <CreateBindingForm secret={secret} onCreate={(binding: ServiceInstanceBinding) => onBindingAdded(binding)} instanceId={props.instance.id} instanceName={props.instance.name} />
         </ui5.Panel>
 
       </ui5.Dialog>

--- a/ui/src/components/ServiceInstancesView.tsx
+++ b/ui/src/components/ServiceInstancesView.tsx
@@ -1,5 +1,5 @@
 import * as ui5 from "@ui5/webcomponents-react";
-import { ServiceInstance, ServiceInstances } from "../shared/models";
+import { Secret, ServiceInstance, ServiceInstances } from "../shared/models";
 import axios from "axios";
 import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
@@ -10,9 +10,11 @@ import ServiceInstancesDetailsView from "./ServiceInstancesDetailsView";
 import { useParams } from "react-router-dom";
 import StatusMessage from "./StatusMessage";
 import {ServiceOfferings} from "../shared/models";
+import { splitSecret } from "../shared/common";
 
 function ServiceInstancesView(props: any) {
   const [serviceInstances, setServiceInstances] = useState<ServiceInstances>();
+  const [secret, setSecret] = useState<Secret>(new Secret());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [selectedInstance, setSelectedInstance] = useState<ServiceInstance>(new ServiceInstance());
@@ -24,6 +26,10 @@ function ServiceInstancesView(props: any) {
 
   useEffect(() => {
     setLoading(true)
+
+    // disable selection when page refresh is done
+    setSelectedInstance(new ServiceInstance());
+
     if (!Ok(props.setTitle)) {
       return;
     }
@@ -35,16 +41,27 @@ function ServiceInstancesView(props: any) {
       if (!Ok(props.secret)) {
         return;
       }
-      const secretText = splitSecret(props.secret);
-      if (Ok(secretText)) {
+      const secret = splitSecret(props.secret);
+      setSecret(secret);
+      if (Ok(secret)) {
         axios
           .get<ServiceOfferings>(
-            api(`service-offerings/${secretText.namespace}/${secretText.secret_name}`)
+            api(`service-offerings/${secret.namespace}/${secret.name}`), {
+              params: {
+                secret_name: secret.name,
+                secret_namespace: secret.namespace
+              }
+            }
           )
           .then((response) => {
             setOfferings(response.data);
             axios
-              .get<ServiceInstances>(api("service-instances"))
+              .get<ServiceInstances>(api("service-instances"), {
+                params: {
+                  secret_name: secret.name,
+                  secret_namespace: secret.namespace
+                }
+              })
               .then((response) => {
                 setServiceInstances(response.data);
                 setError(null);
@@ -91,14 +108,18 @@ function ServiceInstancesView(props: any) {
   function deleteInstance(id: string): boolean {
     setLoading(true);
     axios
-      .delete(api("service-instances") + "/" + id)
+      .delete(api("service-instances") + "/" + id, {
+        params: {
+          secret_name: secret.name,
+          secret_namespace: secret.namespace
+        }
+      })
       .then((response) => {
         serviceInstances!!.items = serviceInstances!!.items.filter(instance => instance.id !== id)
         setServiceInstances(serviceInstances);
         setSuccess("Service instance deleted successfully")
         setError(null)
         setLoading(false);
-
       })
       .catch((error) => {
         setLoading(false);
@@ -189,21 +210,12 @@ function ServiceInstancesView(props: any) {
           {renderData()}
         </ui5.Table>
       </ui5.Card>
-      {createPortal(<ServiceInstancesDetailsView instance={selectedInstance} ref={dialogRef} />, document.getElementById("App")!!)}
+      {createPortal(<ServiceInstancesDetailsView secret={secret} instance={selectedInstance} ref={dialogRef} />, document.getElementById("App")!!)}
 
     </>
   );
 }
 
-function splitSecret(secret: string) {
-  if (secret == null) {
-      return {};
-  }
-  const secretParts = secret.split(" ");
-  const secret_name = secretParts[0];
-  let namespace = secretParts[2].replace("(", "");
-  namespace = namespace.replace(")", "");
-  return {secret_name, namespace};
-}
+
 
 export default ServiceInstancesView;

--- a/ui/src/components/ServiceOfferingsDetailsView.tsx
+++ b/ui/src/components/ServiceOfferingsDetailsView.tsx
@@ -1,6 +1,7 @@
 import * as ui5 from "@ui5/webcomponents-react";
 import Ok from "../shared/validator";
 import {
+  Secret,
   ServiceOffering,
   ServiceOfferingDetails,
   ServiceOfferingPlan,
@@ -12,6 +13,7 @@ import CreateInstanceForm from "./CreateInstanceForm";
 
 function ServiceOfferingsDetailsView(props: any) {
   const [plan, setPlan] = useState<ServiceOfferingPlan>();
+  const [secret, setSecret] = useState<Secret>(new Secret());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [offering, setOffering] = useState<ServiceOffering>();
@@ -37,9 +39,21 @@ function ServiceOfferingsDetailsView(props: any) {
       return;
     }
 
+    if (!Ok(props.secret) || !Ok(props.secret.name) || !Ok(props.secret.namespace)) {
+      return;
+    }
+
+    setSecret(props.secret);
     setLoading(true);
     axios
-      .get<ServiceOfferingDetails>(api(`service-offerings/${props.offering.id}`))
+      .get<ServiceOfferingDetails>(api(`service-offerings/${props.offering.id}`),
+      {
+        params:
+        {
+          secret_name: secret!!.name,
+          secret_namespace: secret!!.namespace
+        }
+      })
       .then((response) => {
         setLoading(false);
         setDetails(response.data);
@@ -156,7 +170,7 @@ function ServiceOfferingsDetailsView(props: any) {
             </ui5.Form>
           </ui5.Panel>
           <ui5.Panel accessibleRole="Form" headerLevel="H2" headerText="Create">
-            <CreateInstanceForm plan={plan} offering={props.offering} />
+            <CreateInstanceForm secret={secret} plan={plan} offering={props.offering} />
           </ui5.Panel>
         </ui5.Dialog>
       </>

--- a/ui/src/components/ServiceOfferingsView.tsx
+++ b/ui/src/components/ServiceOfferingsView.tsx
@@ -1,7 +1,7 @@
 import * as ui5 from "@ui5/webcomponents-react";
 import { useEffect, useState } from "react";
 import axios from "axios";
-import { ServiceOfferings } from "../shared/models";
+import { Secret, ServiceOfferings } from "../shared/models";
 import api from "../shared/api";
 import "@ui5/webcomponents-icons/dist/AllIcons.js"
 import "@ui5/webcomponents-fiori/dist/illustrations/NoEntries.js"
@@ -11,10 +11,12 @@ import Ok from "../shared/validator";
 import { createPortal } from "react-dom";
 import ServiceOfferingsDetailsView from "./ServiceOfferingsDetailsView";
 import { ResponsiveGridLayout } from "@ui5/webcomponents-react";
+import { splitSecret } from "../shared/common";
 
 function ServiceOfferingsView(props: any) {
     const greyImg = "data:image/svg+xml;base64,PHN2ZyBpZD0icGxhY2Vob2xkZXIiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDU2IDU2Ij48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6IzVhN2E5NDt9LmNscy0ye2ZpbGw6IzA0OTFkMDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPnBsYWNlaG9sZGVyPC90aXRsZT48cGF0aCBjbGFzcz0iY2xzLTEiIGQ9Ik00Ni45NTMsMjAuNTg4YTQuMzYzLDQuMzYzLDAsMCwwLTEuODM3LS40NTksMy4yOTEsMy4yOTEsMCwwLDAtMy40LDMuMzc2LDQuMDg0LDQuMDg0LDAsMCwwLC45LDIuNjI1LDMuMDExLDMuMDExLDAsMCwwLDIuNSwxLjEyNiwzLjA4NSwzLjA4NSwwLDAsMCwxLjQ2Mi0uMzc1LDcuNTEyLDcuNTEyLDAsMCwwLDEuMzItLjg5MSwxMC4xMzUsMTAuMTM1LDAsMCwxLDEuMjI2LS44OTEsMi4yNywyLjI3LDAsMCwxLDEuMTc5LS4zNzVBMS41LDEuNSwwLDAsMSw1MiwyNi40MTJWMzkuMDcxYTIuODQzLDIuODQzLDAsMCwxLS41NzYsMiwyLjkyNiwyLjkyNiwwLDAsMS0yLjE1OS42MjZxLTIuOTIzLDAtNC4zODUuMDQ3dC0yLjEyMi4wNDdINDEuOTFhMy4zMjEsMy4zMjEsMCwwLDAsLjYuNjQ0LDUuNzE3LDUuNzE3LDAsMCwxLDIuMDc0LDQuMjIsNS4wNTQsNS4wNTQsMCwwLDEtMS42NSwzLjc1MUE1LjMzMSw1LjMzMSwwLDAsMSwzOS4xMTgsNTJhNS42LDUuNiwwLDAsMS00LjA1NS0xLjU0Nyw1LjA3MSw1LjA3MSwwLDAsMS0xLjYtMy44LDQuODYyLDQuODYyLDAsMCwxLC41MTktMi4zLDExLjQwNywxMS40MDcsMCwwLDEsMS41MTYtMS45NywyLjMzMywyLjMzMywwLDAsMCwuNDc1LS42OUgyOC4zM2ExLjM5NCwxLjM5NCwwLDAsMS0xLjA4NC0uNDY5LDIuMDExLDIuMDExLDAsMCwxLS41MTktMS4wMzJWMTUuOTA5YTEuOCwxLjgsMCwwLDEsLjQyNC0xLjE3MiwxLjQ0NCwxLjQ0NCwwLDAsMSwxLjE3OS0uNTE2aDcuNzMzYTEuOTQ5LDEuOTQ5LDAsMCwwLS4zNzctLjU2MmwtLjgtMS4xNzFhOC43ODgsOC43ODgsMCwwLDEtLjg0Ny0xLjUsNC43ODMsNC43ODMsMCwwLDEtLjQwNi0xLjY3NkE1LjM0OCw1LjM0OCwwLDAsMSwzOS4wODEsNGE1LjU1Miw1LjU1MiwwLDAsMSwzLjc5LDEuNTUzQTQuNjM1LDQuNjM1LDAsMCwxLDQ0LjU1LDkuMzQ1Yy0uMDI4LDEuNjg4LTIuMDIzLDQuMTI1LTIuMjQxLDQuMzc1YTEuNTc2LDEuNTc2LDAsMCwwLS4zLjVoNy4yNjFBMi42NSwyLjY1LDAsMCwxLDUyLDE2Ljg0N3Y0LjEyNnEwLDEuNzgyLTEuNywxLjc4MmExLjc0MywxLjc0MywwLDAsMS0xLjMxOS0uNTQ5QTEzLjE1MiwxMy4xNTIsMCwwLDAsNDYuOTUzLDIwLjU4OFpNMjguMzMsMzkuMDcxYS41ODIuNTgyLDAsMCwwLC42Ni42NTdoNy4xNjdhMS41NzksMS41NzksMCwwLDEsMS43OTIsMS43ODEsMi4yMzgsMi4yMzgsMCwwLDEtLjM4NywxLjI1NGMtLjI4My40MDgtLjU4Mi44MTMtLjksMS4yMTlzLS42MTMuODMtLjksMS4yNjZhMi41NDYsMi41NDYsMCwwLDAtLjQyNCwxLjQwNywzLjExNSwzLjExNSwwLDAsMCwxLjEzMSwyLjUzMiw0LjAyMiw0LjAyMiwwLDAsMCwyLjY0MS45MzgsMy43NzYsMy43NzYsMCwwLDAsMi40NTItLjkzOEEzLjExNSwzLjExNSwwLDAsMCw0Mi43LDQ2LjY1NWEyLjU0NiwyLjU0NiwwLDAsMC0uNDI0LTEuNDA3LDEyLjUxMywxMi41MTMsMCwwLDAtLjk0My0xLjI2NnEtLjUxOS0uNjA5LS45NDMtMS4xNzJhMi4yNjEsMi4yNjEsMCwwLDEtLjQ2Mi0xLjMsMS42MTQsMS42MTQsMCwwLDEsLjU2Ni0xLjMxMywyLjAwNiwyLjAwNiwwLDAsMSwxLjMyLS40NjhoNy40NXEuOTQyLDAsLjk0My0uNjU3VjI2LjUwNmExLjYwOSwxLjYwOSwwLDAsMC0uNzA3LjQyMnEtLjUxOS40MjEtMS4xNzkuODlhMTEuMDY5LDExLjA2OSwwLDAsMS0xLjUwOS44OTEsMy43NywzLjc3LDAsMCwxLTEuNy40MjIsNS40NSw1LjQ1LDAsMCwxLTMuNjc4LTEuNSw0LjI1LDQuMjUsMCwwLDEtMS4yMjYtMS44NzYsNy4wNTMsNy4wNTMsMCwwLDEtLjM3Ny0yLjI1LDUuMTY2LDUuMTY2LDAsMCwxLDEuNi0zLjcsNS4wMDksNS4wMDksMCwwLDEsMy42NzgtMS42NDEsNC44ODQsNC44ODQsMCwwLDEsMi4zNTcuNTE1QTcuNTg3LDcuNTg3LDAsMCwxLDQ5LjUxOCwyMC4yYy41MDYuNTg4Ljc4NS42MjQuNzg1LjYyNFYxNi44NDdhLjU0NC41NDQsMCwwLDAtLjMzMS0uNDY5LDEuNDIyLDEuNDIyLDAsMCwwLS43MDctLjE4N2gtNy40NWEyLjE0NywyLjE0NywwLDAsMS0xLjMyLS40MjIsMS41ODcsMS41ODcsMCwwLDEtLjU2Ni0xLjM2LDIuMDY3LDIuMDY3LDAsMCwxLC40MjUtMS4xNzJxLjQyNS0uNjA5Ljk0My0xLjIxOWExMi4yMjIsMTIuMjIyLDAsMCwwLC45NDMtMS4yNjYsMi41NDEsMi41NDEsMCwwLDAsLjQyNC0xLjQwNywzLjExOCwzLjExOCwwLDAsMC0xLjEzMi0yLjUzMiwzLjc3MSwzLjc3MSwwLDAsMC0yLjQ1MS0uOTM4LDMuODM5LDMuODM5LDAsMCwwLTIuNTk0LjkzOEEzLjE3OCwzLjE3OCwwLDAsMCwzNS40LDkuMzQ1YTIuNzc2LDIuNzc2LDAsMCwwLC40MjQsMS40NTQsMTAuMDM3LDEwLjAzNywwLDAsMCwuOSwxLjI2NWwuODQ5LDEuMjJhMi45MDksMi45MDksMCwwLDEsLjQ3MSwxLjEyNSwxLjYyNSwxLjYyNSwwLDAsMS0uNTE4LDEuMzYsMS45NTYsMS45NTYsMCwwLDEtMS4yNzQuNDIySDI5LjA4NHEtLjc1NSwwLS43NTQuNjU2Wm0yMy42NywwYTIuNywyLjcsMCwwLDEtLjU3NiwyLDIuNjc1LDIuNjc1LDAsMCwxLTIuMTU5LjYyNiIvPjxwYXRoIGNsYXNzPSJjbHMtMiIgZD0iTTM3LjE0NywzMS4wNzRhMy4zMjgsMy4zMjgsMCwwLDAtMi44NzgtMS4zNiw0LjQ0NSw0LjQ0NSwwLDAsMC0yLjEyLjQyMiw2LjE4NSw2LjE4NSwwLDAsMC0xLjE3OC44OTFxLS41NjcuNDcxLTEuMTMyLjg5MWMtLjM3My4yNzgtLjgwOC43NzMtMS4zLjc3NkgyNi43MjdWMTYuNDZhMy4zMzUsMy4zMzUsMCwwLDAtLjM3Ny0xLjUsMS40MzYsMS40MzYsMCwwLDAtMS40MTUtLjc1MUgxOS4yNzdjLS41LDAtLjc1NC4yNTEtLjc1NC44NDRhMS45MDcsMS45MDcsMCwwLDAsLjM3NywxLjEyNiw5LjE0Niw5LjE0NiwwLDAsMCwuOTQzLDEuMTI1LDUuMzQxLDUuMzQxLDAsMCwxLC45NDMsMS4yNjYsMy4yMzYsMy4yMzYsMCwwLDEsLjM3NywxLjU0Nyw0LjQ1NCw0LjQ1NCwwLDAsMS0xLjI3MywzLjE0MSw0LjA0OSw0LjA0OSwwLDAsMS0zLjA2NSwxLjM2LDMuOSwzLjksMCwwLDEtMy4wMTgtMS4zNiw0LjU0Nyw0LjU0NywwLDAsMS0xLjIyNS0zLjE0MSwyLjkzNiwyLjkzNiwwLDAsMSwuNDI0LTEuNTQ3LDEzLjU0OCwxMy41NDgsMCwwLDEsLjktMS4zMTNjLjMxNC0uNDA2LjYyNy0uNzgxLjk0My0xLjEyNWExLjU4OCwxLjU4OCwwLDAsMCwuNDcxLTEuMDc5cTAtLjg0My0xLjAzNy0uODQ0SDUuN2ExLjU4NywxLjU4NywwLDAsMC0xLjIyNi41MTZBMS44MDYsMS44MDYsMCwwLDAsNCwxNS45OTFWMzkuOWExLjgsMS44LDAsMCwwLC40NzEsMS4yNjYsMS41ODMsMS41ODMsMCwwLDAsMS4yMjYuNTE2aDguNDg4Yy42OTEsMCwxLjAzNS4yMzgsMS4wMzcuNzVhMS41NDcsMS41NDcsMCwwLDEtLjQyMi45NDRMMTMuODA3LDQ0LjVhNi41NDksNi41NDksMCwwLDAtLjk5LDEuMjY2LDMuMTE2LDMuMTE2LDAsMCwwLS40MjQsMS42NDEsNC4yMzcsNC4yMzcsMCwwLDAsMS4zNjcsMy40Nyw0Ljc5MSw0Ljc5MSwwLDAsMCw2LjIyNC0uMDQ3LDQuNTE3LDQuNTE3LDAsMCwwLDEuNDQ1LTMuMjgzLDMuNjMxLDMuNjMxLDAsMCwwLS41MTQtMS44ODljLS4yMTUtLjMwNy0uOTc4LTEuMTU4LS45NzgtMS4xNThMMTguOSw0My4zNzNhMS40OTIsMS40OTIsMCwwLDEtLjM3Ny0uOTM4cTAtLjc1Ljg0OC0uNzVoNS42NThxMS4yMjYsMCwxLjctMS41VjM1LjM0MUgyOC4zNWMuNTU3LDAsMS4wNTQuNTE5LDEuNDg5LjhhMTIuMjkxLDEyLjI5MSwwLDAsMSwxLjIyNi44OTFxLjU2NS40NjksMS4xNzkuODlhMy43ODYsMy43ODYsMCwwLDAsMS44MTYuNDIyLDMuMjU2LDMuMjU2LDAsMCwwLDMuMDg3LTEuNDA2LDUuMTE5LDUuMTE5LDAsMCwwLC45OS0zQTQuNzg4LDQuNzg4LDAsMCwwLDM3LjE0NywzMS4wNzRaIi8+PC9zdmc+"
     const [offerings, setOfferings] = useState<ServiceOfferings>();
+    const [secret, setSecret] = useState<Secret>();
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
     const [portal, setPortal] = useState<JSX.Element>();
@@ -23,22 +25,31 @@ function ServiceOfferingsView(props: any) {
         setLoading(true);
 
         if (!Ok(props.setTitle)) {
+            setSecret(new Secret());
             setLoading(false);
             return;
         }
         props.setTitle("Service Offerings");
 
         if (!Ok(props.secret)) {
+            setSecret(new Secret());
             setLoading(false);
             return;
         }
-        const secretText = splitSecret(props.secret);
-        if (Ok(secretText)) {
+        const secret = splitSecret(props.secret);
+        if (Ok(secret)) {
+            setSecret(secret);
             axios
                 .get<ServiceOfferings>(
                     api(
-                        `service-offerings/${secretText.namespace}/${secretText.secret_name}`
-                    )
+                        `service-offerings/${secret.namespace}/${secret.name}`
+                    ), {
+                        params:
+                        {
+                          secret_name: secret.name,
+                          secret_namespace: secret.namespace
+                        }
+                      }
                 )
                 .then((response) => {
                     setLoading(false);
@@ -84,7 +95,7 @@ function ServiceOfferingsView(props: any) {
                 <ui5.Card
                     key={index}
                     onClick={() => {
-                        setPortal(createPortal(<ServiceOfferingsDetailsView offering={offering} />, document.getElementById("App")!!, window.crypto.randomUUID()))
+                        setPortal(createPortal(<ServiceOfferingsDetailsView secret={secret} offering={offering} />, document.getElementById("App")!!, window.crypto.randomUUID()))
                     }}
                     header={
                         <ui5.CardHeader
@@ -122,17 +133,6 @@ function ServiceOfferingsView(props: any) {
     };
 
     return <>{renderData()}</>;
-}
-
-function splitSecret(secret: string) {
-    if (secret == null) {
-        return {};
-    }
-    const secretParts = secret.split(" ");
-    const secret_name = secretParts[0];
-    let namespace = secretParts[2].replace("(", "");
-    namespace = namespace.replace(")", "");
-    return { secret_name, namespace };
 }
 
 function formatStatus(i: number, j: number) {

--- a/ui/src/shared/common.tsx
+++ b/ui/src/shared/common.tsx
@@ -1,0 +1,13 @@
+import { Secret } from "./models";
+
+export function splitSecret(secret: string) : Secret {
+  if (secret == null) {
+      return new Secret();
+  }
+  const output = new Secret();
+  const secretParts = secret.split(" ");
+  output.name = secretParts[0];
+  output.namespace = secretParts[2].replace("(", "");
+  output.namespace = output.namespace.replace(")", "");
+  return output;
+}

--- a/ui/src/shared/models.tsx
+++ b/ui/src/shared/models.tsx
@@ -43,6 +43,10 @@ export interface ServiceInstances {
   items: ServiceInstance[];
 }
 
+export class Secret {
+  name: string = "";
+  namespace: string = "";
+}
 export class CreateServiceInstance {
   id: string = "";
   name: string = "";


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- passing secret and header in each request beside those sent to `/secrets`,
- formatting,
- removal of unnecessary duplicated bindings api calls: https://github.com/kyma-project/btp-manager/pull/845/files#diff-3a49b4e1bfd8aacf907f566581574f29053a65c47f5670147e52aee61f2399b3R31,
- removed redundancy in the form of 2 definitions of `splitSecret`.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#442 