### PR TITLE
Fix controller compile errors after ErrorWithReason and CertificateSignError moves

### DIFF
--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kyma-project/btp-manager/internal/conditions"
 	"github.com/kyma-project/btp-manager/internal/manifest"
 	"github.com/kyma-project/btp-manager/internal/metrics"
+	"github.com/kyma-project/btp-manager/internal/webhook/certificate"
 	"github.com/kyma-project/btp-manager/internal/ymlutils"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -337,15 +338,15 @@ func (r *BtpOperatorReconciler) HandleProcessingState(ctx context.Context, cr *v
 	r.setCredentialsNamespacesAndClusterId(requiredSecret)
 
 	if errWithReason := r.checkDefaultCredentialsSecretNamespace(ctx, logger, requiredSecret); errWithReason != nil {
-		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.reason, errWithReason.message)
+		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.Reason, errWithReason.Message)
 	}
 
 	if errWithReason := r.checkSapBtpServiceOperatorClusterIdConfigMap(ctx, logger, requiredSecret); errWithReason != nil {
-		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.reason, errWithReason.message)
+		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.Reason, errWithReason.Message)
 	}
 
 	if errWithReason := r.checkSapBtpServiceOperatorClusterIdSecret(ctx, logger, requiredSecret); errWithReason != nil {
-		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.reason, errWithReason.message)
+		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.Reason, errWithReason.Message)
 	}
 
 	if err := r.deleteOutdatedResources(ctx); err != nil {
@@ -369,7 +370,7 @@ func (r *BtpOperatorReconciler) HandleProcessingState(ctx context.Context, cr *v
 
 func (r *BtpOperatorReconciler) handleMissingSecret(ctx context.Context, cr *v1alpha1.BtpOperator, logger logr.Logger, errWithReason *ErrorWithReason) error {
 	logger.Info("secret verification failed: " + errWithReason.Error())
-	return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateWarning, errWithReason.reason, errWithReason.message)
+	return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateWarning, errWithReason.Reason, errWithReason.Message)
 }
 
 func (r *BtpOperatorReconciler) getAndVerifyRequiredSecret(ctx context.Context) (*corev1.Secret, *ErrorWithReason) {
@@ -1765,7 +1766,7 @@ func (r *BtpOperatorReconciler) prepareAdmissionWebhooks(ctx context.Context, re
 	}
 	if err := r.validateWebhookCert(webhookCertSecret, caBundle); err != nil {
 		logger.Info(fmt.Sprintf("webhook cert is not valid: %s", err))
-		var certSignErr CertificateSignError
+		var certSignErr certificate.CertificateSignError
 		if errors.As(err, &certSignErr) {
 			return r.regenerateCertificates(ctx, resourcesToApply)
 		}
@@ -2317,8 +2318,11 @@ func (r *BtpOperatorReconciler) validateWebhookCert(webhookCertSecret *corev1.Se
 
 func (r *BtpOperatorReconciler) verifyCASign(caCert []byte, signedCert []byte) error {
 	ok, err := certs.VerifyIfLeafIsSignedByGivenCA(caCert, signedCert)
-	if err != nil || !ok {
-		return NewCertificateSignError(err.Error())
+	if err != nil {
+		return certificate.NewCertificateSignError(err.Error())
+	}
+	if !ok {
+		return certificate.NewCertificateSignError("certificate is not signed by the provided CA")
 	}
 	return nil
 }

--- a/internal/k8s/networkpolicy/manager.go
+++ b/internal/k8s/networkpolicy/manager.go
@@ -1,0 +1,120 @@
+package networkpolicy
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/kyma-project/btp-manager/controllers/config"
+	"github.com/kyma-project/btp-manager/internal/manifest"
+	networkingv1 "k8s.io/api/networking/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	operatorName = "btp-manager"
+	moduleName   = "btp-operator"
+
+	managedByLabelKey         = "app.kubernetes.io/managed-by"
+	kymaProjectModuleLabelKey = "kyma-project.io/module"
+
+	oldWebhookNetworkPolicyName = "kyma-project.io--btp-operator-allow-to-webhook"
+)
+
+var managedByLabelFilter = client.MatchingLabels{managedByLabelKey: operatorName}
+
+type NetworkPolicyManager interface {
+	LoadNetworkPolicies() ([]*unstructured.Unstructured, error)
+	CleanupNetworkPolicies(ctx context.Context) error
+	DeleteOldWebhookNetworkPolicy(ctx context.Context) error
+	IsManaged(obj *networkingv1.NetworkPolicy) bool
+}
+
+type Manager struct {
+	client          client.Client
+	manifestHandler *manifest.Handler
+}
+
+func NewManager(k8sClient client.Client, manifestHandler *manifest.Handler) *Manager {
+	return &Manager{
+		client:          k8sClient,
+		manifestHandler: manifestHandler,
+	}
+}
+
+var _ NetworkPolicyManager = (*Manager)(nil)
+
+func (m *Manager) getNetworkPoliciesPath() string {
+	return fmt.Sprintf("%s%cnetwork-policies", config.ManagerResourcesPath, os.PathSeparator)
+}
+
+func (m *Manager) LoadNetworkPolicies() ([]*unstructured.Unstructured, error) {
+	objects, err := m.manifestHandler.CollectObjectsFromDir(m.getNetworkPoliciesPath())
+	if err != nil {
+		return nil, err
+	}
+	return m.manifestHandler.ObjectsToUnstructured(objects)
+}
+
+func (m *Manager) CleanupNetworkPolicies(ctx context.Context) error {
+	logger := log.FromContext(ctx)
+	logger.Info("deleting all managed network policies")
+	if err := m.client.DeleteAllOf(ctx, &networkingv1.NetworkPolicy{}, client.InNamespace(config.ChartNamespace), managedByLabelFilter); err != nil {
+		if !(k8serrors.IsNotFound(err) || k8serrors.IsMethodNotSupported(err) || meta.IsNoMatchError(err)) {
+			return fmt.Errorf("failed to delete network policies: %w", err)
+		}
+	}
+	return nil
+}
+
+func (m *Manager) DeleteOldWebhookNetworkPolicy(ctx context.Context) error {
+	logger := log.FromContext(ctx)
+	oldPolicy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      oldWebhookNetworkPolicyName,
+			Namespace: config.ChartNamespace,
+		},
+	}
+	if err := m.client.Delete(ctx, oldPolicy); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			logger.Error(err, "failed to delete old webhook network policy during migration", "policyName", oldWebhookNetworkPolicyName)
+			return fmt.Errorf("failed to delete old webhook network policy: %w", err)
+		}
+		logger.Info("old webhook network policy not found, skipping deletion", "policyName", oldWebhookNetworkPolicyName)
+	}
+	return nil
+}
+
+func (m *Manager) IsManaged(obj *networkingv1.NetworkPolicy) bool {
+	labels := obj.GetLabels()
+	if labels != nil {
+		if labels[managedByLabelKey] == operatorName && labels[kymaProjectModuleLabelKey] == moduleName {
+			return true
+		}
+	}
+	nameSet, err := m.getNetworkPolicyNamesFromManifests()
+	if err != nil {
+		return false
+	}
+	_, ok := nameSet[obj.GetName()]
+	return ok
+}
+
+func (m *Manager) getNetworkPolicyNamesFromManifests() (map[string]struct{}, error) {
+	names := make(map[string]struct{})
+	us, err := m.LoadNetworkPolicies()
+	if err != nil {
+		return names, err
+	}
+	for _, u := range us {
+		if n := u.GetName(); n != "" {
+			names[n] = struct{}{}
+		}
+	}
+	return names, nil
+}

