### PR TITLE
Exclude kube rbac proxy image when generating external images

### DIFF
--- a/config/crd/bases/operator.kyma-project.io_btpoperators.yaml
+++ b/config/crd/bases/operator.kyma-project.io_btpoperators.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: btpoperators.operator.kyma-project.io
 spec:
   group: operator.kyma-project.io

--- a/config/crd/bases/operator.kyma-project.io_btpoperators.yaml
+++ b/config/crd/bases/operator.kyma-project.io_btpoperators.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.19.0
+    controller-gen.kubebuilder.io/version: v0.16.1
   name: btpoperators.operator.kyma-project.io
 spec:
   group: operator.kyma-project.io

--- a/external-images.yaml
+++ b/external-images.yaml
@@ -1,3 +1,2 @@
 images:
   - source: "ghcr.io/sap/sap-btp-service-operator/controller:v0.10.5"
-  - source: "quay.io/brancz/kube-rbac-proxy:v0.20.2"

--- a/scripts/update/update-external-images.sh
+++ b/scripts/update/update-external-images.sh
@@ -14,7 +14,7 @@ OUTPUT_FILE="external-images.yaml"
 VALUES_YAML="./module-chart/chart/values.yaml"
 
 # List of images to exclude from the output
-EXCLUDE_IMAGES=("bitnami/kubectl" "bitnamisecure/kubectl")
+EXCLUDE_IMAGES=("bitnami/kubectl" "bitnamisecure/kubectl" "brancz/kube-rbac-proxy")
 
 echo "images:" > "$OUTPUT_FILE"
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- Exclude kube rbac proxy image when generating external images

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
