### PR TITLE
Store release logs as a release asset

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -358,5 +358,5 @@ jobs:
 
       - name: Publish release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: ./scripts/publish_release.sh ${{ needs.create-draft.outputs.release_id }}

--- a/.github/workflows/upload-release-logs.yml
+++ b/.github/workflows/upload-release-logs.yml
@@ -1,0 +1,45 @@
+name: "Upload release logs as assets"
+run-name: Upload release ${{ github.event.release.tag_name }} logs as assets
+on:
+  release:
+    types: [released]
+
+permissions:
+  contents: write
+
+jobs:
+  upload-release-logs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Wait for release workflow to finish if in progress
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Checking if a release workflow is in progress..."
+          while true; do
+            IN_PROGRESS=$(gh run list --workflow "Create release" --json status -L 1 --jq '.[] | select(.status == "in_progress") | .status')
+            if [ -z "$IN_PROGRESS" ]; then
+              echo "No release workflow in progress."
+              break
+            fi
+            echo "Release workflow is in progress. Waiting 30 seconds..."
+            sleep 30
+          done
+
+      - name: Download logs from all attempts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./scripts/download_workflow_logs.sh "Create release" "Create release ${{ github.event.release.tag_name }}"
+
+      - name: Upload logs as release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for file in logs_attempt_*.zip; do
+            echo "Uploading $file to release ${{ github.event.release.tag_name }}..."
+            gh release upload ${{ github.event.release.tag_name }} "$file" --repo "$GITHUB_REPOSITORY" --clobber
+          done

--- a/scripts/download_workflow_logs.sh
+++ b/scripts/download_workflow_logs.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# This script downloads logs from all attempts of the latest workflow run by workflow name and title.
+
+# standard bash error handling
+set -o nounset  # treat unset variables as an error and exit immediately.
+set -o errexit  # exit immediately when a command fails.
+set -E          # needs to be set if we want the ERR trap
+set -o pipefail # prevents errors in a pipeline from being masked
+
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <workflow_name> <workflow_title>"
+  exit 1
+fi
+
+WORKFLOW_NAME="$1"
+WORKFLOW_TITLE="$2"
+
+REPO="${GITHUB_REPOSITORY:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+
+workflow_id=$(gh api \
+  -H "Accept: application/vnd.github+json" \
+  "/repos/${REPO}/actions/workflows" | jq -r --arg name "$WORKFLOW_NAME" '.workflows[] | select(.name == $name) | .id')
+if [ -z "$workflow_id" ] || [ "$workflow_id" = "null" ]; then
+  echo "Workflow '$WORKFLOW_NAME' not found."
+  exit 1
+fi
+
+run_id=$(gh api \
+  -H "Accept: application/vnd.github+json" \
+  "/repos/${REPO}/actions/workflows/${workflow_id}/runs" | jq -r --arg workflow_title_filter "$WORKFLOW_TITLE" '.workflow_runs[] | select(.display_title | test($workflow_title_filter; "i")) | .id' | head -n 1)
+if [ -z "$run_id" ] || [ "$run_id" = "null" ]; then
+  echo "No runs found for workflow: $WORKFLOW_NAME with title filter: $WORKFLOW_TITLE"
+  exit 1
+fi
+
+attempts=$(gh api \
+  -H "Accept: application/vnd.github+json" \
+  "/repos/${REPO}/actions/runs/${run_id}" | jq -r '.run_attempt')
+if [ -z "$attempts" ] || [ "$attempts" = "null" ]; then
+  echo "Attempts not found."
+  exit 1
+fi
+
+for attempt in $(seq 1 $attempts); do
+  echo "Downloading logs for attempt $attempt..."
+  gh api \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "/repos/${REPO}/actions/runs/${run_id}/attempts/${attempt}/logs" > "logs_attempt_${attempt}.zip"
+done
+
+echo "Downloaded logs for $attempts attempt(s)."


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

A new workflow is triggered on the release publication event, which is executed by an user. Thats why we must use the kyma-gopher-bot token to publish the release, instead of the workflow github token. The the workflow waits for the release workflow to finish, then downloads the release logs from all attempts and uploads them to the release as asssets.

Changes proposed in this pull request:
- Publish release as kyma-gopher-bot
- Add workflow and script for uploading logs to release

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #1047 