### PR TITLE
Update external images along with SAP BTP service operator resources

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -48,6 +48,11 @@ jobs:
           scripts/update/make-module-chart.sh $TAG
           scripts/update/make-module-resources.sh $TAG
 
+      - name: Update external images
+        if: env.CONTINUE_JOB == 'true'
+        run: |
+          scripts/update/update-external-images.sh
+
       - name: Create PR if anything changed
         if: env.CONTINUE_JOB == 'true'
         env:

--- a/scripts/update/update-external-images.sh
+++ b/scripts/update/update-external-images.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+OUTPUT_FILE="external-images.yaml"
+
+echo "images:" > "$OUTPUT_FILE"
+
+# Extract images from module-resources/apply/deployment.yml if the file exists
+DEPLOYMENT_YAML="./module-resources/apply/deployment.yml"
+if [ -f "$DEPLOYMENT_YAML" ]; then
+  IMAGES=$(yq '.spec.template.spec.containers[].image' "$DEPLOYMENT_YAML" | uniq)
+  echo "Images found in $DEPLOYMENT_YAML:"
+  echo "$IMAGES" | awk '{print "- "$0""}'
+  echo "$IMAGES" | awk '{print "  - source: \""$0"\""}' >> "$OUTPUT_FILE"
+fi
+
+echo "Images have been written to $OUTPUT_FILE"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Continuation of #1094.
Add a script to update external-images.yaml when the workflow updates SAP BTP service operator chart and resources.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #1079 