### PR TITLE
Remove build-engine: buildx

### DIFF
--- a/.github/workflows/create-release-with-version-submit.yaml
+++ b/.github/workflows/create-release-with-version-submit.yaml
@@ -83,7 +83,6 @@ jobs:
       dockerfile: Dockerfile
       context: .
       tags: ${{ inputs.name }}
-      build-engine: buildx
 
   run-unit-tests:
     name: Unit tests

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -83,7 +83,6 @@ jobs:
       dockerfile: Dockerfile
       context: .
       tags: ${{ inputs.name }}
-      build-engine: buildx
 
   run-unit-tests:
     name: Unit tests

--- a/.github/workflows/pull-btp-manager-build.yaml
+++ b/.github/workflows/pull-btp-manager-build.yaml
@@ -18,4 +18,3 @@ jobs:
          name: btp-manager
          dockerfile: Dockerfile
          context: .
-         build-engine: buildx


### PR DESCRIPTION
This PR removes the deprecated `build-engine: buildx` entry from workflows.