### PR TITLE
Bump go to 1.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/btp-manager
 
-go 1.24.5
+go 1.25.0
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- bump go to [1.25.0](https://go.dev/doc/go1.25)
