### PR TITLE
Improve error reasons on btpOperator

### DIFF
--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -616,7 +616,10 @@ func (r *BtpOperatorReconciler) applyOrUpdateResources(ctx context.Context, us [
 func (r *BtpOperatorReconciler) waitForResourcesReadiness(ctx context.Context, us []*unstructured.Unstructured) error {
 	numOfResources := len(us)
 	resourcesReadinessInformer := make(chan bool, numOfResources-1)
-	deploymentReadinessInformer := make(chan bool, 1)
+	deploymentReadinessInformer := make(chan struct {
+		Name  string
+		Ready bool
+	}, 1)
 	for _, u := range us {
 		if u.GetKind() == deploymentKind {
 			go r.checkDeploymentReadiness(ctx, u, deploymentReadinessInformer)
@@ -633,8 +636,8 @@ func (r *BtpOperatorReconciler) waitForResourcesReadiness(ctx context.Context, u
 			}
 			continue
 		case deploymentReady := <-deploymentReadinessInformer:
-			if !deploymentReady {
-				return errors.New("deployment readiness timeout reached")
+			if !deploymentReady.Ready {
+				return fmt.Errorf("deployment readiness timeout reached for %s", deploymentReady.Name)
 			}
 			continue
 		}
@@ -642,7 +645,10 @@ func (r *BtpOperatorReconciler) waitForResourcesReadiness(ctx context.Context, u
 	return nil
 }
 
-func (r *BtpOperatorReconciler) checkDeploymentReadiness(ctx context.Context, u *unstructured.Unstructured, c chan<- bool) {
+func (r *BtpOperatorReconciler) checkDeploymentReadiness(ctx context.Context, u *unstructured.Unstructured, c chan<- struct {
+	Name  string
+	Ready bool
+}) {
 	logger := log.FromContext(ctx)
 	ctxWithTimeout, cancel := context.WithTimeout(ctx, ReadyCheckInterval)
 	defer cancel()
@@ -654,7 +660,10 @@ func (r *BtpOperatorReconciler) checkDeploymentReadiness(ctx context.Context, u 
 	for {
 		if time.Since(now) >= ReadyTimeout {
 			logger.Error(err, fmt.Sprintf("timed out while checking %s %s readiness", u.GetName(), u.GetKind()))
-			c <- false
+			c <- struct {
+				Name  string
+				Ready bool
+			}{Name: u.GetName(), Ready: false}
 			return
 		}
 		if err = r.Get(ctxWithTimeout, client.ObjectKey{Name: u.GetName(), Namespace: u.GetNamespace()}, got); err == nil {
@@ -666,7 +675,10 @@ func (r *BtpOperatorReconciler) checkDeploymentReadiness(ctx context.Context, u 
 				}
 			}
 			if progressingConditionStatus == "True" && availableConditionStatus == "True" {
-				c <- true
+				c <- struct {
+					Name  string
+					Ready bool
+				}{Name: u.GetName(), Ready: true}
 				return
 			}
 		}

--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -627,7 +627,7 @@ func (r *BtpOperatorReconciler) waitForResourcesReadiness(ctx context.Context, u
 		go r.checkResourceReadiness(ctx, u, resourcesReadinessInformer)
 	}
 	go func(c, c2 chan bool, c3 bool) {
-		timeout := time.After(ReadyTimeout + time.Minute)
+		timeout := time.After(ReadyTimeout)
 		for i := 0; i < numOfResources; i++ {
 			select {
 			case <-resourcesReadinessInformer:
@@ -647,7 +647,7 @@ func (r *BtpOperatorReconciler) waitForResourcesReadiness(ctx context.Context, u
 	select {
 	case <-allReadyInformer:
 		return nil
-	case <-time.After(ReadyTimeout + time.Minute):
+	case <-time.After(ReadyTimeout):
 		if !deploymentOk {
 			return errors.New("deployment readiness timeout reached")
 		}

--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -632,11 +632,8 @@ func (r *BtpOperatorReconciler) waitForResourcesReadiness(ctx context.Context, u
 	}
 
 	for i := 0; i < numOfResources; i++ {
-		select {
-		case resourceReady := <-resourcesReadinessInformer:
-			if !resourceReady.Ready {
-				return fmt.Errorf("%s %s in namespace %s readiness timeout reached", resourceReady.Kind, resourceReady.Name, resourceReady.Namespace)
-			}
+		if resourceReady := <-resourcesReadinessInformer; !resourceReady.Ready {
+			return fmt.Errorf("%s %s in namespace %s readiness timeout reached", resourceReady.Kind, resourceReady.Name, resourceReady.Namespace)
 		}
 	}
 	return nil

--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -623,7 +623,7 @@ func (r *BtpOperatorReconciler) waitForResourcesReadiness(ctx context.Context, u
 			go r.checkResourceReadiness(ctx, u, deploymentReadinessInformer)
 			continue
 		}
-		go r.checkResourceExistence(ctx, u, resourcesReadinessInformer)
+		go r.checkResourceReadiness(ctx, u, resourcesReadinessInformer)
 	}
 	go func(resourcesReadinessInformer, deploymentReadinessInformer chan bool) {
 		timeout := time.After(ReadyTimeout)

--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -633,12 +633,11 @@ func (r *BtpOperatorReconciler) waitForResourcesReadiness(ctx context.Context, u
 			case <-resourcesReadinessInformer:
 				continue
 			case ready := <-deploymentReadinessInformer:
-				if ready {
-					continue
-				} else {
+				if !ready {
 					deploymentOk = false
-					continue
+					return
 				}
+				continue
 			case <-timeout:
 				return
 			}
@@ -647,9 +646,6 @@ func (r *BtpOperatorReconciler) waitForResourcesReadiness(ctx context.Context, u
 	}(resourcesReadinessInformer, deploymentReadinessInformer, deploymentOk)
 	select {
 	case <-allReadyInformer:
-		if !deploymentOk {
-			return errors.New("deployment readiness timeout reached")
-		}
 		return nil
 	case <-time.After(ReadyTimeout + time.Minute):
 		if !deploymentOk {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

How the message looks like now:

> message: 'timed out while waiting for resources readiness: Deployment sap-btp-operator-controller-manager
>         in namespace kyma-system readiness timeout reached'

Changes proposed in this pull request:

- Add to error reason resource type, name and namespace
- Remove one redundant goroutine

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #931 