### PR TITLE
Set GODEBUG=fips140=only,tlsmlkem=0 in SAP BTP service operator

### DIFF
--- a/module-chart/overrides.yaml
+++ b/module-chart/overrides.yaml
@@ -28,4 +28,4 @@ manager:
     runAsNonRoot: true
     seccompProfile:
       type: RuntimeDefault
-  fips: "fips140=only"
+  fips: "fips140=only,tlsmlkem=0"

--- a/module-resources/apply/configmap.yml
+++ b/module-resources/apply/configmap.yml
@@ -8,7 +8,7 @@ metadata:
   labels:
     "services.cloud.sap.com/managed-by-sap-btp-operator": "true"
 data:
-  CLUSTER_ID: 2e81f701-6e6c-44b8-b2a2-c1694a589d65
+  CLUSTER_ID: bce5397a-e967-4cd7-8151-dc2d7a264537
   MANAGEMENT_NAMESPACE: kyma-system
   RELEASE_NAMESPACE: kyma-system
   ENABLE_LIMITED_CACHE: "false"

--- a/module-resources/apply/deployment.yml
+++ b/module-resources/apply/deployment.yml
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 76617be24abbc53f78030979a78ffef6bfd32dfb6f90cd7b2e66849163c4202c
+        checksum/config: 8f43ca2ed6e599a2f5f667ca6cdcb32dc0bd981f1540c5763ae392fde28d51c6
         sidecar.istio.io/inject: "false"
       labels:
         control-plane: controller-manager
@@ -65,7 +65,7 @@ spec:
             - name: APP_VERSION
               value: "v0.9.8"
             - name: GODEBUG
-              value: "fips140=only"
+              value: "fips140=only,tlsmlkem=0"
           envFrom:
             - configMapRef:
                 name: sap-btp-operator-config


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

override the upstream chart value for FIPS 140-3 mode to fips140=only.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
