### PR TITLE
Bump Golang to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/btp-manager
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Bump Go version from 1.26.3 to 1.26.4 in `go.mod`

**Related issue(s)**