### PR TITLE
Add CLAUDE.md and Claude Code Skills

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: commit
+description: Drafts and creates a git commit following BTP Manager commit message conventions.
+---
+
+# commit
+
+Create a git commit for staged or unstaged changes in the BTP Manager repository.
+
+## Usage
+
+```
+/commit [optional hint about what changed]
+```
+
+**Examples:**
+- `/commit`
+- `/commit Add network policy reconciliation`
+- `/commit Fix deprovisioning race condition`
+
+---
+
+## What to do
+
+1. **Check current state** — run `git status` and `git diff` (staged + unstaged) to understand what changed. If nothing has changed, say so and stop.
+
+2. **Stage changes** — if files are unstaged and the user didn't already stage them, ask which files to include before staging. Never run `git add -A` or `git add .` without asking — that can accidentally commit test data, `.env` files, or generated files.
+
+3. **Draft the commit message** using the conventions below.
+
+4. **Show the message** to the user for approval before committing. Ask: "Shall I commit with this message?"
+
+5. **Commit** once confirmed.
+
+6. **Ask about pushing** — after a successful commit, ask: "Would you like to push the changes to `<current-branch>`?" If yes, run `git push -u origin HEAD`. If no, ask which branch to push to and run `git push -u origin HEAD:<target-branch>`.
+
+---
+
+## Commit message conventions
+
+```
+<Short summary>
+
+[optional body — only if the why isn't obvious from the diff]
+```
+
+**Short summary:** imperative mood, title case, no trailing period, ≤72 chars.
+
+**Examples:**
+```
+Add network policy reconciliation
+Fix deprovisioning race condition
+Handle missing cluster ID gracefully
+Add unit tests for BtpOperator provisioning flow
+Update CLAUDE.md with state machine documentation
+Bump golang to 1.26.3-alpine3.22
+```
+
+---
+
+## Rules
+
+- Never commit files that look like secrets (`.env`, `credentials*.json`, `*_key.pem`, etc.) — warn the user if such files are staged.
+- Never use `--no-verify`.
+- Never amend published commits. Create a new commit instead.
+- If a pre-commit hook fails, fix the issue and create a **new** commit — do not `--amend`.

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: create-pr
+description: Creates a pull request from a fork branch to kyma-project/btp-manager main.
+---
+
+# create-pr
+
+Create a pull request from the current fork branch to the upstream `kyma-project/btp-manager` repository.
+
+## Usage
+
+```
+/create-pr [optional hint about what changed]
+```
+
+**Examples:**
+- `/create-pr`
+- `/create-pr Add network policy reconciliation`
+
+---
+
+## What to do
+
+### 1. Confirm intent
+
+Ask the user:
+
+> You are about to open a PR from branch `<current-branch>` to `kyma-project/btp-manager:main`. Continue?
+
+Stop if they say no.
+
+### 2. Gather changes
+
+The local `main` branch may be stale. Always diff against the upstream remote to get only the changes this branch uniquely introduces:
+
+```bash
+git fetch upstream main
+git diff upstream/main...HEAD
+```
+
+The three-dot syntax (`...`) diffs from the merge-base, so only commits unique to this branch are shown — not unrelated upstream commits that the local branch happens to include.
+
+If no `upstream` remote exists, fall back to `origin/main`:
+
+```bash
+git fetch origin main
+git diff origin/main...HEAD
+```
+
+Read the diff carefully and summarize the most important changes as bullet points. Base the summary entirely on what the code actually changed.
+
+### 3. Draft the PR body
+
+Read `.github/pull-request-template.md` and use it as the body structure. Fill in the **Description** bullets from the diff.
+
+Rules:
+- Never include `Closes #<issue>`, `Fixes #<issue>`, or any issue-closing keywords unless the user explicitly asks.
+- Keep bullets factual and concise — derived from the actual diff, not paraphrased vaguely.
+- Start each bullet with an infinitive verb (e.g. "Add...", "Rename...", "Update...", "Remove...", "Fix...").
+
+### 4. Ask about related issues
+
+Ask the user:
+
+> Would you like to reference any related issues? (e.g. `See also #123`) If yes, provide the issue number(s).
+
+If yes, place the reference on the line immediately after `**Related issue(s)**` with no blank line between them. Use `See also #<n>` unless the user explicitly asks for a closing keyword.
+
+### 5. Ask about the changelog label
+
+Ask the user which changelog label to apply:
+
+> Which changelog label should this PR have?
+> - `kind/feature` — New feature
+> - `kind/enhancement` — Enhancement to an existing feature
+> - `kind/bug` — Bug fix
+
+Apply exactly one of these labels. No other labels unless the user explicitly requests them.
+
+### 6. Draft the PR title
+
+Derive the title from the diff:
+
+- Imperative mood, title case, no trailing period, ≤72 chars.
+- No `feat:`, `fix:`, `chore:` prefixes.
+- Examples: `Add Network Policy Reconciliation`, `Fix Deprovisioning Race Condition`
+
+Show the user the full title + body and ask: "Shall I open the PR with this title and description?"
+
+### 7. Create the PR
+
+To determine `<fork-owner>` and the PR creator's GitHub username, run:
+
+```bash
+git remote get-url origin
+gh api user --jq .login
+```
+
+Extract `<fork-owner>` from the origin URL. The PR creator's GitHub username comes from `gh api user`.
+
+```bash
+gh pr create \
+  --repo kyma-project/btp-manager \
+  --base main \
+  --head <fork-owner>:<current-branch> \
+  --title "<title>" \
+  --label "<chosen-label>" \
+  --assignee "<github-username>" \
+  --body "$(cat <<'EOF'
+<body>
+EOF
+)"
+```
+
+Return the PR URL to the user once created.
+
+---
+
+## Rules
+
+- Always target `--base main` on `kyma-project/btp-manager` — never an upstream feature branch.
+- Never add issue-closing keywords (`Closes`, `Fixes`, `Resolves`) unless the user explicitly asks.
+- Never use `--no-verify` or bypass any git hooks.
+- Apply exactly one `kind/*` label per PR.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: review-pr
+description: Reviews a PR against BTP Manager conventions (reconciler patterns, conditions API, state machine, test structure, etc.).
+---
+
+# review-pr
+
+Review a pull request with BTP Manager-specific context in mind.
+
+## Usage
+
+```
+/review-pr <PR number or URL>
+```
+
+**Examples:**
+- `/review-pr 1234`
+- `/review-pr https://github.com/kyma-project/btp-manager/pull/1234`
+
+---
+
+## What to do
+
+Fetch the PR diff and review it through the lens of BTP Manager conventions. Structure your review as:
+
+### Summary
+
+One paragraph: what the PR does and whether the approach makes sense.
+
+### Issues (if any)
+
+List only real problems — not style nits unless they violate a hard rule. For each issue:
+- **File:line** — description of the problem
+- Severity: `blocking` | `suggestion`
+
+### BTP Manager checklist
+
+Evaluate every item below. **Only print items that have a note or failure** — skip items that pass cleanly. If everything passes, write a single line: `BTP Manager checklist: all clear`.
+
+Use this format for printed items only:
+- ⚠️ **[category]** — description of the note
+- ❌ **[category]** — description of the failure
+
+**Reconciler / state machine (if controllers/ is touched):**
+- New state handlers follow the existing pattern: dedicated `Handle*State` method dispatched from `Reconcile()`
+- Status updates go through `UpdateBtpOperatorStatus()` — not direct client patches
+- Finalizer (`operator.kyma-project.io/btp-manager`) is only added/removed in the correct lifecycle phases
+- Requeue intervals use the configured values (`processingStateRequeueInterval`, `readyStateRequeueInterval`) — no hardcoded `time.Duration` literals
+
+**Conditions (if internal/conditions/ or status conditions are touched):**
+- New condition reasons are defined as constants in `internal/conditions/conditions.go`
+- Documentation comment for each new reason is present — `make test-docs` would pass
+- Reasons map to the correct state (Ready/Processing/Error/Warning/Deleting)
+
+**Resource management (if module-resources/ or manifest handling is touched):**
+- Resources to apply go in `module-resources/apply/`, resources to delete go in `module-resources/delete/`
+- No direct `client.Apply` / `client.Delete` calls that bypass the manifest reconciliation path
+
+**Tests:**
+- Tests use Ginkgo v2 + Gomega (not `testify`)
+- New controller tests are placed in the appropriately named file (`btpoperator_controller_<concern>_test.go`)
+- Shared setup uses `controllers/suite_test.go` — no duplicate envtest bootstrapping
+- `make test` would pass (envtest env vars sourced from `scripts/testing/set-env-vars.sh`)
+
+**Code generation (if api/v1alpha1/ or controller markers are touched):**
+- `make generate` and `make manifests` were run — generated files (`zz_generated.deepcopy.go`, CRD YAMLs) are up to date
+
+**Documentation:**
+- `CLAUDE.md` updated if project structure, conventions, or build/test workflow changed
+
+**General:**
+- No speculative abstractions or features beyond the PR scope
+- Imports cleaned up (no unused imports left from changes)
+- No backwards-compatibility shims for removed code
+
+### Verdict
+
+`Approve` / `Request changes` / `Comment` — with one sentence explaining why.
+
+---
+
+## Tone
+
+- Be direct and specific. Point to file and line numbers.
+- Don't praise code that is merely correct — save positive comments for non-obvious good decisions.
+- Don't suggest improvements outside the PR scope.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,194 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```gig
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+## 5. Project-Specific Guidelines
+
+BTP Manager is a Kubernetes operator (built with Kubebuilder/controller-runtime) that manages the SAP BTP service operator lifecycle within Kyma clusters. It reconciles a `BtpOperator` CRD in the `kyma-system` namespace and orchestrates Helm chart deployment, secrets validation, certificate management, and resource cleanup.
+
+### Common Commands
+
+#### Build & Generate
+```bash
+make build          # Build the manager binary to bin/manager
+make run            # Run controller locally (requires KUBECONFIG)
+make generate       # Regenerate DeepCopy methods (after API changes)
+make manifests      # Regenerate CRDs, RBAC, webhooks (after API/marker changes)
+```
+
+#### Testing
+```bash
+make test           # Run all tests using envtest (no cluster needed)
+make test-docs      # Validate condition reasons match documentation
+```
+
+To run a single test or subset using Ginkgo labels:
+```bash
+. ./scripts/testing/set-env-vars.sh
+GINKGO_LABEL_FILTER="<label>" ./bin/ginkgo controllers
+```
+
+To run with verbose output or increased timeouts (useful when debugging):
+```bash
+USE_EXISTING_CLUSTER=true SUITE_TIMEOUT=180s SINGLE_TEST_TIMEOUT=60s make test
+```
+
+#### Code Quality
+```bash
+make fmt            # go fmt ./...
+make vet            # go vet ./...
+make go-lint        # Run golangci-lint (config: .golangci.yml)
+make fix            # go mod tidy + golangci-lint --fix
+```
+
+#### Deployment
+```bash
+make install        # Install CRDs into the cluster
+make deploy         # Deploy controller to the cluster
+make docker-build   # Build Docker image (runs tests first)
+make module-image   # Build and push module image
+```
+
+### Architecture
+
+#### Core Components
+
+**Entry point:** `main.go` initializes the controller-runtime manager with leader election, registers reconcilers, sets up health/metrics probes, and starts config watching.
+
+**Primary reconciler:** `controllers/btpoperator_controller.go` (~2600 lines) — contains the main reconciliation logic. It owns the BtpOperator state machine and drives all provisioning, updating, and deprovisioning work.
+
+**Supporting reconcilers:**
+- `controllers/serviceinstance_controller.go` — watches ServiceInstance/ServiceBinding resources to trigger BtpOperator status updates when instances or bindings change.
+- `controllers/instance_binding_controller_manager.go` — controls lifecycle of the SISB (ServiceInstance/ServiceBinding) cleanup controller, disabling it during deletion and enabling it after provisioning.
+- `controllers/config/handler.go` — watches a ConfigMap for dynamic config changes.
+
+#### State Machine
+
+The `BtpOperator` CR flows through these states:
+
+```
+[Empty] → Processing → Ready
+                ↓
+         Warning / Error  (transient or permanent failures)
+                ↓
+            Deleting → [finalizer removed, CR gone]
+```
+
+Each state has a dedicated handler method (`HandleInitialState`, `HandleProcessingState`, `HandleReadyState`, `HandleWarningState`, `HandleErrorState`, `HandleDeletingState`) dispatched from `Reconcile()`.
+
+#### Provisioning Flow (HandleProcessingState)
+
+1. Fetch and validate the `sap-btp-manager` secret (must contain `clientid`, `clientsecret`, `sm_url`, `tokenurl`, `cluster_id`).
+2. Check credentials namespace and cluster ID consistency across secrets/configmaps.
+3. Delete outdated resources from `module-resources/delete/`.
+4. Apply resources from `module-resources/apply/`.
+5. Enable the SISB controller.
+6. Transition to Ready.
+
+#### Deletion Flow (HandleDeletingState)
+
+1. Disable SISB controller.
+2. Attempt hard delete of operator resources (with graceful timeout for active instances/bindings).
+3. Fall back to soft delete if hard delete fails.
+4. Remove the finalizer (`operator.kyma-project.io/btp-manager`).
+
+#### Key Directories
+
+| Directory | Purpose |
+|---|---|
+| `api/v1alpha1/` | BtpOperator CRD type definitions |
+| `controllers/` | All reconcilers and config handler |
+| `internal/` | Utilities: `certs/`, `conditions/`, `manifest/`, `metrics/`, `ymlutils/`, `gvksutils/` |
+| `module-chart/` | Helm chart for the SAP BTP operator that BTP Manager deploys |
+| `module-resources/apply/` | K8s manifests applied during provisioning |
+| `module-resources/delete/` | K8s manifests deleted during provisioning (outdated resources) |
+| `manager-resources/` | BTP Manager-specific resources (e.g. network policies) |
+| `config/` | Kustomize manifests for deploying BTP Manager itself |
+| `cmd/autodoc/` | Tool that validates condition reason constants match documentation |
+| `scripts/testing/` | Test environment setup (`set-env-vars.sh`, envtest, e2e scripts) |
+
+#### Conditions System
+
+Conditions track reconciliation progress via the Kubernetes conditions API. Reason constants are defined in `internal/conditions/conditions.go` and are validated against inline documentation by `make test-docs`. When adding or changing condition reasons, update the documentation comments in that file.
+
+#### Testing Structure
+
+Tests are organized by concern alongside the controllers they test:
+- `controllers/btpoperator_controller_provisioning_test.go`
+- `controllers/btpoperator_controller_deprovisioning_test.go`
+- `controllers/btpoperator_controller_updating_test.go`
+- `controllers/btpoperator_controller_certificates_test.go`
+- `controllers/btpoperator_controller_network_policies_test.go`
+- `controllers/btpoperator_controller_configuration_test.go`
+- `controllers/btpoperator_controller_secret_customization_test.go`
+
+Shared test setup (envtest bootstrapping, scheme registration, client creation) lives in `controllers/suite_test.go`. Test helpers live in `controllers/utils_test.go`.
+
+Tests use Ginkgo v2 (BDD-style) with Gomega assertions against a local envtest Kubernetes environment (k8s 1.25.0). Key test environment variables are sourced from `scripts/testing/set-env-vars.sh`.
+
+### Claude Skills
+
+Skills for Claude Code are stored in `.claude/skills/`. Each skill is a directory containing a `SKILL.md` file.
+
+Available skills:
+- **`commit`** — Drafts and creates a git commit following BTP Manager commit message conventions.
+- **`create-pr`** — Creates a pull request from a fork branch to `kyma-project/btp-manager:main`.
+- **`review-pr`** — Reviews a PR against BTP Manager conventions.
+
+**Maintenance:** Any PR that changes project structure, adds a new pattern, or modifies the build/test workflow must update `CLAUDE.md` and the relevant skills in the same PR. This keeps Claude Code's assistance accurate as the project evolves.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Transform tasks into verifiable goals:
 - "Refactor X" → "Ensure tests pass before and after"
 
 For multi-step tasks, state a brief plan:
-```gig
+```text
 1. [Step] → verify: [check]
 2. [Step] → verify: [check]
 3. [Step] → verify: [check]

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,3 +4,7 @@
 # Owners of all .md files and all files within the /docs/ directory
 *.md @kyma-project/technical-writers
 /docs/ @kyma-project/technical-writers
+
+# CLAUDE.md and Claude Code skills are also reviewed by gophers
+CLAUDE.md @kyma-project/technical-writers @kyma-project/gopher
+/.claude/skills/ @kyma-project/technical-writers @kyma-project/gopher


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `CLAUDE.md` with project guidance for Claude Code (architecture overview, common commands, state machine, testing structure, and coding conventions)
- Add `.claude/skills/commit/SKILL.md` — skill for drafting and creating git commits following BTP Manager conventions
- Add `.claude/skills/create-pr/SKILL.md` — skill for creating pull requests from a fork branch to `kyma-project/btp-manager:main`
- Add `.claude/skills/review-pr/SKILL.md` — skill for reviewing PRs against BTP Manager-specific conventions

**Related issue(s)**
See also #1435