### PR TITLE
Fix script to read images from chart values.yaml

### DIFF
--- a/scripts/update/update-external-images.sh
+++ b/scripts/update/update-external-images.sh
@@ -1,18 +1,27 @@
 #!/usr/bin/env bash
 
+# This script extracts container images from module-chart/chart/values.yaml by
+# concatenating manager.image.repository and manager.image.tag for the first image,
+# and manager.rbacProxy.image.repository and manager.rbacProxy.image.tag for the second image.
+# The images are written to external-images.yaml in the format:
+# images:
+#   - source: "<IMAGE>"
+
 set -euo pipefail
 
 OUTPUT_FILE="external-images.yaml"
+VALUES_YAML="./module-chart/chart/values.yaml"
 
 echo "images:" > "$OUTPUT_FILE"
 
-# Extract images from module-resources/apply/deployment.yml if the file exists
-DEPLOYMENT_YAML="./module-resources/apply/deployment.yml"
-if [ -f "$DEPLOYMENT_YAML" ]; then
-  IMAGES=$(yq '.spec.template.spec.containers[].image' "$DEPLOYMENT_YAML" | uniq)
-  echo "Images found in $DEPLOYMENT_YAML:"
-  echo "$IMAGES" | awk '{print "- "$0""}'
-  echo "$IMAGES" | awk '{print "  - source: \""$0"\""}' >> "$OUTPUT_FILE"
+if [ -f "$VALUES_YAML" ]; then
+  MANAGER_IMAGE=$(yq -r '.manager.image.repository + ":" + .manager.image.tag' "$VALUES_YAML")
+  RBAC_PROXY_IMAGE=$(yq -r '.manager.rbacProxy.image.repository + ":" + .manager.rbacProxy.image.tag' "$VALUES_YAML")
+  echo "Images found in $VALUES_YAML:"
+  echo "- $MANAGER_IMAGE"
+  echo "- $RBAC_PROXY_IMAGE"
+  echo "  - source: \"$MANAGER_IMAGE\"" >> "$OUTPUT_FILE"
+  echo "  - source: \"$RBAC_PROXY_IMAGE\"" >> "$OUTPUT_FILE"
 fi
 
 echo "Images have been written to $OUTPUT_FILE"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

fixes the script to read images from the upstream chart [values.yaml](https://github.com/kyma-project/btp-manager/blob/e1731fa0696ed5cc592cdc683a777d60420da2e9/module-chart/chart/values.yaml) instead of rendered [deployment.yml](https://github.com/kyma-project/btp-manager/blob/e1731fa0696ed5cc592cdc683a777d60420da2e9/module-resources/apply/deployment.yml). The fix ensures appropriate images are set in the [external-images.yaml](https://github.com/kyma-project/btp-manager/blob/e1731fa0696ed5cc592cdc683a777d60420da2e9/external-images.yaml)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #1079 #1095 