### PR TITLE
Enable dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,9 @@
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
   - package-ecosystem: "gomod"
     directory: "/"
     labels:
-      - "skip-review"
+      - "go"
       - "area/dependency"
       - "kind/enhancement"
     schedule:
@@ -16,10 +14,22 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     labels:
+      - "docker"
       - "area/dependency"
       - "kind/enhancement"
     schedule:
       interval: "daily"
     commit-message:
       prefix: "docker"
+      include: "scope"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels:
+      - "github-actions"
+      - "area/dependency"
+      - "kind/enhancement"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "github-actions"
       include: "scope"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- enable dependabot for GitHub Actions,
- remove a deprecated documentation link,
- remove the `skip-review` label (previously used by Tide to mark trusted PRs for auto-merge), as Tide is no longer in use.