--- a/internal/k8s/networkpolicy/manager_test.go
+++ b/internal/k8s/networkpolicy/manager_test.go
@@ -1,0 +1,162 @@
+package networkpolicy_test
+
+import (
+	"context"
+
+	"github.com/kyma-project/btp-manager/controllers/config"
+	"github.com/kyma-project/btp-manager/internal/k8s/networkpolicy"
+	"github.com/kyma-project/btp-manager/internal/manifest"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const testManagerResourcesPath = "./testdata"
+
+var _ = Describe("Network Policy Manager", func() {
+	var (
+		mgr *networkpolicy.Manager
+		ctx context.Context
+	)
+
+	BeforeEach(func() {
+		config.ManagerResourcesPath = testManagerResourcesPath
+
+		fakeClient = newFakeClient()
+		mgr = networkpolicy.NewManager(fakeClient, &manifest.Handler{Scheme: scheme})
+		ctx = context.Background()
+	})
+
+	Describe("LoadNetworkPolicies", func() {
+		It("should return unstructured network policies from the manifests directory", func() {
+			policies, err := mgr.LoadNetworkPolicies()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(policies).To(HaveLen(2))
+
+			names := extractNames(policies)
+			Expect(names).To(ContainElements(policyName1, policyName2))
+		})
+
+		It("should return an error when the manifests directory does not exist", func() {
+			config.ManagerResourcesPath = "./non-existent"
+
+			_, err := mgr.LoadNetworkPolicies()
+
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("IsManaged", func() {
+		It("should return true for a policy with managed-by and module labels", func() {
+			policy := managedNetworkPolicy("any-name")
+
+			Expect(mgr.IsManaged(policy)).To(BeTrue())
+		})
+
+		It("should return true for a policy whose name appears in the manifests, even without labels", func() {
+			policy := unmanagedNetworkPolicy(policyName1)
+
+			Expect(mgr.IsManaged(policy)).To(BeTrue())
+		})
+
+		It("should return false for a policy without managed-by labels and whose name is not in manifests", func() {
+			policy := unmanagedNetworkPolicy("some-other-policy")
+
+			Expect(mgr.IsManaged(policy)).To(BeFalse())
+		})
+
+		It("should return false for a policy with only the managed-by label but not the module label", func() {
+			policy := unmanagedNetworkPolicy("partial-label-policy")
+			policy.Labels = map[string]string{managedByLabelKey: operatorName}
+
+			Expect(mgr.IsManaged(policy)).To(BeFalse())
+		})
+
+		It("should return false for a policy with only the module label but not the managed-by label", func() {
+			policy := unmanagedNetworkPolicy("partial-label-policy")
+			policy.Labels = map[string]string{kymaProjectModuleLabelKey: moduleName}
+
+			Expect(mgr.IsManaged(policy)).To(BeFalse())
+		})
+	})
+
+	Describe("CleanupNetworkPolicies", func() {
+		It("should delete all managed network policies from the cluster", func() {
+			policy1 := managedNetworkPolicy(policyName1)
+			policy2 := managedNetworkPolicy(policyName2)
+			fakeClient = newFakeClient(policy1, policy2)
+			mgr = networkpolicy.NewManager(fakeClient, &manifest.Handler{Scheme: scheme})
+
+			err := mgr.CleanupNetworkPolicies(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+
+			remaining := &networkingv1.NetworkPolicyList{}
+			Expect(fakeClient.List(ctx, remaining, client.InNamespace(kymaNamespace))).To(Succeed())
+			Expect(remaining.Items).To(BeEmpty())
+		})
+
+		It("should succeed when no managed network policies exist", func() {
+			err := mgr.CleanupNetworkPolicies(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should not delete unmanaged network policies", func() {
+			managedPolicy := managedNetworkPolicy(policyName1)
+			unmanagedPolicy := unmanagedNetworkPolicy("user-defined-policy")
+			fakeClient = newFakeClient(managedPolicy, unmanagedPolicy)
+			mgr = networkpolicy.NewManager(fakeClient, &manifest.Handler{Scheme: scheme})
+
+			err := mgr.CleanupNetworkPolicies(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+
+			remaining := &networkingv1.NetworkPolicyList{}
+			Expect(fakeClient.List(ctx, remaining, client.InNamespace(kymaNamespace))).To(Succeed())
+			Expect(remaining.Items).To(HaveLen(1))
+			Expect(remaining.Items[0].Name).To(Equal(unmanagedPolicy.Name))
+		})
+	})
+
+	Describe("DeleteOldWebhookNetworkPolicy", func() {
+		const oldWebhookPolicyName = "kyma-project.io--btp-operator-allow-to-webhook"
+
+		It("should delete the old webhook network policy when it exists", func() {
+			oldPolicy := &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      oldWebhookPolicyName,
+					Namespace: kymaNamespace,
+				},
+			}
+			fakeClient = newFakeClient(oldPolicy)
+			mgr = networkpolicy.NewManager(fakeClient, &manifest.Handler{Scheme: scheme})
+
+			err := mgr.DeleteOldWebhookNetworkPolicy(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+
+			remaining := &networkingv1.NetworkPolicy{}
+			getErr := fakeClient.Get(ctx, client.ObjectKeyFromObject(oldPolicy), remaining)
+			Expect(getErr).To(HaveOccurred())
+		})
+
+		It("should succeed without an error when the old webhook policy does not exist", func() {
+			err := mgr.DeleteOldWebhookNetworkPolicy(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})
+
+func extractNames(us []*unstructured.Unstructured) []string {
+	names := make([]string, 0, len(us))
+	for _, u := range us {
+		names = append(names, u.GetName())
+	}
+	return names
+}

--- a/internal/k8s/networkpolicy/suite_test.go
+++ b/internal/k8s/networkpolicy/suite_test.go
@@ -1,0 +1,72 @@
+package networkpolicy_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	kymaNamespace = "kyma-system"
+
+	policyName1 = "kyma-project.io--btp-operator-allow-to-apiserver"
+	policyName2 = "kyma-project.io--btp-operator-to-dns"
+
+	managedByLabelKey         = "app.kubernetes.io/managed-by"
+	kymaProjectModuleLabelKey = "kyma-project.io/module"
+	operatorName              = "btp-manager"
+	moduleName                = "btp-operator"
+)
+
+var (
+	fakeClient client.Client
+	scheme     *runtime.Scheme
+)
+
+func TestNetworkPolicyManager(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Network Policy Manager Suite")
+}
+
+var _ = BeforeSuite(func() {
+	scheme = runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(networkingv1.AddToScheme(scheme))
+})
+
+func managedNetworkPolicy(name string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: kymaNamespace,
+			Labels: map[string]string{
+				managedByLabelKey:         operatorName,
+				kymaProjectModuleLabelKey: moduleName,
+			},
+		},
+	}
+}
+
+func unmanagedNetworkPolicy(name string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: kymaNamespace,
+		},
+	}
+}
+
+func newFakeClient(objects ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		Build()
+}

--- a/internal/k8s/networkpolicy/testdata/network-policies/network-policies.yaml
+++ b/internal/k8s/networkpolicy/testdata/network-policies/network-policies.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  namespace: kyma-system
+  name: kyma-project.io--btp-operator-allow-to-apiserver
+  labels:
+    app.kubernetes.io/managed-by: btp-manager
+    kyma-project.io/module: btp-operator
+spec:
+  podSelector:
+    matchLabels:
+      kyma-project.io/module: btp-operator
+  policyTypes:
+  - Egress
+  egress:
+  - ports:
+    - port: 443
+      protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  namespace: kyma-system
+  name: kyma-project.io--btp-operator-to-dns
+  labels:
+    app.kubernetes.io/managed-by: btp-manager
+    kyma-project.io/module: btp-operator
+spec:
+  podSelector:
+    matchLabels:
+      kyma-project.io/module: btp-operator
+  policyTypes:
+  - Egress
+  egress:
+  - ports:
+    - port: 53
+      protocol: UDP

--- a/internal/webhook/certificate/manager.go
+++ b/internal/webhook/certificate/manager.go
@@ -1,0 +1,360 @@
+package certificate
+
+import (
+	"context"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/kyma-project/btp-manager/controllers/config"
+	"github.com/kyma-project/btp-manager/internal/certs"
+	"github.com/kyma-project/btp-manager/internal/k8s/secrets"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	caCertSecretName      = "ca-server-cert"
+	webhookCertSecretName = "webhook-server-cert"
+
+	caCertSecretCertField      = "ca.crt"
+	caCertSecretKeyField       = "ca.key"
+	webhookCertSecretCertField = "tls.crt"
+	webhookCertSecretKeyField  = "tls.key"
+
+	MutatingWebhookConfigurationKind   = "MutatingWebhookConfiguration"
+	ValidatingWebhookConfigurationKind = "ValidatingWebhookConfiguration"
+
+	secretKind   = "Secret"
+	managedByKey = "app.kubernetes.io/managed-by"
+	operatorName = "btp-manager"
+)
+
+type CertificateSignError struct {
+	message string
+}
+
+func NewCertificateSignError(message string) CertificateSignError {
+	return CertificateSignError{message: message}
+}
+
+func (e CertificateSignError) Error() string {
+	return e.message
+}
+
+type CertificateManager interface {
+	PrepareAdmissionWebhooks(ctx context.Context, webhookResources []*unstructured.Unstructured) ([]*unstructured.Unstructured, error)
+}
+
+// WebhookMetrics is the metrics sink consumed by the certificate manager.
+type WebhookMetrics interface {
+	IncrementCertsRegenerationCounter()
+}
+
+// IsAdmissionWebhook reports whether the given resource kind is a webhook
+// configuration managed by the certificate manager.
+func IsAdmissionWebhook(kind string) bool {
+	return kind == MutatingWebhookConfigurationKind || kind == ValidatingWebhookConfigurationKind
+}
+
+type Manager struct {
+	secretsManager secrets.Manager
+	webhookMetrics WebhookMetrics
+}
+
+func NewManager(secretsManager secrets.Manager, webhookMetrics WebhookMetrics) *Manager {
+	return &Manager{
+		secretsManager: secretsManager,
+		webhookMetrics: webhookMetrics,
+	}
+}
+
+var _ CertificateManager = (*Manager)(nil)
+
+func (m *Manager) PrepareAdmissionWebhooks(ctx context.Context, webhookResources []*unstructured.Unstructured) ([]*unstructured.Unstructured, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("preparing admission webhooks")
+
+	logger.Info("checking CA certificate")
+	caCertSecret, err := m.secretsManager.GetCaServerCertSecret(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if caCertSecret == nil {
+		logger.Info("CA cert secret does not exist")
+		return m.regenerateCertificates(ctx, webhookResources)
+	}
+	if err := m.validateCert(caCertSecret); err != nil {
+		logger.Info(fmt.Sprintf("CA cert is not valid: %s", err))
+		return m.regenerateCertificates(ctx, webhookResources)
+	}
+
+	caBundle := caCertSecret.Data[caCertSecretCertField]
+
+	logger.Info("checking webhook certificate")
+	webhookCertSecret, err := m.secretsManager.GetWebhookServerCertSecret(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if webhookCertSecret == nil {
+		logger.Info("webhook cert secret does not exist")
+		return m.regenerateWebhookCertificate(ctx, webhookResources, caCertSecret.Data)
+	}
+	if err := m.validateWebhookCert(webhookCertSecret, caBundle); err != nil {
+		logger.Info(fmt.Sprintf("webhook cert is not valid: %s", err))
+		var certSignErr CertificateSignError
+		if errors.As(err, &certSignErr) {
+			return m.regenerateCertificates(ctx, webhookResources)
+		}
+		return m.regenerateWebhookCertificate(ctx, webhookResources, caCertSecret.Data)
+	}
+
+	logger.Info("certificates for admission webhooks are valid")
+	return m.prepareWebhooksManifests(ctx, webhookResources, caBundle)
+}
+
+func (m *Manager) regenerateCertificates(ctx context.Context, webhookResources []*unstructured.Unstructured) ([]*unstructured.Unstructured, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("regenerating CA and webhook certificates")
+
+	caCertificate, caPrivateKey, err := m.generateSelfSignedCert(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("while generating CA self signed cert: %w", err)
+	}
+
+	caSecret, err := m.buildCertificateSecret(caCertSecretName, caCertificate, caPrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("while building secret with regenerated CA self signed cert: %w", err)
+	}
+
+	webhookCertificate, webhookPrivateKey, err := m.generateSignedCert(ctx, caCertificate, caPrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("while generating webhook signed cert: %w", err)
+	}
+
+	webhookSecret, err := m.buildCertificateSecret(webhookCertSecretName, webhookCertificate, webhookPrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("while building regenerated webhook signed cert secret: %w", err)
+	}
+
+	preparedWebhooks, err := m.prepareWebhooksManifests(ctx, webhookResources, caCertificate)
+	if err != nil {
+		return nil, fmt.Errorf("while preparing webhooks manifests: %w", err)
+	}
+
+	logger.Info("certificates regeneration succeeded")
+	m.webhookMetrics.IncrementCertsRegenerationCounter()
+	return append([]*unstructured.Unstructured{caSecret, webhookSecret}, preparedWebhooks...), nil
+}
+
+func (m *Manager) regenerateWebhookCertificate(ctx context.Context, webhookResources []*unstructured.Unstructured, caCertSecretData map[string][]byte) ([]*unstructured.Unstructured, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("regenerating webhook certificate")
+
+	webhookCertificate, webhookPrivateKey, err := m.generateSignedCert(ctx, caCertSecretData[caCertSecretCertField], caCertSecretData[caCertSecretKeyField])
+	if err != nil {
+		return nil, fmt.Errorf("while regenerating webhook signed cert: %w", err)
+	}
+
+	webhookSecret, err := m.buildCertificateSecret(webhookCertSecretName, webhookCertificate, webhookPrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("while building regenerated webhook signed cert secret: %w", err)
+	}
+
+	preparedWebhooks, err := m.prepareWebhooksManifests(ctx, webhookResources, caCertSecretData[caCertSecretCertField])
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Info("webhook certificate regeneration succeeded")
+	m.webhookMetrics.IncrementCertsRegenerationCounter()
+	return append([]*unstructured.Unstructured{webhookSecret}, preparedWebhooks...), nil
+}
+
+func (m *Manager) generateSelfSignedCert(ctx context.Context) ([]byte, []byte, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("generating self signed cert")
+	caCertificate, caPrivateKey, err := certs.GenerateSelfSignedCertificate(time.Now().UTC().Add(config.CaCertificateExpiration))
+	if err != nil {
+		return nil, nil, fmt.Errorf("while generating self signed cert: %w", err)
+	}
+	return caCertificate, caPrivateKey, nil
+}
+
+func (m *Manager) generateSignedCert(ctx context.Context, caCert, caPrivateKey []byte) ([]byte, []byte, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("generating webhook signed cert")
+	webhookCertificate, webhookPrivateKey, err := certs.GenerateSignedCertificate(time.Now().UTC().Add(config.WebhookCertificateExpiration), caCert, caPrivateKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("while generating webhook signed cert: %w", err)
+	}
+	return webhookCertificate, webhookPrivateKey, nil
+}
+
+func (m *Manager) buildCertificateSecret(secretName string, certificate, privateKey []byte) (*unstructured.Unstructured, error) {
+	certFieldName, err := certFieldFromSecretBySecretName(secretName)
+	if err != nil {
+		return nil, err
+	}
+	privateKeyFieldName, err := privateKeyFieldFromSecretBySecretName(secretName)
+	if err != nil {
+		return nil, err
+	}
+
+	secret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{Kind: secretKind, APIVersion: "v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: config.ChartNamespace,
+			Labels:    map[string]string{managedByKey: operatorName},
+		},
+		Data: map[string][]byte{
+			certFieldName:       certificate,
+			privateKeyFieldName: privateKey,
+		},
+	}
+
+	unstructuredObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(secret)
+	if err != nil {
+		return nil, err
+	}
+	return &unstructured.Unstructured{Object: unstructuredObj}, nil
+}
+
+func (m *Manager) prepareWebhooksManifests(ctx context.Context, webhookResources []*unstructured.Unstructured, caBundle []byte) ([]*unstructured.Unstructured, error) {
+	logger := log.FromContext(ctx)
+	logger.Info("preparing webhooks manifests")
+
+	prepared := make([]*unstructured.Unstructured, 0, len(webhookResources))
+	for _, resource := range webhookResources {
+		webhookManifest, err := prepareWebhookManifest(ctx, resource, caBundle)
+		if err != nil {
+			return nil, err
+		}
+		prepared = append(prepared, webhookManifest)
+	}
+
+	logger.Info("webhooks manifests have been prepared successfully")
+	return prepared, nil
+}
+
+func prepareWebhookManifest(ctx context.Context, webhookManifest *unstructured.Unstructured, caBundle []byte) (*unstructured.Unstructured, error) {
+	const (
+		webhooksKey     = "webhooks"
+		clientConfigKey = "clientConfig"
+		caBundleKey     = "caBundle"
+	)
+	webhookManifestCopy := webhookManifest.DeepCopy()
+
+	logger := log.FromContext(ctx)
+	logger.Info(fmt.Sprintf("setting CA bundle in %s %s", webhookManifestCopy.GetName(), webhookManifestCopy.GetKind()))
+
+	webhooks, exists, err := unstructured.NestedSlice(webhookManifestCopy.Object, webhooksKey)
+	if err != nil {
+		return nil, fmt.Errorf("while getting webhooks array from the webhook manifest: %w", err)
+	}
+	if !exists {
+		return nil, fmt.Errorf("webhooks array does not exist in the webhook manifest")
+	}
+	webhookManifestCopy.SetManagedFields(nil)
+
+	for i, webhook := range webhooks {
+		genericWebhook, ok := webhook.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("while casting webhook object to map[string]interface{}")
+		}
+		genericClientConfig, ok := genericWebhook[clientConfigKey].(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("while casting webhook.clientConfig object to map[string]interface{}")
+		}
+		genericClientConfig[caBundleKey] = caBundle
+		genericWebhook[clientConfigKey] = genericClientConfig
+		webhooks[i] = genericWebhook
+	}
+	webhookManifestCopy.Object[webhooksKey] = webhooks
+
+	return webhookManifestCopy, nil
+}
+
+func (m *Manager) validateCert(secret *corev1.Secret) error {
+	certFieldName, err := certFieldFromSecretBySecretName(secret.GetName())
+	if err != nil {
+		return err
+	}
+	encodedCert, err := getSecretDataValueByKey(certFieldName, secret.Data)
+	if err != nil {
+		return err
+	}
+	privateKeyFieldName, err := privateKeyFieldFromSecretBySecretName(secret.GetName())
+	if err != nil {
+		return err
+	}
+	if _, err = getSecretDataValueByKey(privateKeyFieldName, secret.Data); err != nil {
+		return err
+	}
+	block, err := certs.DecodeCertificate(encodedCert)
+	if err != nil {
+		return err
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return err
+	}
+	if certs.CertificateExpires(cert, config.ExpirationBoundary) {
+		return fmt.Errorf("CA cert expires soon")
+	}
+	return nil
+}
+
+func (m *Manager) validateWebhookCert(webhookCertSecret *corev1.Secret, caCert []byte) error {
+	if err := m.validateCert(webhookCertSecret); err != nil {
+		return err
+	}
+	return verifyCASign(caCert, webhookCertSecret.Data[webhookCertSecretCertField])
+}
+
+func verifyCASign(caCert, signedCert []byte) error {
+	ok, err := certs.VerifyIfLeafIsSignedByGivenCA(caCert, signedCert)
+	if err != nil {
+		return NewCertificateSignError(err.Error())
+	}
+	if !ok {
+		return NewCertificateSignError("certificate is not signed by the provided CA")
+	}
+	return nil
+}
+
+func getSecretDataValueByKey(key string, data map[string][]byte) ([]byte, error) {
+	value, ok := data[key]
+	if !ok {
+		return nil, fmt.Errorf("missing key: %s", key)
+	}
+	if len(value) == 0 {
+		return nil, fmt.Errorf("empty value for key: %s", key)
+	}
+	return value, nil
+}
+
+func certFieldFromSecretBySecretName(secretName string) (string, error) {
+	switch secretName {
+	case caCertSecretName:
+		return caCertSecretCertField, nil
+	case webhookCertSecretName:
+		return webhookCertSecretCertField, nil
+	}
+	return "", fmt.Errorf("unknown secret %q - cert field undefined", secretName)
+}
+
+func privateKeyFieldFromSecretBySecretName(secretName string) (string, error) {
+	switch secretName {
+	case caCertSecretName:
+		return caCertSecretKeyField, nil
+	case webhookCertSecretName:
+		return webhookCertSecretKeyField, nil
+	}
+	return "", fmt.Errorf("unknown secret %q - private key field undefined", secretName)
+}

--- a/internal/webhook/certificate/manager_test.go
+++ b/internal/webhook/certificate/manager_test.go
@@ -1,0 +1,212 @@
+package certificate_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/kyma-project/btp-manager/internal/webhook/certificate"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = Describe("Certificate Manager", func() {
+	var (
+		mgr        *certificate.Manager
+		secretsMgr *fakeSecretsManager
+		metrics    *fakeWebhookMetrics
+		ctx        context.Context
+	)
+
+	BeforeEach(func() {
+		secretsMgr = &fakeSecretsManager{}
+		metrics = &fakeWebhookMetrics{}
+		mgr = certificate.NewManager(secretsMgr, metrics)
+		ctx = context.Background()
+	})
+
+	Describe("PrepareAdmissionWebhooks", func() {
+		Context("when CA cert secret does not exist", func() {
+			BeforeEach(func() {
+				secretsMgr.caCertSecret = nil
+			})
+
+			It("returns both the CA and webhook cert secrets", func() {
+				result, err := mgr.PrepareAdmissionWebhooks(ctx, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(secretNamesIn(result)).To(ConsistOf(caCertSecretName, webhookCertSecretName))
+			})
+
+			It("increments the regeneration counter", func() {
+				_, err := mgr.PrepareAdmissionWebhooks(ctx, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(metrics.counter).To(Equal(1))
+			})
+
+			It("returns the webhook config with CA bundle injected", func() {
+				result, err := mgr.PrepareAdmissionWebhooks(ctx, []*unstructured.Unstructured{
+					mutatingWebhookConfig("test-mutating"),
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(caBundleIn(webhookResourceIn(result))).NotTo(BeEmpty())
+			})
+		})
+
+		Context("when CA cert secret exists but the certificate is expiring soon", func() {
+			BeforeEach(func() {
+				secretsMgr.caCertSecret = caSecret(expiringCACert, expiringCAKey)
+			})
+
+			It("returns both the CA and webhook cert secrets", func() {
+				result, err := mgr.PrepareAdmissionWebhooks(ctx, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(secretNamesIn(result)).To(ConsistOf(caCertSecretName, webhookCertSecretName))
+			})
+
+			It("increments the regeneration counter", func() {
+				_, err := mgr.PrepareAdmissionWebhooks(ctx, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(metrics.counter).To(Equal(1))
+			})
+		})
+
+		Context("when CA cert is valid but webhook cert secret does not exist", func() {
+			BeforeEach(func() {
+				secretsMgr.caCertSecret = caSecret(validCACert, validCAKey)
+				secretsMgr.webhookCertSecret = nil
+			})
+
+			It("returns only the webhook cert secret", func() {
+				result, err := mgr.PrepareAdmissionWebhooks(ctx, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				names := secretNamesIn(result)
+				Expect(names).To(ConsistOf(webhookCertSecretName))
+				Expect(names).NotTo(ContainElement(caCertSecretName))
+			})
+
+			It("increments the regeneration counter", func() {
+				_, err := mgr.PrepareAdmissionWebhooks(ctx, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(metrics.counter).To(Equal(1))
+			})
+
+			It("returns the webhook config with the existing CA bundle injected", func() {
+				result, err := mgr.PrepareAdmissionWebhooks(ctx, []*unstructured.Unstructured{
+					mutatingWebhookConfig("test-mutating"),
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(caBundleIn(webhookResourceIn(result))).NotTo(BeEmpty())
+			})
+		})
+
+		Context("when CA cert is valid but webhook cert is expiring soon", func() {
+			BeforeEach(func() {
+				secretsMgr.caCertSecret = caSecret(validCACert, validCAKey)
+				secretsMgr.webhookCertSecret = webhookSecret(expiringWebhookCert, expiringWebhookKey)
+			})
+
+			It("returns only the webhook cert secret", func() {
+				result, err := mgr.PrepareAdmissionWebhooks(ctx, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				names := secretNamesIn(result)
+				Expect(names).To(ConsistOf(webhookCertSecretName))
+				Expect(names).NotTo(ContainElement(caCertSecretName))
+			})
+
+			It("increments the regeneration counter", func() {
+				_, err := mgr.PrepareAdmissionWebhooks(ctx, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(metrics.counter).To(Equal(1))
+			})
+		})
+
+		Context("when CA cert is valid but webhook cert was signed by a different CA", func() {
+			BeforeEach(func() {
+				secretsMgr.caCertSecret = caSecret(validCACert, validCAKey)
+				secretsMgr.webhookCertSecret = webhookSecret(wrongSignedWebhookCert, wrongSignedWebhookKey)
+			})
+
+			It("returns both the CA and webhook cert secrets", func() {
+				result, err := mgr.PrepareAdmissionWebhooks(ctx, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(secretNamesIn(result)).To(ConsistOf(caCertSecretName, webhookCertSecretName))
+			})
+
+			It("increments the regeneration counter", func() {
+				_, err := mgr.PrepareAdmissionWebhooks(ctx, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(metrics.counter).To(Equal(1))
+			})
+		})
+
+		Context("when both CA and webhook certs are valid", func() {
+			BeforeEach(func() {
+				secretsMgr.caCertSecret = caSecret(validCACert, validCAKey)
+				secretsMgr.webhookCertSecret = webhookSecret(validWebhookCert, validWebhookKey)
+			})
+
+			It("returns no cert secrets", func() {
+				result, err := mgr.PrepareAdmissionWebhooks(ctx, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(secretNamesIn(result)).To(BeEmpty())
+			})
+
+			It("does not increment the regeneration counter", func() {
+				_, err := mgr.PrepareAdmissionWebhooks(ctx, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(metrics.counter).To(Equal(0))
+			})
+
+			It("returns a MutatingWebhookConfiguration with the CA bundle injected", func() {
+				result, err := mgr.PrepareAdmissionWebhooks(ctx, []*unstructured.Unstructured{
+					mutatingWebhookConfig("test-mutating"),
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(caBundleIn(webhookResourceIn(result))).To(Equal(validCACert))
+			})
+
+			It("returns a ValidatingWebhookConfiguration with the CA bundle injected", func() {
+				result, err := mgr.PrepareAdmissionWebhooks(ctx, []*unstructured.Unstructured{
+					validatingWebhookConfig("test-validating"),
+				})
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(caBundleIn(webhookResourceIn(result))).To(Equal(validCACert))
+			})
+		})
+
+		Context("error paths", func() {
+			It("returns an error when fetching the CA cert secret fails", func() {
+				secretsMgr.caCertSecretErr = errors.New("api server unavailable")
+
+				_, err := mgr.PrepareAdmissionWebhooks(ctx, nil)
+
+				Expect(err).To(MatchError(ContainSubstring("api server unavailable")))
+			})
+
+			It("returns an error when fetching the webhook cert secret fails", func() {
+				secretsMgr.caCertSecret = caSecret(validCACert, validCAKey)
+				secretsMgr.webhookCertErr = errors.New("api server unavailable")
+
+				_, err := mgr.PrepareAdmissionWebhooks(ctx, nil)
+
+				Expect(err).To(MatchError(ContainSubstring("api server unavailable")))
+			})
+		})
+	})
+})

--- a/internal/webhook/certificate/suite_test.go
+++ b/internal/webhook/certificate/suite_test.go
@@ -1,0 +1,203 @@
+package certificate_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kyma-project/btp-manager/controllers/config"
+	"github.com/kyma-project/btp-manager/internal/certs"
+	"github.com/kyma-project/btp-manager/internal/webhook/certificate"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	kymaNamespace = "kyma-system"
+
+	caCertSecretName      = "ca-server-cert"
+	webhookCertSecretName = "webhook-server-cert"
+
+	caCertField      = "ca.crt"
+	caKeyField       = "ca.key"
+	webhookCertField = "tls.crt"
+	webhookKeyField  = "tls.key"
+)
+
+var (
+	validCACert    []byte
+	validCAKey     []byte
+	expiringCACert []byte
+	expiringCAKey  []byte
+
+	validWebhookCert       []byte
+	validWebhookKey        []byte
+	expiringWebhookCert    []byte
+	expiringWebhookKey     []byte
+	wrongSignedWebhookCert []byte
+	wrongSignedWebhookKey  []byte
+)
+
+func TestCertificateManager(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Certificate Manager Suite")
+}
+
+var _ = BeforeSuite(func() {
+	// Use 1024-bit keys (minimum accepted by Go's crypto/rsa) so cert generation is fast in tests.
+	certs.SetRsaKeyBits(1024)
+
+	var err error
+
+	validCACert, validCAKey, err = certs.GenerateSelfSignedCertificate(
+		time.Now().UTC().Add(config.CaCertificateExpiration),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Expiry within ExpirationBoundary (1 week) triggers regeneration.
+	expiringCACert, expiringCAKey, err = certs.GenerateSelfSignedCertificate(
+		time.Now().UTC().Add(time.Hour),
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	validWebhookCert, validWebhookKey, err = certs.GenerateSignedCertificate(
+		time.Now().UTC().Add(config.WebhookCertificateExpiration),
+		validCACert, validCAKey,
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	expiringWebhookCert, expiringWebhookKey, err = certs.GenerateSignedCertificate(
+		time.Now().UTC().Add(time.Hour),
+		validCACert, validCAKey,
+	)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Cert signed by a completely different CA — triggers CertificateSignError.
+	wrongCACert, wrongCAKey, err := certs.GenerateSelfSignedCertificate(
+		time.Now().UTC().Add(config.CaCertificateExpiration),
+	)
+	Expect(err).NotTo(HaveOccurred())
+	wrongSignedWebhookCert, wrongSignedWebhookKey, err = certs.GenerateSignedCertificate(
+		time.Now().UTC().Add(config.WebhookCertificateExpiration),
+		wrongCACert, wrongCAKey,
+	)
+	Expect(err).NotTo(HaveOccurred())
+})
+
+// fakeSecretsManager is a test double for secrets.Manager. Only the two cert
+// getters matter for the certificate manager; the rest return nil.
+type fakeSecretsManager struct {
+	caCertSecret      *corev1.Secret
+	caCertSecretErr   error
+	webhookCertSecret *corev1.Secret
+	webhookCertErr    error
+}
+
+func (f *fakeSecretsManager) GetRequiredSecret(_ context.Context) (*corev1.Secret, error) {
+	return nil, nil
+}
+func (f *fakeSecretsManager) GetCaServerCertSecret(_ context.Context) (*corev1.Secret, error) {
+	return f.caCertSecret, f.caCertSecretErr
+}
+func (f *fakeSecretsManager) GetWebhookServerCertSecret(_ context.Context) (*corev1.Secret, error) {
+	return f.webhookCertSecret, f.webhookCertErr
+}
+func (f *fakeSecretsManager) GetSapBtpServiceOperatorSecret(_ context.Context) (*corev1.Secret, error) {
+	return nil, nil
+}
+func (f *fakeSecretsManager) GetSapBtpServiceOperatorClusterIdSecret(_ context.Context) (*corev1.Secret, error) {
+	return nil, nil
+}
+
+func caSecret(cert, key []byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: caCertSecretName, Namespace: kymaNamespace},
+		Data:       map[string][]byte{caCertField: cert, caKeyField: key},
+	}
+}
+
+func webhookSecret(cert, key []byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: webhookCertSecretName, Namespace: kymaNamespace},
+		Data:       map[string][]byte{webhookCertField: cert, webhookKeyField: key},
+	}
+}
+
+func mutatingWebhookConfig(name string) *unstructured.Unstructured {
+	return webhookConfigUnstructured("MutatingWebhookConfiguration", name)
+}
+
+func validatingWebhookConfig(name string) *unstructured.Unstructured {
+	return webhookConfigUnstructured("ValidatingWebhookConfiguration", name)
+}
+
+func webhookConfigUnstructured(kind, name string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetKind(kind)
+	u.SetAPIVersion("admissionregistration.k8s.io/v1")
+	u.SetName(name)
+	_ = unstructured.SetNestedSlice(u.Object, []interface{}{
+		map[string]interface{}{
+			"name":         "test-webhook",
+			"clientConfig": map[string]interface{}{},
+		},
+	}, "webhooks")
+	return u
+}
+
+// fakeWebhookMetrics is a minimal test double for certificate.WebhookMetrics.
+type fakeWebhookMetrics struct {
+	counter int
+}
+
+func (f *fakeWebhookMetrics) IncrementCertsRegenerationCounter() {
+	f.counter++
+}
+
+func webhookResourceIn(resources []*unstructured.Unstructured) *unstructured.Unstructured {
+	for _, r := range resources {
+		if certificate.IsAdmissionWebhook(r.GetKind()) {
+			return r
+		}
+	}
+	return nil
+}
+
+func secretNamesIn(resources []*unstructured.Unstructured) []string {
+	var names []string
+	for _, r := range resources {
+		if r.GetKind() == "Secret" {
+			names = append(names, r.GetName())
+		}
+	}
+	return names
+}
+
+func caBundleIn(resource *unstructured.Unstructured) []byte {
+	// NestedFieldNoCopy is used instead of NestedSlice because the CA bundle is
+	// stored as []byte inside the nested map, which NestedSlice cannot deep-copy.
+	webhooksRaw, exists, _ := unstructured.NestedFieldNoCopy(resource.Object, "webhooks")
+	if !exists {
+		return nil
+	}
+	webhooks, ok := webhooksRaw.([]interface{})
+	if !ok || len(webhooks) == 0 {
+		return nil
+	}
+	webhook, ok := webhooks[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	clientConfig, ok := webhook["clientConfig"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	raw, ok := clientConfig["caBundle"].([]byte)
+	if !ok {
+		return nil
+	}
+	return raw
+}


### PR DESCRIPTION
**Description**

Fixes compile errors introduced by #1433 and #1434 in \`btpoperator_controller.go\` (which is not part of either PR's diff).

Changes:
- Add import for \`internal/webhook/certificate\` — \`CertificateSignError\` and \`NewCertificateSignError\` were moved there by #1433
- Replace \`var certSignErr CertificateSignError\` → \`certificate.CertificateSignError\`
- Replace \`NewCertificateSignError\` → \`certificate.NewCertificateSignError\`
- Fix nil-pointer panic in \`verifyCASign\`: split \`err != nil || !ok\` into two separate checks so \`err.Error()\` is never called on a nil error
- Update \`errWithReason.reason\`/\`.message\` → \`errWithReason.Reason\`/\`.Message\` — \`ErrorWithReason\` was moved to \`internal/conditions\` with exported fields by #1434

**Related issue(s)**
See #1433, #1434