### PR TITLE
Fix SI and SB names in E2E module tests

### DIFF
--- a/scripts/testing/run_e2e_module_tests.sh
+++ b/scripts/testing/run_e2e_module_tests.sh
@@ -22,9 +22,11 @@ SAP_BTP_OPERATOR_DEPLOYMENT_NAME=sap-btp-operator-controller-manager
 
 [[ -z ${GITHUB_RUN_ID} ]] && echo "required variable GITHUB_RUN_ID not set" && exit 1
 
-SI_NAME=auditlog-management-si-${GITHUB_JOB}-${GITHUB_RUN_ID}
-SB_NAME=auditlog-management-sb-${GITHUB_JOB}-${GITHUB_RUN_ID}
-SI_PARAMS_SECRET_NAME=auditlog-management-params-secret-${GITHUB_JOB}-${GITHUB_RUN_ID}
+K8S_VER=$(kubectl version -o json | jq .serverVersion.gitVersion -r | cut -d + -f 1)
+
+SI_NAME=${GITHUB_JOB}-${K8S_VER}-${GITHUB_RUN_ID}
+SB_NAME=${GITHUB_JOB}-${K8S_VER}-${GITHUB_RUN_ID}
+SI_PARAMS_SECRET_NAME=params-secret
 
 export SI_NAME
 export SB_NAME


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

fix Service Instance and Service Binding names to avoid running parallel operations on the same resource in the external platform.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #955 