### PR TITLE
Downgrade SAP BTP service operator to v0.7.6 for auto-update workflow tests

### DIFF
--- a/external-images.yaml
+++ b/external-images.yaml
@@ -1,3 +1,3 @@
 images:
-  - source: "quay.io/brancz/kube-rbac-proxy:v0.19.1"
-  - source: "ghcr.io/sap/sap-btp-service-operator/controller:v0.7.9"
+  - source: "quay.io/brancz/kube-rbac-proxy:v0.15.0"
+  - source: "ghcr.io/sap/sap-btp-service-operator/controller:v0.7.6"

--- a/module-chart/chart/Chart.yaml
+++ b/module-chart/chart/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: v0.7.9
+appVersion: v0.7.6
 description: A Helm chart for SAP BTP Operator for Kubernetes
 name: sap-btp-operator
-version: v0.7.9
+version: v0.7.6

--- a/module-chart/chart/values.yaml
+++ b/module-chart/chart/values.yaml
@@ -16,7 +16,7 @@ manager:
   management_namespace:
   image:
     repository: ghcr.io/sap/sap-btp-service-operator/controller
-    tag: v0.7.9
+    tag: v0.7.6
     sha: ""
   secret:
     b64encoded: false
@@ -34,7 +34,7 @@ manager:
     image:
       repository: quay.io/brancz/kube-rbac-proxy
       sha: ""
-      tag: v0.19.1
+      tag: v0.15.0
     memory_limit: ""
     cpu_limit: ""
     req_memory_limit: ""

--- a/module-resources/apply/deployment.yml
+++ b/module-resources/apply/deployment.yml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: bd31875df9c0d8e2e39cf78f02fdd06e019f20a45b5e2e4a85aff86744a9e8eb
+        checksum/config: 9b7aa60ea0cc7f425a0f0f58b0cf8863d3c4ec221ca8bb97cfb693022b864e77
         sidecar.istio.io/inject: "false"
       labels:
         control-plane: controller-manager
@@ -33,7 +33,7 @@ spec:
             - --upstream=http://127.0.0.1:8080/
             - --logtostderr=true
             - --v=10
-          image: "europe-docker.pkg.dev/kyma-project/prod/external/quay.io/brancz/kube-rbac-proxy:v0.19.1"
+          image: "quay.io/brancz/kube-rbac-proxy:v0.15.0"
           name: kube-rbac-proxy
           resources:
             limits:
@@ -52,7 +52,7 @@ spec:
             - secretRef:
                 name: sap-btp-operator-clusterid
                 optional: true
-          image: "europe-docker.pkg.dev/kyma-project/prod/external/ghcr.io/sap/sap-btp-service-operator/controller:v0.7.9"
+          image: "ghcr.io/sap/sap-btp-service-operator/controller:v0.7.6"
           imagePullPolicy: IfNotPresent
           name: manager
           ports:

--- a/module-resources/excluded/to-exclude.yml
+++ b/module-resources/excluded/to-exclude.yml
@@ -6,7 +6,7 @@ metadata:
   name: pre-delete-job
   namespace: kyma-system
   labels:
-    release: v0.7.9
+    release: v0.7.6
   annotations:
     "helm.sh/hook": pre-delete
     "helm.sh/hook-weight": "0"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

Downgrade SAP BTP service operator to v0.7.6 to test auto-update workflow.
Ref: https://github.com/SAP/sap-btp-service-operator/releases/tag/v0.7.6

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
