### PR TITLE
Fix cluster ID secret removal during module deprovisioning 

### DIFF
--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -812,9 +812,10 @@ func (r *BtpOperatorReconciler) HandleDeletingState(ctx context.Context, cr *v1a
 func (r *BtpOperatorReconciler) handleDeleting(ctx context.Context, cr *v1alpha1.BtpOperator) error {
 	logger := log.FromContext(ctx)
 
-	requiredSecret, errWithReason := r.getAndVerifyRequiredSecret(ctx)
-	if errWithReason != nil {
-		return r.handleMissingSecret(ctx, cr, logger, errWithReason)
+	requiredSecret, err := r.getSecretByNameAndNamespace(ctx, SecretName, ChartNamespace)
+	if err != nil {
+		logger.Error(err, fmt.Sprintf("while getting %s secret in %s namespace", SecretName, ChartNamespace))
+		return fmt.Errorf("failed to get the required secret: %w", err)
 	}
 
 	r.setCredentialsNamespacesAndClusterId(requiredSecret)
@@ -2210,13 +2211,15 @@ func (r *BtpOperatorReconciler) isCertSecret(s *corev1.Secret) bool {
 
 func (r *BtpOperatorReconciler) setCredentialsNamespacesAndClusterId(s *corev1.Secret) {
 	credentialsNamespace := ChartNamespace
-	if v, ok := s.Data[CredentialsNamespaceSecretKey]; ok && len(v) > 0 {
-		credentialsNamespace = string(v)
+	if s != nil {
+		if v, ok := s.Data[CredentialsNamespaceSecretKey]; ok && len(v) > 0 {
+			credentialsNamespace = string(v)
+		}
+		r.clusterIdFromSapBtpManagerSecret = string(s.Data[ClusterIdSecretKey])
+		r.previousCredentialsNamespace = s.Annotations[previousCredentialsNamespaceAnnotationKey]
 	}
 	r.credentialsNamespaceFromSapBtpManagerSecret = credentialsNamespace
 	r.credentialsNamespaceFromSapBtpServiceOperatorSecret = credentialsNamespace
-	r.previousCredentialsNamespace = s.Annotations[previousCredentialsNamespaceAnnotationKey]
-	r.clusterIdFromSapBtpManagerSecret = string(s.Data[ClusterIdSecretKey])
 }
 
 func (r *BtpOperatorReconciler) checkDefaultCredentialsSecretNamespace(ctx context.Context, logger logr.Logger, requiredSecret *corev1.Secret) *ErrorWithReason {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

The controller loses information about cluster ID and credentials namespace in a case where BTP Manager is restarted when BtpOperator CR is in Deleting state. The default values should be set prior to cluster ID secret removal.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
