### PR TITLE
Disable Istio sidecar for btp-manager

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -14,8 +14,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
-        traffic.sidecar.istio.io/includeInboundPorts: '*'
-        traffic.sidecar.istio.io/excludeInboundPorts: "8080"
+        sidecar.istio.io/inject: "false"
       labels:
         app.kubernetes.io/component: btp-manager.kyma-project.io
     spec:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- remove Istio traffic sidecar annotations and disable sidecar injection by adding `sidecar.istio.io/inject: "false"`.

**Related issue(s)**
See also #1204
