### PR TITLE
Closing Message Strip

### DIFF
--- a/docs/contributor/09-10-ui.md
+++ b/docs/contributor/09-10-ui.md
@@ -30,7 +30,7 @@ Follow the steps below to run BTP Manager with UI:
     ```
 3. Set the **IMG** environment variable to the image of BTP Manager with UI.
     ```shell
-    export IMG=europe-docker.pkg.dev/kyma-project/dev/btp-manager:PR-856
+    export IMG=europe-docker.pkg.dev/kyma-project/dev/btp-manager:PR-857
     ```
 4. Run `deploy` makefile rule to deploy BTP Manager with UI.
     ```shell
@@ -42,7 +42,7 @@ Follow the steps below to run BTP Manager with UI:
     ```
     If you encounter the following error during Pod creation due to Warden's admission webhook:
     ```
-    Error creating: admission webhook "validation.webhook.warden.kyma-project.io" denied the request: Pod images europe-docker.pkg.dev/kyma-project/dev/btp-manager:PR-856 validation failed
+    Error creating: admission webhook "validation.webhook.warden.kyma-project.io" denied the request: Pod images europe-docker.pkg.dev/kyma-project/dev/btp-manager:PR-857 validation failed
     ```
     you must scale the BTP Manager deployment to 0 replicas, delete the webhook, and then scale the deployment back to 1 replica.
     ```shell

--- a/ui/src/components/StatusMessage.tsx
+++ b/ui/src/components/StatusMessage.tsx
@@ -24,29 +24,37 @@ function StatusMessage(props: StatusMessageProps) {
                     message += " - " + props.error!!.response.data;
                     setMessage(message);
                 }
+
             } else {
                 console.log(props.error);
             }
+        } else if (props.success) {
+            setMessage(props.success);
         }
     }, [props.error, props.success]);
 
 
     const renderData = () => {
 
-        if (props.error) {
+        if (props.error && message) {
             return (
-                    <ui5.MessageStrip
-                        design="Negative"
-                        >
-                        {message}
-                    </ui5.MessageStrip>
+                <ui5.MessageStrip
+                    design="Negative"
+                    onClose={function _s() {
+                        setMessage("");
+                    }}>
+                    {message}
+                </ui5.MessageStrip>
             );
-        } else if (props.success) {
+        } else if (props.success && message) {
             return (
-                    <ui5.MessageStrip
-                        design="Information">
-                        {props.success}
-                    </ui5.MessageStrip>
+                <ui5.MessageStrip
+                    design="Information"
+                    onClose={function _s() {
+                        setMessage("");
+                    }}>
+                    {message}
+                </ui5.MessageStrip>
             );
         } else {
             <div></div>


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Added handler that closes Message strip when "x" button is clicked.

Changes proposed in this pull request:
- added onClose event handler,
- displaying message from `useState` property with the same name,
- clearing `message` property when MessageStrip should be closed.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

#442 
