### PR TITLE
Fix controller compile errors after ErrorWithReason and CertificateSignError moves

### DIFF
--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kyma-project/btp-manager/internal/conditions"
 	"github.com/kyma-project/btp-manager/internal/manifest"
 	"github.com/kyma-project/btp-manager/internal/metrics"
+	"github.com/kyma-project/btp-manager/internal/webhook/certificate"
 	"github.com/kyma-project/btp-manager/internal/ymlutils"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -337,15 +338,15 @@ func (r *BtpOperatorReconciler) HandleProcessingState(ctx context.Context, cr *v
 	r.setCredentialsNamespacesAndClusterId(requiredSecret)
 
 	if errWithReason := r.checkDefaultCredentialsSecretNamespace(ctx, logger, requiredSecret); errWithReason != nil {
-		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.reason, errWithReason.message)
+		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.Reason, errWithReason.Message)
 	}
 
 	if errWithReason := r.checkSapBtpServiceOperatorClusterIdConfigMap(ctx, logger, requiredSecret); errWithReason != nil {
-		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.reason, errWithReason.message)
+		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.Reason, errWithReason.Message)
 	}
 
 	if errWithReason := r.checkSapBtpServiceOperatorClusterIdSecret(ctx, logger, requiredSecret); errWithReason != nil {
-		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.reason, errWithReason.message)
+		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.Reason, errWithReason.Message)
 	}
 
 	if err := r.deleteOutdatedResources(ctx); err != nil {
@@ -369,7 +370,7 @@ func (r *BtpOperatorReconciler) HandleProcessingState(ctx context.Context, cr *v
 
 func (r *BtpOperatorReconciler) handleMissingSecret(ctx context.Context, cr *v1alpha1.BtpOperator, logger logr.Logger, errWithReason *ErrorWithReason) error {
 	logger.Info("secret verification failed: " + errWithReason.Error())
-	return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateWarning, errWithReason.reason, errWithReason.message)
+	return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateWarning, errWithReason.Reason, errWithReason.Message)
 }
 
 func (r *BtpOperatorReconciler) getAndVerifyRequiredSecret(ctx context.Context) (*corev1.Secret, *ErrorWithReason) {
@@ -1765,7 +1766,7 @@ func (r *BtpOperatorReconciler) prepareAdmissionWebhooks(ctx context.Context, re
 	}
 	if err := r.validateWebhookCert(webhookCertSecret, caBundle); err != nil {
 		logger.Info(fmt.Sprintf("webhook cert is not valid: %s", err))
-		var certSignErr CertificateSignError
+		var certSignErr certificate.CertificateSignError
 		if errors.As(err, &certSignErr) {
 			return r.regenerateCertificates(ctx, resourcesToApply)
 		}
@@ -2317,8 +2318,11 @@ func (r *BtpOperatorReconciler) validateWebhookCert(webhookCertSecret *corev1.Se
 
 func (r *BtpOperatorReconciler) verifyCASign(caCert []byte, signedCert []byte) error {
 	ok, err := certs.VerifyIfLeafIsSignedByGivenCA(caCert, signedCert)
-	if err != nil || !ok {
-		return NewCertificateSignError(err.Error())
+	if err != nil {
+		return certificate.NewCertificateSignError(err.Error())
+	}
+	if !ok {
+		return certificate.NewCertificateSignError("certificate is not signed by the provided CA")
 	}
 	return nil
 }

--- a/controllers/errors.go
+++ b/controllers/errors.go
@@ -2,32 +2,8 @@ package controllers
 
 import "github.com/kyma-project/btp-manager/internal/conditions"
 
-type ErrorWithReason struct {
-	message string
-	reason  conditions.Reason
-}
+type ErrorWithReason = conditions.ErrorWithReason
 
 func NewErrorWithReason(reason conditions.Reason, message string) *ErrorWithReason {
-	return &ErrorWithReason{
-		message: message,
-		reason:  reason,
-	}
-}
-
-func (e *ErrorWithReason) Error() string {
-	return e.message
-}
-
-type CertificateSignError struct {
-	message string
-}
-
-func NewCertificateSignError(message string) CertificateSignError {
-	return CertificateSignError{
-		message: message,
-	}
-}
-
-func (e CertificateSignError) Error() string {
-	return e.message
+	return conditions.NewErrorWithReason(reason, message)
 }

--- a/internal/conditions/errors.go
+++ b/internal/conditions/errors.go
@@ -1,0 +1,17 @@
+package conditions
+
+type ErrorWithReason struct {
+	Message string
+	Reason  Reason
+}
+
+func NewErrorWithReason(reason Reason, message string) *ErrorWithReason {
+	return &ErrorWithReason{
+		Message: message,
+		Reason:  reason,
+	}
+}
+
+func (e *ErrorWithReason) Error() string {
+	return e.Message
+}

--- a/internal/credentials/drift/detector.go
+++ b/internal/credentials/drift/detector.go
@@ -1,0 +1,353 @@
+package drift
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/kyma-project/btp-manager/controllers/config"
+	"github.com/kyma-project/btp-manager/internal/conditions"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	clusterIdSecretKey            = "cluster_id"
+	credentialsNamespaceSecretKey = "credentials_namespace"
+	initialClusterIdSecretKey     = "INITIAL_CLUSTER_ID"
+
+	operatorName = "btp-manager"
+	operandName  = "sap-btp-operator"
+
+	sapBtpServiceOperatorSecretName          = "sap-btp-service-operator"
+	sapBtpServiceOperatorClusterIdSecretName = operandName + "-clusterid"
+	sapBtpServiceOperatorConfigMapName       = operandName + "-config"
+
+	operatorLabelPrefix                       = "operator.kyma-project.io/"
+	previousClusterIdAnnotationKey            = operatorLabelPrefix + "previous-cluster-id"
+	previousCredentialsNamespaceAnnotationKey = operatorLabelPrefix + "previous-credentials-namespace"
+
+	managedByLabelKey    = "app.kubernetes.io/managed-by"
+	instanceLabelKey     = "app.kubernetes.io/instance"
+)
+
+type Detector interface {
+	InitializeFromSecret(s *corev1.Secret)
+	CredentialsNamespaceFromManager() string
+	CredentialsNamespaceFromOperator() string
+	ClusterIdFromManager() string
+	ClusterIdFromOperatorConfigMap() string
+	ClusterIdFromOperatorClusterIdSecret() string
+	PreviousCredentialsNamespace() string
+	SetCredentialsNamespaceFromOperator(ns string)
+	SetClusterIdFromOperatorConfigMap(id string)
+	CheckCredentialsNamespaceDrift(ctx context.Context, requiredSecret *corev1.Secret) *conditions.ErrorWithReason
+	CheckClusterIdConfigMapDrift(ctx context.Context, requiredSecret *corev1.Secret) *conditions.ErrorWithReason
+	CheckClusterIdSecretDrift(ctx context.Context, requiredSecret *corev1.Secret) *conditions.ErrorWithReason
+	GetDefaultCredentialsSecret(ctx context.Context) (*corev1.Secret, error)
+	GetSapBtpServiceOperatorConfigMap(ctx context.Context) (*corev1.ConfigMap, error)
+	DeleteClusterIdSecret(ctx context.Context) error
+	DeleteChangedResources(ctx context.Context) error
+}
+
+type DriftDetector struct {
+	client          client.Client
+	apiServerClient client.Client
+
+	previousCredentialsNamespace                        string
+	clusterIdFromSapBtpManagerSecret                    string
+	clusterIdFromSapBtpServiceOperatorConfigMap         string
+	clusterIdFromSapBtpServiceOperatorClusterIdSecret   string
+	credentialsNamespaceFromSapBtpManagerSecret         string
+	credentialsNamespaceFromSapBtpServiceOperatorSecret string
+}
+
+func NewDetector(k8sClient client.Client, apiServerClient client.Client) *DriftDetector {
+	return &DriftDetector{
+		client:          k8sClient,
+		apiServerClient: apiServerClient,
+	}
+}
+
+var _ Detector = (*DriftDetector)(nil)
+
+func (d *DriftDetector) InitializeFromSecret(s *corev1.Secret) {
+	credentialsNamespace := config.ChartNamespace
+	if s != nil {
+		if v, ok := s.Data[credentialsNamespaceSecretKey]; ok && len(v) > 0 {
+			credentialsNamespace = string(v)
+		}
+		d.clusterIdFromSapBtpManagerSecret = string(s.Data[clusterIdSecretKey])
+		d.previousCredentialsNamespace = s.Annotations[previousCredentialsNamespaceAnnotationKey]
+	}
+	d.credentialsNamespaceFromSapBtpManagerSecret = credentialsNamespace
+	d.credentialsNamespaceFromSapBtpServiceOperatorSecret = credentialsNamespace
+}
+
+func (d *DriftDetector) CredentialsNamespaceFromManager() string {
+	return d.credentialsNamespaceFromSapBtpManagerSecret
+}
+
+func (d *DriftDetector) CredentialsNamespaceFromOperator() string {
+	return d.credentialsNamespaceFromSapBtpServiceOperatorSecret
+}
+
+func (d *DriftDetector) ClusterIdFromManager() string {
+	return d.clusterIdFromSapBtpManagerSecret
+}
+
+func (d *DriftDetector) ClusterIdFromOperatorConfigMap() string {
+	return d.clusterIdFromSapBtpServiceOperatorConfigMap
+}
+
+func (d *DriftDetector) ClusterIdFromOperatorClusterIdSecret() string {
+	return d.clusterIdFromSapBtpServiceOperatorClusterIdSecret
+}
+
+func (d *DriftDetector) PreviousCredentialsNamespace() string {
+	return d.previousCredentialsNamespace
+}
+
+func (d *DriftDetector) SetCredentialsNamespaceFromOperator(ns string) {
+	d.credentialsNamespaceFromSapBtpServiceOperatorSecret = ns
+}
+
+func (d *DriftDetector) SetClusterIdFromOperatorConfigMap(id string) {
+	d.clusterIdFromSapBtpServiceOperatorConfigMap = id
+}
+
+func (d *DriftDetector) CheckCredentialsNamespaceDrift(ctx context.Context, requiredSecret *corev1.Secret) *conditions.ErrorWithReason {
+	logger := log.FromContext(ctx)
+
+	defaultCredentialsSecret, err := d.GetDefaultCredentialsSecret(ctx)
+	if err != nil {
+		logger.Error(err, fmt.Sprintf("while getting %s secret", sapBtpServiceOperatorSecretName))
+		return conditions.NewErrorWithReason(conditions.GettingDefaultCredentialsSecretFailed, err.Error())
+	}
+
+	if defaultCredentialsSecret != nil {
+		d.credentialsNamespaceFromSapBtpServiceOperatorSecret = defaultCredentialsSecret.Namespace
+		if d.credentialsNamespaceFromSapBtpManagerSecret != d.credentialsNamespaceFromSapBtpServiceOperatorSecret {
+			logger.Info(fmt.Sprintf("credentials namespaces between %s secret and %s secret don't match", config.SecretName, sapBtpServiceOperatorSecretName))
+			if err := d.annotateSecret(ctx, requiredSecret, previousCredentialsNamespaceAnnotationKey, d.credentialsNamespaceFromSapBtpServiceOperatorSecret); err != nil {
+				return conditions.NewErrorWithReason(conditions.AnnotatingSecretFailed, err.Error())
+			}
+		}
+	}
+
+	return nil
+}
+
+func (d *DriftDetector) CheckClusterIdConfigMapDrift(ctx context.Context, requiredSecret *corev1.Secret) *conditions.ErrorWithReason {
+	logger := log.FromContext(ctx)
+
+	sapBtpOperatorConfigMap, err := d.GetSapBtpServiceOperatorConfigMap(ctx)
+	if err != nil {
+		logger.Error(err, fmt.Sprintf("while getting %s ConfigMap", sapBtpServiceOperatorConfigMapName))
+		return conditions.NewErrorWithReason(conditions.GettingSapBtpServiceOperatorConfigMapFailed, err.Error())
+	}
+
+	if sapBtpOperatorConfigMap != nil {
+		d.clusterIdFromSapBtpServiceOperatorConfigMap = sapBtpOperatorConfigMap.Data[strings.ToUpper(clusterIdSecretKey)]
+		d.clusterIdFromSapBtpServiceOperatorClusterIdSecret = d.clusterIdFromSapBtpServiceOperatorConfigMap
+		if d.clusterIdFromSapBtpManagerSecret != d.clusterIdFromSapBtpServiceOperatorConfigMap {
+			logger.Info(fmt.Sprintf("cluster IDs between %s secret and %s configmap don't match", config.SecretName, sapBtpServiceOperatorConfigMapName))
+			if err := d.annotateSecret(ctx, requiredSecret, previousClusterIdAnnotationKey, d.clusterIdFromSapBtpServiceOperatorConfigMap); err != nil {
+				return conditions.NewErrorWithReason(conditions.AnnotatingSecretFailed, err.Error())
+			}
+		}
+	}
+
+	return nil
+}
+
+func (d *DriftDetector) CheckClusterIdSecretDrift(ctx context.Context, requiredSecret *corev1.Secret) *conditions.ErrorWithReason {
+	logger := log.FromContext(ctx)
+
+	clusterIdSecret, err := d.getSecretByNameAndNamespace(ctx, sapBtpServiceOperatorClusterIdSecretName, d.credentialsNamespaceFromSapBtpServiceOperatorSecret)
+	if err != nil {
+		logger.Error(err, fmt.Sprintf("while getting %s secret", sapBtpServiceOperatorClusterIdSecretName))
+		return conditions.NewErrorWithReason(conditions.GettingSapBtpServiceOperatorClusterIdSecretFailed, err.Error())
+	}
+
+	if clusterIdSecret != nil {
+		if clusterIdFromSecret, ok := clusterIdSecret.Data[initialClusterIdSecretKey]; ok && len(clusterIdFromSecret) > 0 {
+			d.clusterIdFromSapBtpServiceOperatorClusterIdSecret = string(clusterIdFromSecret)
+		}
+		if d.clusterIdFromSapBtpServiceOperatorConfigMap != d.clusterIdFromSapBtpServiceOperatorClusterIdSecret {
+			logger.Info(fmt.Sprintf("cluster IDs between %s configmap and %s secret don't match", sapBtpServiceOperatorConfigMapName, sapBtpServiceOperatorClusterIdSecretName))
+			if err = d.annotateSecret(ctx, requiredSecret, previousClusterIdAnnotationKey, d.clusterIdFromSapBtpServiceOperatorClusterIdSecret); err != nil {
+				logger.Error(err, fmt.Sprintf("while annotating %s secret", requiredSecret.Name))
+				return conditions.NewErrorWithReason(conditions.AnnotatingSecretFailed, err.Error())
+			}
+			logger.Info(fmt.Sprintf("deleting %s secret from %s namespace due to invalid cluster ID", clusterIdSecret.Name, clusterIdSecret.Namespace))
+			if err = d.deleteObject(ctx, clusterIdSecret); err != nil {
+				logger.Error(err, fmt.Sprintf("while deleting %s secret", clusterIdSecret.Name))
+				return conditions.NewErrorWithReason(conditions.DeletionOfOrphanedResourcesFailed, err.Error())
+			}
+			if err = d.restartSapBtpServiceOperatorPodIfNotReady(ctx, logger); err != nil {
+				return conditions.NewErrorWithReason(conditions.ResourceRemovalFailed, fmt.Sprintf("while restarting SAP BTP service operator pod: %s", err))
+			}
+		}
+	}
+
+	return nil
+}
+
+func (d *DriftDetector) DeleteChangedResources(ctx context.Context) error {
+	clusterIdSecret, err := d.getSecretByNameAndNamespace(ctx, sapBtpServiceOperatorClusterIdSecretName, d.credentialsNamespaceFromSapBtpServiceOperatorSecret)
+	if err != nil {
+		return err
+	}
+	pod, err := d.getSapBtpServiceOperatorPod(ctx)
+	if err != nil {
+		return err
+	}
+	credentialsSecret, err := d.getSecretByNameAndNamespace(ctx, sapBtpServiceOperatorSecretName, d.credentialsNamespaceFromSapBtpServiceOperatorSecret)
+	if err != nil {
+		return err
+	}
+
+	isCredentialsNamespaceChanged := d.credentialsNamespaceFromSapBtpServiceOperatorSecret != "" &&
+		d.credentialsNamespaceFromSapBtpManagerSecret != d.credentialsNamespaceFromSapBtpServiceOperatorSecret
+
+	isClusterIdChanged := d.clusterIdFromSapBtpServiceOperatorConfigMap != "" &&
+		(d.clusterIdFromSapBtpManagerSecret != d.clusterIdFromSapBtpServiceOperatorConfigMap ||
+			d.clusterIdFromSapBtpServiceOperatorConfigMap != d.clusterIdFromSapBtpServiceOperatorClusterIdSecret)
+
+	if isCredentialsNamespaceChanged || isClusterIdChanged {
+		if clusterIdSecret != nil {
+			if err = d.deleteObject(ctx, clusterIdSecret); err != nil {
+				return err
+			}
+		}
+		if pod != nil {
+			if err = d.deleteObject(ctx, pod); err != nil {
+				return err
+			}
+		}
+	}
+
+	if isCredentialsNamespaceChanged && credentialsSecret != nil {
+		if err = d.deleteObject(ctx, credentialsSecret); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *DriftDetector) DeleteClusterIdSecret(ctx context.Context) error {
+	clusterIdSecret, err := d.getSecretByNameAndNamespace(ctx, sapBtpServiceOperatorClusterIdSecretName, d.credentialsNamespaceFromSapBtpManagerSecret)
+	if err != nil {
+		return fmt.Errorf("failed to get cluster ID secret: %w", err)
+	}
+	if clusterIdSecret != nil {
+		if err := d.deleteObject(ctx, clusterIdSecret); err != nil {
+			return fmt.Errorf("failed to delete cluster ID secret: %w", err)
+		}
+	}
+	return nil
+}
+
+func (d *DriftDetector) GetDefaultCredentialsSecret(ctx context.Context) (*corev1.Secret, error) {
+	var defaultCredentialsSecret *corev1.Secret
+	secrets := &corev1.SecretList{}
+	if err := d.client.List(ctx, secrets, client.MatchingLabels{managedByLabelKey: operatorName}); err != nil {
+		return nil, fmt.Errorf("unable to list managed secrets: %w", err)
+	}
+	if len(secrets.Items) == 0 {
+		return nil, nil
+	}
+	for i, s := range secrets.Items {
+		if s.Name == sapBtpServiceOperatorSecretName && s.Namespace == d.previousCredentialsNamespace {
+			defaultCredentialsSecret = &secrets.Items[i]
+			break
+		} else if s.Name == sapBtpServiceOperatorSecretName {
+			defaultCredentialsSecret = &secrets.Items[i]
+		}
+	}
+	return defaultCredentialsSecret, nil
+}
+
+func (d *DriftDetector) GetSapBtpServiceOperatorConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {
+	cm := &corev1.ConfigMap{}
+	if err := d.client.Get(ctx, client.ObjectKey{Namespace: config.ChartNamespace, Name: sapBtpServiceOperatorConfigMapName}, cm); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return cm, nil
+}
+
+func (d *DriftDetector) annotateSecret(ctx context.Context, s *corev1.Secret, key, value string) error {
+	annotations := s.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	if annotations[key] == value {
+		return nil
+	}
+	annotations[key] = value
+	s.SetAnnotations(annotations)
+	return d.client.Update(ctx, s, client.FieldOwner(operatorName))
+}
+
+func (d *DriftDetector) getSecretByNameAndNamespace(ctx context.Context, name, namespace string) (*corev1.Secret, error) {
+	secret := &corev1.Secret{}
+	if err := d.apiServerClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, secret); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("while getting %s secret from %s namespace: %w", name, namespace, err)
+	}
+	return secret, nil
+}
+
+func (d *DriftDetector) getSapBtpServiceOperatorPod(ctx context.Context) (*corev1.Pod, error) {
+	var pod *corev1.Pod
+	pods := &corev1.PodList{}
+	if err := d.apiServerClient.List(ctx, pods, client.MatchingLabels{instanceLabelKey: operandName}); err != nil {
+		return nil, fmt.Errorf("unable to list SAP BTP service operator pods: %w", err)
+	}
+	if len(pods.Items) == 0 {
+		return nil, nil
+	}
+	for i, p := range pods.Items {
+		if strings.HasPrefix(p.Name, operandName) && p.Namespace == config.ChartNamespace {
+			pod = &pods.Items[i]
+			break
+		}
+	}
+	return pod, nil
+}
+
+func (d *DriftDetector) deleteObject(ctx context.Context, obj client.Object) error {
+	if err := d.apiServerClient.Delete(ctx, obj); err != nil {
+		return fmt.Errorf("while deleting %s %s from %s namespace: %w", obj.GetName(), obj.GetObjectKind().GroupVersionKind().Kind, obj.GetNamespace(), err)
+	}
+	return nil
+}
+
+func (d *DriftDetector) restartSapBtpServiceOperatorPodIfNotReady(ctx context.Context, logger logr.Logger) error {
+	pod, err := d.getSapBtpServiceOperatorPod(ctx)
+	if err != nil {
+		logger.Error(err, "while getting SAP BTP service operator pod")
+		return err
+	}
+	if pod != nil {
+		for _, condition := range pod.Status.Conditions {
+			if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionFalse {
+				if err := d.deleteObject(ctx, pod); err != nil {
+					logger.Error(err, fmt.Sprintf("while deleting not ready %s pod", pod.Name))
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/internal/credentials/drift/detector_test.go
+++ b/internal/credentials/drift/detector_test.go
@@ -1,0 +1,707 @@
+package drift_test
+
+import (
+	"context"
+
+	"github.com/kyma-project/btp-manager/controllers/config"
+	"github.com/kyma-project/btp-manager/internal/conditions"
+	"github.com/kyma-project/btp-manager/internal/credentials/drift"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Drift Detector", func() {
+	var (
+		detector  *drift.DriftDetector
+		k8sClient client.Client
+		ctx       context.Context
+	)
+
+	BeforeEach(func() {
+		config.ChartNamespace = kymaNamespace
+		ctx = context.Background()
+	})
+
+	Describe("InitializeFromSecret", func() {
+		BeforeEach(func() {
+			k8sClient = newFakeClient()
+			detector = drift.NewDetector(k8sClient, k8sClient)
+		})
+
+		It("should extract cluster ID from the secret", func() {
+			secret := btpManagerSecret("test-cluster-id", "", nil)
+
+			detector.InitializeFromSecret(secret)
+
+			Expect(detector.ClusterIdFromManager()).To(Equal("test-cluster-id"))
+		})
+
+		It("should extract credentials namespace from the secret", func() {
+			secret := btpManagerSecret("", "custom-ns", nil)
+
+			detector.InitializeFromSecret(secret)
+
+			Expect(detector.CredentialsNamespaceFromManager()).To(Equal("custom-ns"))
+			Expect(detector.CredentialsNamespaceFromOperator()).To(Equal("custom-ns"))
+		})
+
+		It("should default credentials namespace to ChartNamespace when not set in the secret", func() {
+			secret := btpManagerSecret("", "", nil)
+
+			detector.InitializeFromSecret(secret)
+
+			Expect(detector.CredentialsNamespaceFromManager()).To(Equal(kymaNamespace))
+		})
+
+		It("should extract previous credentials namespace from annotation", func() {
+			secret := btpManagerSecret("", "", map[string]string{
+				previousCredentialsNamespaceAnnotationKey: "old-ns",
+			})
+
+			detector.InitializeFromSecret(secret)
+
+			Expect(detector.PreviousCredentialsNamespace()).To(Equal("old-ns"))
+		})
+
+		It("should default credentials namespace to ChartNamespace when secret is nil", func() {
+			detector.InitializeFromSecret(nil)
+
+			Expect(detector.CredentialsNamespaceFromManager()).To(Equal(kymaNamespace))
+			Expect(detector.CredentialsNamespaceFromOperator()).To(Equal(kymaNamespace))
+			Expect(detector.ClusterIdFromManager()).To(BeEmpty())
+			Expect(detector.PreviousCredentialsNamespace()).To(BeEmpty())
+		})
+	})
+
+	Describe("GetDefaultCredentialsSecret", func() {
+		It("should return nil when no managed secrets exist", func() {
+			k8sClient = newFakeClient()
+			detector = drift.NewDetector(k8sClient, k8sClient)
+
+			secret, err := detector.GetDefaultCredentialsSecret(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secret).To(BeNil())
+		})
+
+		It("should return the operator secret matching the previous credentials namespace", func() {
+			secretInDefault := operatorSecret(kymaNamespace)
+			secretInPrevious := operatorSecret("previous-ns")
+			k8sClient = newFakeClient(secretInDefault, secretInPrevious)
+			detector = drift.NewDetector(k8sClient, k8sClient)
+
+			managerSecret := btpManagerSecret("", "", map[string]string{
+				previousCredentialsNamespaceAnnotationKey: "previous-ns",
+			})
+			detector.InitializeFromSecret(managerSecret)
+
+			secret, err := detector.GetDefaultCredentialsSecret(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secret).NotTo(BeNil())
+			Expect(secret.Namespace).To(Equal("previous-ns"))
+		})
+
+		It("should fall back to any matching secret when previous namespace does not match", func() {
+			secretInOther := operatorSecret("other-ns")
+			k8sClient = newFakeClient(secretInOther)
+			detector = drift.NewDetector(k8sClient, k8sClient)
+
+			detector.InitializeFromSecret(nil)
+
+			secret, err := detector.GetDefaultCredentialsSecret(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secret).NotTo(BeNil())
+			Expect(secret.Namespace).To(Equal("other-ns"))
+		})
+
+		It("should ignore secrets with a different name", func() {
+			unrelatedSecret := &corev1.Secret{}
+			unrelatedSecret.Name = "some-other-secret"
+			unrelatedSecret.Namespace = kymaNamespace
+			unrelatedSecret.Labels = map[string]string{managedByLabelKey: operatorName}
+
+			k8sClient = newFakeClient(unrelatedSecret)
+			detector = drift.NewDetector(k8sClient, k8sClient)
+
+			secret, err := detector.GetDefaultCredentialsSecret(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secret).To(BeNil())
+		})
+	})
+
+	Describe("GetSapBtpServiceOperatorConfigMap", func() {
+		It("should return the ConfigMap when it exists", func() {
+			cm := operatorConfigMap("cluster-123")
+			k8sClient = newFakeClient(cm)
+			detector = drift.NewDetector(k8sClient, k8sClient)
+
+			result, err := detector.GetSapBtpServiceOperatorConfigMap(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Data[clusterIdConfigMapKey]).To(Equal("cluster-123"))
+		})
+
+		It("should return nil when the ConfigMap does not exist", func() {
+			k8sClient = newFakeClient()
+			detector = drift.NewDetector(k8sClient, k8sClient)
+
+			result, err := detector.GetSapBtpServiceOperatorConfigMap(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeNil())
+		})
+	})
+
+	Describe("CheckCredentialsNamespaceDrift", func() {
+		var requiredSecret *corev1.Secret
+
+		BeforeEach(func() {
+			requiredSecret = btpManagerSecret("cluster-1", kymaNamespace, nil)
+		})
+
+		Context("when no operator secret exists", func() {
+			BeforeEach(func() {
+				k8sClient = newFakeClient()
+				detector = drift.NewDetector(k8sClient, k8sClient)
+				detector.InitializeFromSecret(requiredSecret)
+			})
+
+			It("should return nil (no drift)", func() {
+				result := detector.CheckCredentialsNamespaceDrift(ctx, requiredSecret)
+
+				Expect(result).To(BeNil())
+			})
+		})
+
+		Context("when the operator secret is in the same namespace as the manager secret", func() {
+			BeforeEach(func() {
+				opSecret := operatorSecret(kymaNamespace)
+				k8sClient = newFakeClient(opSecret)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+				detector.InitializeFromSecret(requiredSecret)
+			})
+
+			It("should return nil (no drift)", func() {
+				result := detector.CheckCredentialsNamespaceDrift(ctx, requiredSecret)
+
+				Expect(result).To(BeNil())
+			})
+
+			It("should track the operator's namespace", func() {
+				Expect(detector.CheckCredentialsNamespaceDrift(ctx, requiredSecret)).To(Succeed())
+
+				Expect(detector.CredentialsNamespaceFromOperator()).To(Equal(kymaNamespace))
+			})
+		})
+
+		Context("when the operator secret is in a different namespace", func() {
+			BeforeEach(func() {
+				opSecret := operatorSecret("old-ns")
+				k8sClient = newFakeClient(opSecret, requiredSecret)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+				detector.InitializeFromSecret(requiredSecret)
+			})
+
+			It("should return nil but annotate the required secret with the previous namespace", func() {
+				result := detector.CheckCredentialsNamespaceDrift(ctx, requiredSecret)
+
+				Expect(result).To(BeNil())
+				Expect(requiredSecret.Annotations).To(HaveKeyWithValue(
+					previousCredentialsNamespaceAnnotationKey, "old-ns",
+				))
+			})
+
+			It("should track the operator's namespace", func() {
+				Expect(detector.CheckCredentialsNamespaceDrift(ctx, requiredSecret)).To(Succeed())
+
+				Expect(detector.CredentialsNamespaceFromOperator()).To(Equal("old-ns"))
+			})
+		})
+
+		Context("error paths", func() {
+			It("should return GettingDefaultCredentialsSecretFailed when listing secrets fails", func() {
+				k8sClient = newErrorOnListClient(newFakeClient())
+				detector = drift.NewDetector(k8sClient, newFakeClient())
+				detector.InitializeFromSecret(requiredSecret)
+
+				result := detector.CheckCredentialsNamespaceDrift(ctx, requiredSecret)
+
+				Expect(result).NotTo(BeNil())
+				Expect(result.Reason).To(Equal(conditions.GettingDefaultCredentialsSecretFailed))
+			})
+
+			It("should return AnnotatingSecretFailed when annotating the secret fails", func() {
+				opSecret := operatorSecret("old-ns")
+				// List must succeed (to detect drift); Update must fail (to trigger annotation error).
+				k8sClient = newErrorOnUpdateClient(newFakeClient(opSecret, requiredSecret))
+				detector = drift.NewDetector(k8sClient, newFakeClient())
+				detector.InitializeFromSecret(requiredSecret)
+
+				result := detector.CheckCredentialsNamespaceDrift(ctx, requiredSecret)
+
+				Expect(result).NotTo(BeNil())
+				Expect(result.Reason).To(Equal(conditions.AnnotatingSecretFailed))
+			})
+		})
+	})
+
+	Describe("CheckClusterIdConfigMapDrift", func() {
+		var requiredSecret *corev1.Secret
+
+		BeforeEach(func() {
+			requiredSecret = btpManagerSecret("cluster-1", kymaNamespace, nil)
+		})
+
+		Context("when no operator ConfigMap exists", func() {
+			BeforeEach(func() {
+				k8sClient = newFakeClient()
+				detector = drift.NewDetector(k8sClient, k8sClient)
+				detector.InitializeFromSecret(requiredSecret)
+			})
+
+			It("should return nil (no drift)", func() {
+				result := detector.CheckClusterIdConfigMapDrift(ctx, requiredSecret)
+
+				Expect(result).To(BeNil())
+			})
+		})
+
+		Context("when the ConfigMap cluster ID matches the manager secret", func() {
+			BeforeEach(func() {
+				cm := operatorConfigMap("cluster-1")
+				k8sClient = newFakeClient(cm)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+				detector.InitializeFromSecret(requiredSecret)
+			})
+
+			It("should return nil (no drift)", func() {
+				result := detector.CheckClusterIdConfigMapDrift(ctx, requiredSecret)
+
+				Expect(result).To(BeNil())
+			})
+
+			It("should track the ConfigMap's cluster ID", func() {
+				Expect(detector.CheckClusterIdConfigMapDrift(ctx, requiredSecret)).To(Succeed())
+
+				Expect(detector.ClusterIdFromOperatorConfigMap()).To(Equal("cluster-1"))
+			})
+		})
+
+		Context("when the ConfigMap cluster ID differs from the manager secret", func() {
+			BeforeEach(func() {
+				cm := operatorConfigMap("old-cluster-id")
+				k8sClient = newFakeClient(cm, requiredSecret)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+				detector.InitializeFromSecret(requiredSecret)
+			})
+
+			It("should return nil but annotate the required secret with the old cluster ID", func() {
+				result := detector.CheckClusterIdConfigMapDrift(ctx, requiredSecret)
+
+				Expect(result).To(BeNil())
+				Expect(requiredSecret.Annotations).To(HaveKeyWithValue(
+					previousClusterIdAnnotationKey, "old-cluster-id",
+				))
+			})
+
+			It("should track the ConfigMap's cluster ID", func() {
+				Expect(detector.CheckClusterIdConfigMapDrift(ctx, requiredSecret)).To(Succeed())
+
+				Expect(detector.ClusterIdFromOperatorConfigMap()).To(Equal("old-cluster-id"))
+			})
+		})
+
+		Context("error paths", func() {
+			It("should return GettingSapBtpServiceOperatorConfigMapFailed when the ConfigMap fetch fails", func() {
+				badClient := newErrorOnGetClient(newFakeClient())
+				detector = drift.NewDetector(badClient, badClient)
+				detector.InitializeFromSecret(requiredSecret)
+
+				result := detector.CheckClusterIdConfigMapDrift(ctx, requiredSecret)
+
+				Expect(result).NotTo(BeNil())
+				Expect(result.Reason).To(Equal(conditions.GettingSapBtpServiceOperatorConfigMapFailed))
+			})
+
+			It("should return AnnotatingSecretFailed when annotating the secret fails", func() {
+				cm := operatorConfigMap("old-cluster-id")
+				// Get must succeed (to return ConfigMap); Update must fail (to trigger annotation error).
+				k8sClient = newErrorOnUpdateClient(newFakeClient(cm, requiredSecret))
+				detector = drift.NewDetector(k8sClient, newFakeClient())
+				detector.InitializeFromSecret(requiredSecret)
+
+				result := detector.CheckClusterIdConfigMapDrift(ctx, requiredSecret)
+
+				Expect(result).NotTo(BeNil())
+				Expect(result.Reason).To(Equal(conditions.AnnotatingSecretFailed))
+			})
+		})
+	})
+
+	Describe("CheckClusterIdSecretDrift", func() {
+		var requiredSecret *corev1.Secret
+
+		BeforeEach(func() {
+			requiredSecret = btpManagerSecret("cluster-1", kymaNamespace, nil)
+		})
+
+		Context("when no cluster ID secret exists", func() {
+			BeforeEach(func() {
+				k8sClient = newFakeClient()
+				detector = drift.NewDetector(k8sClient, k8sClient)
+				detector.InitializeFromSecret(requiredSecret)
+			})
+
+			It("should return nil (no drift)", func() {
+				result := detector.CheckClusterIdSecretDrift(ctx, requiredSecret)
+
+				Expect(result).To(BeNil())
+			})
+		})
+
+		Context("when the cluster ID secret matches the ConfigMap value", func() {
+			BeforeEach(func() {
+				cidSecret := clusterIdSecret(kymaNamespace, "cluster-1")
+				k8sClient = newFakeClient(cidSecret)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+				detector.InitializeFromSecret(requiredSecret)
+				detector.SetClusterIdFromOperatorConfigMap("cluster-1")
+			})
+
+			It("should return nil (no drift)", func() {
+				result := detector.CheckClusterIdSecretDrift(ctx, requiredSecret)
+
+				Expect(result).To(BeNil())
+			})
+
+			It("should track the cluster ID secret's value", func() {
+				Expect(detector.CheckClusterIdSecretDrift(ctx, requiredSecret)).To(Succeed())
+
+				Expect(detector.ClusterIdFromOperatorClusterIdSecret()).To(Equal("cluster-1"))
+			})
+		})
+
+		Context("when the cluster ID secret differs from the ConfigMap value", func() {
+			var cidSecret *corev1.Secret
+
+			BeforeEach(func() {
+				cidSecret = clusterIdSecret(kymaNamespace, "stale-cluster-id")
+				pod := operatorPod(operandName+"-controller-manager-abc", kymaNamespace, corev1.ConditionFalse)
+				k8sClient = newFakeClient(cidSecret, pod, requiredSecret)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+				detector.InitializeFromSecret(requiredSecret)
+				detector.SetClusterIdFromOperatorConfigMap("cluster-1")
+			})
+
+			It("should annotate the required secret with the stale cluster ID", func() {
+				Expect(detector.CheckClusterIdSecretDrift(ctx, requiredSecret)).To(Succeed())
+
+				Expect(requiredSecret.Annotations).To(HaveKeyWithValue(
+					previousClusterIdAnnotationKey, "stale-cluster-id",
+				))
+			})
+
+			It("should delete the stale cluster ID secret", func() {
+				result := detector.CheckClusterIdSecretDrift(ctx, requiredSecret)
+
+				Expect(result).To(BeNil())
+
+				secret := &corev1.Secret{}
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(cidSecret), secret)
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should restart the not-ready operator pod", func() {
+				result := detector.CheckClusterIdSecretDrift(ctx, requiredSecret)
+
+				Expect(result).To(BeNil())
+
+				pods := &corev1.PodList{}
+				Expect(k8sClient.List(ctx, pods, client.MatchingLabels{instanceLabelKey: operandName})).To(Succeed())
+				Expect(pods.Items).To(BeEmpty())
+			})
+		})
+
+		Context("when the cluster ID secret differs but the operator pod is ready", func() {
+			BeforeEach(func() {
+				cidSecret := clusterIdSecret(kymaNamespace, "stale-cluster-id")
+				pod := operatorPod(operandName+"-controller-manager-abc", kymaNamespace, corev1.ConditionTrue)
+				k8sClient = newFakeClient(cidSecret, pod, requiredSecret)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+				detector.InitializeFromSecret(requiredSecret)
+				detector.SetClusterIdFromOperatorConfigMap("cluster-1")
+			})
+
+			It("should not delete the ready pod", func() {
+				Expect(detector.CheckClusterIdSecretDrift(ctx, requiredSecret)).To(Succeed())
+
+				pods := &corev1.PodList{}
+				Expect(k8sClient.List(ctx, pods, client.MatchingLabels{instanceLabelKey: operandName})).To(Succeed())
+				Expect(pods.Items).To(HaveLen(1))
+			})
+		})
+
+		Context("when the cluster ID secret differs but the labelled pod is in a different namespace", func() {
+			BeforeEach(func() {
+				cidSecret := clusterIdSecret(kymaNamespace, "stale-cluster-id")
+				podInWrongNs := operatorPod(operandName+"-abc", "other-namespace", corev1.ConditionFalse)
+				k8sClient = newFakeClient(cidSecret, podInWrongNs, requiredSecret)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+				detector.InitializeFromSecret(requiredSecret)
+				detector.SetClusterIdFromOperatorConfigMap("cluster-1")
+			})
+
+			It("should not restart a pod outside ChartNamespace", func() {
+				Expect(detector.CheckClusterIdSecretDrift(ctx, requiredSecret)).To(Succeed())
+
+				pods := &corev1.PodList{}
+				Expect(k8sClient.List(ctx, pods, client.MatchingLabels{instanceLabelKey: operandName})).To(Succeed())
+				Expect(pods.Items).To(HaveLen(1))
+			})
+		})
+
+		Context("error paths", func() {
+			It("should return GettingSapBtpServiceOperatorClusterIdSecretFailed when the cluster ID secret fetch fails", func() {
+				badApiClient := newErrorOnGetClient(newFakeClient())
+				detector = drift.NewDetector(k8sClient, badApiClient)
+				detector.InitializeFromSecret(requiredSecret)
+
+				result := detector.CheckClusterIdSecretDrift(ctx, requiredSecret)
+
+				Expect(result).NotTo(BeNil())
+				Expect(result.Reason).To(Equal(conditions.GettingSapBtpServiceOperatorClusterIdSecretFailed))
+			})
+
+			It("should return AnnotatingSecretFailed when annotating the required secret fails", func() {
+				cidSecret := clusterIdSecret(kymaNamespace, "stale-cluster-id")
+				// Get must succeed (apiServerClient); Update must fail (cached client).
+				apiServerClient := newFakeClient(cidSecret)
+				cachedClient := newErrorOnUpdateClient(newFakeClient(requiredSecret))
+				detector = drift.NewDetector(cachedClient, apiServerClient)
+				detector.InitializeFromSecret(requiredSecret)
+				detector.SetClusterIdFromOperatorConfigMap("cluster-1")
+
+				result := detector.CheckClusterIdSecretDrift(ctx, requiredSecret)
+
+				Expect(result).NotTo(BeNil())
+				Expect(result.Reason).To(Equal(conditions.AnnotatingSecretFailed))
+			})
+
+			It("should return DeletionOfOrphanedResourcesFailed when deleting the cluster ID secret fails", func() {
+				cidSecret := clusterIdSecret(kymaNamespace, "stale-cluster-id")
+				// Get must succeed; Update must succeed; Delete must fail.
+				apiServerClient := newErrorOnDeleteClient(newFakeClient(cidSecret))
+				cachedClient := newFakeClient(requiredSecret)
+				detector = drift.NewDetector(cachedClient, apiServerClient)
+				detector.InitializeFromSecret(requiredSecret)
+				detector.SetClusterIdFromOperatorConfigMap("cluster-1")
+
+				result := detector.CheckClusterIdSecretDrift(ctx, requiredSecret)
+
+				Expect(result).NotTo(BeNil())
+				Expect(result.Reason).To(Equal(conditions.DeletionOfOrphanedResourcesFailed))
+			})
+
+			It("should return ResourceRemovalFailed when restarting the operator pod fails", func() {
+				cidSecret := clusterIdSecret(kymaNamespace, "stale-cluster-id")
+				notReadyPod := operatorPod(operandName+"-abc", kymaNamespace, corev1.ConditionFalse)
+				// Get/Delete must succeed; List must fail to simulate pod listing failure during restart.
+				apiServerClient := newErrorOnListClient(newFakeClient(cidSecret, notReadyPod))
+				cachedClient := newFakeClient(requiredSecret)
+				detector = drift.NewDetector(cachedClient, apiServerClient)
+				detector.InitializeFromSecret(requiredSecret)
+				detector.SetClusterIdFromOperatorConfigMap("cluster-1")
+
+				result := detector.CheckClusterIdSecretDrift(ctx, requiredSecret)
+
+				Expect(result).NotTo(BeNil())
+				Expect(result.Reason).To(Equal(conditions.ResourceRemovalFailed))
+			})
+		})
+	})
+
+	Describe("DeleteChangedResources", func() {
+		// DeleteChangedResources relies on internal state populated by the
+		// Check* methods. These tests simulate the real reconciler workflow:
+		// InitializeFromSecret → Check* → DeleteChangedResources.
+
+		Context("when nothing changed", func() {
+			BeforeEach(func() {
+				cidSecret := clusterIdSecret(kymaNamespace, "cluster-1")
+				cm := operatorConfigMap("cluster-1")
+				opSecret := operatorSecret(kymaNamespace)
+				pod := operatorPod(operandName+"-abc", kymaNamespace, corev1.ConditionTrue)
+				requiredSecret := btpManagerSecret("cluster-1", kymaNamespace, nil)
+				k8sClient = newFakeClient(cidSecret, cm, opSecret, pod, requiredSecret)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+
+				detector.InitializeFromSecret(requiredSecret)
+				Expect(detector.CheckCredentialsNamespaceDrift(ctx, requiredSecret)).To(Succeed())
+				Expect(detector.CheckClusterIdConfigMapDrift(ctx, requiredSecret)).To(Succeed())
+				Expect(detector.CheckClusterIdSecretDrift(ctx, requiredSecret)).To(Succeed())
+			})
+
+			It("should not delete any resources", func() {
+				err := detector.DeleteChangedResources(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				secrets := &corev1.SecretList{}
+				Expect(k8sClient.List(ctx, secrets)).To(Succeed())
+				secretNames := extractSecretNames(secrets.Items)
+				Expect(secretNames).To(ContainElements(
+					sapBtpServiceOperatorSecretName,
+					sapBtpServiceOperatorClusterIdSecretName,
+				))
+
+				pods := &corev1.PodList{}
+				Expect(k8sClient.List(ctx, pods)).To(Succeed())
+				Expect(pods.Items).To(HaveLen(1))
+			})
+		})
+
+		Context("when cluster ID changed (manager secret differs from ConfigMap)", func() {
+			BeforeEach(func() {
+				cidSecret := clusterIdSecret(kymaNamespace, "old-cluster")
+				cm := operatorConfigMap("old-cluster")
+				opSecret := operatorSecret(kymaNamespace)
+				pod := operatorPod(operandName+"-abc", kymaNamespace, corev1.ConditionTrue)
+				requiredSecret := btpManagerSecret("new-cluster", kymaNamespace, nil)
+				k8sClient = newFakeClient(cidSecret, cm, opSecret, pod, requiredSecret)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+
+				detector.InitializeFromSecret(requiredSecret)
+				Expect(detector.CheckCredentialsNamespaceDrift(ctx, requiredSecret)).To(Succeed())
+				Expect(detector.CheckClusterIdConfigMapDrift(ctx, requiredSecret)).To(Succeed())
+				Expect(detector.CheckClusterIdSecretDrift(ctx, requiredSecret)).To(Succeed())
+			})
+
+			It("should delete the cluster ID secret and the operator pod", func() {
+				err := detector.DeleteChangedResources(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				pods := &corev1.PodList{}
+				Expect(k8sClient.List(ctx, pods)).To(Succeed())
+				Expect(pods.Items).To(BeEmpty())
+
+				secrets := &corev1.SecretList{}
+				Expect(k8sClient.List(ctx, secrets)).To(Succeed())
+				secretNames := extractSecretNames(secrets.Items)
+				Expect(secretNames).NotTo(ContainElement(sapBtpServiceOperatorClusterIdSecretName))
+			})
+
+			It("should not delete the operator credentials secret", func() {
+				err := detector.DeleteChangedResources(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				secrets := &corev1.SecretList{}
+				Expect(k8sClient.List(ctx, secrets)).To(Succeed())
+				secretNames := extractSecretNames(secrets.Items)
+				Expect(secretNames).To(ContainElement(sapBtpServiceOperatorSecretName))
+			})
+		})
+
+		Context("when credentials namespace changed", func() {
+			BeforeEach(func() {
+				cidSecret := clusterIdSecret("old-ns", "cluster-1")
+				opSecret := operatorSecret("old-ns")
+				pod := operatorPod(operandName+"-abc", kymaNamespace, corev1.ConditionTrue)
+				requiredSecret := btpManagerSecret("cluster-1", "new-ns", nil)
+				k8sClient = newFakeClient(cidSecret, opSecret, pod, requiredSecret)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+
+				detector.InitializeFromSecret(requiredSecret)
+				Expect(detector.CheckCredentialsNamespaceDrift(ctx, requiredSecret)).To(Succeed())
+			})
+
+			It("should delete the cluster ID secret, the operator pod, and the credentials secret", func() {
+				err := detector.DeleteChangedResources(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				pods := &corev1.PodList{}
+				Expect(k8sClient.List(ctx, pods)).To(Succeed())
+				Expect(pods.Items).To(BeEmpty())
+
+				secrets := &corev1.SecretList{}
+				Expect(k8sClient.List(ctx, secrets)).To(Succeed())
+				secretNames := extractSecretNames(secrets.Items)
+				Expect(secretNames).NotTo(ContainElement(sapBtpServiceOperatorClusterIdSecretName))
+				Expect(secretNames).NotTo(ContainElement(sapBtpServiceOperatorSecretName))
+			})
+		})
+
+		Context("when resources targeted for deletion are already absent", func() {
+			BeforeEach(func() {
+				cm := operatorConfigMap("old-cluster")
+				requiredSecret := btpManagerSecret("new-cluster", kymaNamespace, nil)
+				k8sClient = newFakeClient(cm, requiredSecret)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+
+				detector.InitializeFromSecret(requiredSecret)
+				Expect(detector.CheckClusterIdConfigMapDrift(ctx, requiredSecret)).To(Succeed())
+			})
+
+			It("should succeed without errors", func() {
+				err := detector.DeleteChangedResources(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("DeleteClusterIdSecret", func() {
+		Context("when the cluster ID secret exists", func() {
+			BeforeEach(func() {
+				cidSecret := clusterIdSecret(kymaNamespace, "cluster-1")
+				k8sClient = newFakeClient(cidSecret)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+
+				managerSecret := btpManagerSecret("cluster-1", kymaNamespace, nil)
+				detector.InitializeFromSecret(managerSecret)
+			})
+
+			It("should delete it", func() {
+				err := detector.DeleteClusterIdSecret(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				secrets := &corev1.SecretList{}
+				Expect(k8sClient.List(ctx, secrets)).To(Succeed())
+				Expect(secrets.Items).To(BeEmpty())
+			})
+		})
+
+		Context("when the cluster ID secret does not exist", func() {
+			BeforeEach(func() {
+				k8sClient = newFakeClient()
+				detector = drift.NewDetector(k8sClient, k8sClient)
+
+				managerSecret := btpManagerSecret("cluster-1", kymaNamespace, nil)
+				detector.InitializeFromSecret(managerSecret)
+			})
+
+			It("should succeed without errors", func() {
+				err := detector.DeleteClusterIdSecret(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+})
+
+func extractSecretNames(secrets []corev1.Secret) []string {
+	names := make([]string, 0, len(secrets))
+	for _, s := range secrets {
+		names = append(names, s.Name)
+	}
+	return names
+}

--- a/internal/credentials/drift/suite_test.go
+++ b/internal/credentials/drift/suite_test.go
@@ -1,0 +1,176 @@
+package drift_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	kymaNamespace = "kyma-system"
+
+	sapBtpManagerSecretName                 = "sap-btp-manager"
+	sapBtpServiceOperatorSecretName         = "sap-btp-service-operator"
+	sapBtpServiceOperatorClusterIdSecretName = "sap-btp-operator-clusterid"
+	sapBtpServiceOperatorConfigMapName      = "sap-btp-operator-config"
+	operandName                             = "sap-btp-operator"
+
+	managedByLabelKey = "app.kubernetes.io/managed-by"
+	instanceLabelKey  = "app.kubernetes.io/instance"
+	operatorName      = "btp-manager"
+
+	clusterIdSecretKey            = "cluster_id"
+	credentialsNamespaceSecretKey = "credentials_namespace"
+	initialClusterIdSecretKey     = "INITIAL_CLUSTER_ID"
+	clusterIdConfigMapKey         = "CLUSTER_ID"
+
+	previousClusterIdAnnotationKey            = "operator.kyma-project.io/previous-cluster-id"
+	previousCredentialsNamespaceAnnotationKey = "operator.kyma-project.io/previous-credentials-namespace"
+)
+
+var scheme *runtime.Scheme
+
+func TestDriftDetector(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Drift Detector Suite")
+}
+
+var _ = BeforeSuite(func() {
+	scheme = runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+})
+
+func newFakeClient(objects ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		Build()
+}
+
+func btpManagerSecret(clusterID, credentialsNamespace string, annotations map[string]string) *corev1.Secret {
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        sapBtpManagerSecretName,
+			Namespace:   kymaNamespace,
+			Annotations: annotations,
+		},
+		Data: map[string][]byte{
+			clusterIdSecretKey: []byte(clusterID),
+		},
+	}
+	if credentialsNamespace != "" {
+		s.Data[credentialsNamespaceSecretKey] = []byte(credentialsNamespace)
+	}
+	return s
+}
+
+func operatorSecret(namespace string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sapBtpServiceOperatorSecretName,
+			Namespace: namespace,
+			Labels:    map[string]string{managedByLabelKey: operatorName},
+		},
+	}
+}
+
+func clusterIdSecret(namespace, initialClusterID string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sapBtpServiceOperatorClusterIdSecretName,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			initialClusterIdSecretKey: []byte(initialClusterID),
+		},
+	}
+}
+
+func operatorConfigMap(clusterID string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sapBtpServiceOperatorConfigMapName,
+			Namespace: kymaNamespace,
+		},
+		Data: map[string]string{
+			clusterIdConfigMapKey: clusterID,
+		},
+	}
+}
+
+func operatorPod(name, namespace string, ready corev1.ConditionStatus) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{instanceLabelKey: operandName},
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: ready},
+			},
+		},
+	}
+}
+
+// errorOnGetClient wraps a real client and forces Get calls to fail.
+type errorOnGetClient struct {
+	client.Client
+}
+
+func newErrorOnGetClient(inner client.Client) client.Client {
+	return &errorOnGetClient{Client: inner}
+}
+
+func (c *errorOnGetClient) Get(_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+	return fmt.Errorf("simulated Get error")
+}
+
+// errorOnListClient wraps a real client and forces List calls to fail.
+type errorOnListClient struct {
+	client.Client
+}
+
+func newErrorOnListClient(inner client.Client) client.Client {
+	return &errorOnListClient{Client: inner}
+}
+
+func (c *errorOnListClient) List(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
+	return fmt.Errorf("simulated List error")
+}
+
+// errorOnUpdateClient wraps a real client and forces Update calls to fail.
+type errorOnUpdateClient struct {
+	client.Client
+}
+
+func newErrorOnUpdateClient(inner client.Client) client.Client {
+	return &errorOnUpdateClient{Client: inner}
+}
+
+func (c *errorOnUpdateClient) Update(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+	return fmt.Errorf("simulated Update error")
+}
+
+// errorOnDeleteClient wraps a real client and forces Delete calls to fail.
+type errorOnDeleteClient struct {
+	client.Client
+}
+
+func newErrorOnDeleteClient(inner client.Client) client.Client {
+	return &errorOnDeleteClient{Client: inner}
+}
+
+func (c *errorOnDeleteClient) Delete(_ context.Context, _ client.Object, _ ...client.DeleteOption) error {
+	return fmt.Errorf("simulated Delete error")
+}

--- a/internal/manager/moduleresource/manager.go
+++ b/internal/manager/moduleresource/manager.go
@@ -152,22 +152,20 @@ func (m *Manager) ResourcesOfKinds(resources []*unstructured.Unstructured, kinds
 }
 
 func (m *Manager) PrepareModuleResources(ctx context.Context, resourcesToApply []*unstructured.Unstructured, s *corev1.Secret) error {
-	var configMapIndex, secretIndex, deploymentIndex int
+	configMapIndex, secretIndex, deploymentIndex := -1, -1, -1
 	for i, u := range resourcesToApply {
-		if u.GetName() == SapBtpServiceOperatorName+"-config" && u.GetKind() == "ConfigMap" {
+		switch {
+		case u.GetName() == "sap-btp-operator-config" && u.GetKind() == "ConfigMap":
 			configMapIndex = i
-			continue
-		}
-		if u.GetName() == SapBtpServiceOperatorName && u.GetKind() == "Secret" {
+		case u.GetName() == SapBtpServiceOperatorName && u.GetKind() == "Secret":
 			secretIndex = i
-			continue
-		}
-		if u.GetName() == config.DeploymentName && u.GetKind() == DeploymentKind {
+		case u.GetName() == config.DeploymentName && u.GetKind() == DeploymentKind:
 			deploymentIndex = i
-			continue
 		}
 	}
-
+	if configMapIndex < 0 || secretIndex < 0 || deploymentIndex < 0 {
+		return fmt.Errorf("required module resources not found in manifests (configMapIndex=%d, secretIndex=%d, deploymentIndex=%d)", configMapIndex, secretIndex, deploymentIndex)
+	}
 	chartVer, err := ymlutils.ExtractStringValueFromYamlForGivenKey(fmt.Sprintf("%s/Chart.yaml", config.ChartPath), "version")
 	if err != nil {
 		return fmt.Errorf("failed to get module chart version: %w", err)

--- a/internal/manager/moduleresource/manager.go
+++ b/internal/manager/moduleresource/manager.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/kyma-project/btp-manager/controllers/config"
 	"github.com/kyma-project/btp-manager/internal/manifest"
+	"github.com/kyma-project/btp-manager/internal/ymlutils"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -49,105 +50,55 @@ const (
 
 	sapBtpServiceOperatorContainerName = "manager"
 	kubeRbacProxyContainerName         = KubeRbacProxyName
-
-	operatorLabelPrefix                       = "operator.kyma-project.io/"
-	previousCredentialsNamespaceAnnotationKey = operatorLabelPrefix + "previous-credentials-namespace"
 )
+
+// CredentialsProvider gives the module resource manager the authoritative credential
+// values it needs to configure the operand's ConfigMap and Secret.
+// drift.DriftDetector satisfies this interface via Go's structural typing.
+type CredentialsProvider interface {
+	CredentialsNamespaceFromManager() string
+	ClusterIdFromManager() string
+}
 
 type Metadata struct {
 	Kind string
 	Name string
 }
 
-type credentialsContext struct {
-	previousCredentialsNamespace                        string
-	clusterIdFromSapBtpManagerSecret                    string
-	clusterIdFromSapBtpServiceOperatorConfigMap         string
-	clusterIdFromSapBtpServiceOperatorClusterIdSecret   string
-	credentialsNamespaceFromSapBtpManagerSecret         string
-	credentialsNamespaceFromSapBtpServiceOperatorSecret string
+type ResourceManager interface {
+	CreateUnstructuredObjectsFromManifestsDir(manifestsDir string) ([]*unstructured.Unstructured, error)
+	ResourcesOfKinds(resources []*unstructured.Unstructured, kinds ...string) (matching, rest []*unstructured.Unstructured)
+	PrepareModuleResources(ctx context.Context, resourcesToApply []*unstructured.Unstructured, s *corev1.Secret) error
+	ApplyOrUpdateResources(ctx context.Context, us []*unstructured.Unstructured) error
+	WaitForResourcesReadiness(ctx context.Context, us []*unstructured.Unstructured) error
+	DeleteOutdatedResources(ctx context.Context) error
+	DeleteResources(ctx context.Context, us []*unstructured.Unstructured) error
+	DeleteCreationTimestamp(us ...*unstructured.Unstructured)
+	GetResourcesToApplyPath() string
+	GetResourcesToDeletePath() string
 }
 
 type Manager struct {
-	client             client.Client
-	scheme             *runtime.Scheme
-	manifestHandler    *manifest.Handler
-	resourceIndices    map[Metadata]int
-	credentialsContext credentialsContext
+	client          client.Client
+	scheme          *runtime.Scheme
+	manifestHandler *manifest.Handler
+	resourceIndices map[Metadata]int
+	driftDetector   CredentialsProvider
 }
 
-func NewManager(client client.Client, scheme *runtime.Scheme) *Manager {
+func NewManager(client client.Client, scheme *runtime.Scheme, driftDetector CredentialsProvider) *Manager {
 	return &Manager{
 		client:          client,
 		scheme:          scheme,
 		manifestHandler: &manifest.Handler{Scheme: scheme},
 		resourceIndices: make(map[Metadata]int),
+		driftDetector:   driftDetector,
 	}
 }
 
-func (m *Manager) getRequiredSecret(ctx context.Context) (*corev1.Secret, error) {
-	secret := &corev1.Secret{}
-	objKey := client.ObjectKey{Namespace: config.ChartNamespace, Name: config.SecretName}
-	if err := m.client.Get(ctx, objKey, secret); err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil, errors.Join(err, fmt.Errorf("%s Secret in %s namespace not found", config.SecretName, config.ChartNamespace))
-		}
-		return nil, fmt.Errorf("unable to get Secret: %w", err)
-	}
+var _ ResourceManager = (*Manager)(nil)
 
-	return secret, nil
-}
-
-func (m *Manager) verifySecret(secret *corev1.Secret) error {
-	missingKeys := make([]string, 0)
-	missingValues := make([]string, 0)
-	errs := make([]string, 0)
-	requiredKeys := []string{ClientIdSecretKey, ClientSecretKey, SmUrlSecretKey, TokenUrlSecretKey, ClusterIdSecretKey}
-	for _, key := range requiredKeys {
-		value, exists := secret.Data[key]
-		if !exists {
-			missingKeys = append(missingKeys, key)
-			continue
-		}
-		if len(value) == 0 {
-			missingValues = append(missingValues, key)
-		}
-	}
-	if len(missingKeys) > 0 {
-		missingKeysMsg := fmt.Sprintf("key(s) %s not found", strings.Join(missingKeys, ", "))
-		errs = append(errs, missingKeysMsg)
-	}
-	if len(missingValues) > 0 {
-		missingValuesMsg := fmt.Sprintf("missing value(s) for %s key(s)", strings.Join(missingValues, ", "))
-		errs = append(errs, missingValuesMsg)
-	}
-	if len(errs) > 0 {
-		return fmt.Errorf("%s", strings.Join(errs, ", "))
-	}
-	return nil
-}
-
-func (m *Manager) setCredentialsContext(s *corev1.Secret) {
-	m.setClusterID(s)
-	m.setCredentialsNamespace(s)
-}
-
-func (m *Manager) setCredentialsNamespace(s *corev1.Secret) {
-	credentialsNamespace := config.ChartNamespace
-	if s != nil {
-		if v, ok := s.Data[CredentialsNamespaceSecretKey]; ok && len(v) > 0 {
-			credentialsNamespace = string(v)
-		}
-		m.credentialsContext.previousCredentialsNamespace = s.Annotations[previousCredentialsNamespaceAnnotationKey]
-	}
-	m.credentialsContext.credentialsNamespaceFromSapBtpManagerSecret = credentialsNamespace
-}
-
-func (m *Manager) setClusterID(s *corev1.Secret) {
-	m.credentialsContext.clusterIdFromSapBtpManagerSecret = string(s.Data[ClusterIdSecretKey])
-}
-
-func (m *Manager) createUnstructuredObjectsFromManifestsDir(manifestsDir string) ([]*unstructured.Unstructured, error) {
+func (m *Manager) CreateUnstructuredObjectsFromManifestsDir(manifestsDir string) ([]*unstructured.Unstructured, error) {
 	objects, err := m.manifestHandler.CollectObjectsFromDir(manifestsDir)
 	if err != nil {
 		return nil, fmt.Errorf("while collecting objects from directory %s: %w", manifestsDir, err)
@@ -173,7 +124,80 @@ func (m *Manager) indexModuleResources(unstructuredObjects []*unstructured.Unstr
 	}
 }
 
-func (m *Manager) addLabels(chartVersion string, us ...*unstructured.Unstructured) error {
+// ResourcesOfKinds partitions resources into two slices: those whose kind is
+// listed in kinds (matching) and everything else (rest). The partition is based
+// on the index built during manifest loading, so resources appended after
+// loading (e.g. network policies) are always placed in rest regardless of kind.
+func (m *Manager) ResourcesOfKinds(resources []*unstructured.Unstructured, kinds ...string) (matching, rest []*unstructured.Unstructured) {
+	kindSet := make(map[string]struct{}, len(kinds))
+	for _, k := range kinds {
+		kindSet[k] = struct{}{}
+	}
+
+	matchingIndices := make(map[int]struct{})
+	for meta, idx := range m.resourceIndices {
+		if _, ok := kindSet[meta.Kind]; ok {
+			matchingIndices[idx] = struct{}{}
+		}
+	}
+
+	for i, r := range resources {
+		if _, ok := matchingIndices[i]; ok {
+			matching = append(matching, r)
+		} else {
+			rest = append(rest, r)
+		}
+	}
+	return
+}
+
+func (m *Manager) PrepareModuleResources(ctx context.Context, resourcesToApply []*unstructured.Unstructured, s *corev1.Secret) error {
+	var configMapIndex, secretIndex, deploymentIndex int
+	for i, u := range resourcesToApply {
+		if u.GetName() == SapBtpServiceOperatorName+"-config" && u.GetKind() == "ConfigMap" {
+			configMapIndex = i
+			continue
+		}
+		if u.GetName() == SapBtpServiceOperatorName && u.GetKind() == "Secret" {
+			secretIndex = i
+			continue
+		}
+		if u.GetName() == config.DeploymentName && u.GetKind() == DeploymentKind {
+			deploymentIndex = i
+			continue
+		}
+	}
+
+	chartVer, err := ymlutils.ExtractStringValueFromYamlForGivenKey(fmt.Sprintf("%s/Chart.yaml", config.ChartPath), "version")
+	if err != nil {
+		return fmt.Errorf("failed to get module chart version: %w", err)
+	}
+
+	if err := m.AddLabels(chartVer, resourcesToApply...); err != nil {
+		return fmt.Errorf("failed to add labels to resources: %w", err)
+	}
+	m.SetNamespace(resourcesToApply)
+
+	if err := m.SetConfigMapValues(resourcesToApply[configMapIndex]); err != nil {
+		return fmt.Errorf("failed to set ConfigMap values: %w", err)
+	}
+	if err := m.SetSecretValues(s, resourcesToApply[secretIndex]); err != nil {
+		return fmt.Errorf("failed to set Secret values: %w", err)
+	}
+	if err := m.SetDeploymentImages(resourcesToApply[deploymentIndex]); err != nil {
+		return fmt.Errorf("failed to set container images in Deployment: %w", err)
+	}
+
+	return nil
+}
+
+func (m *Manager) DeleteCreationTimestamp(us ...*unstructured.Unstructured) {
+	for _, u := range us {
+		unstructured.RemoveNestedField(u.Object, "metadata", "creationTimestamp")
+	}
+}
+
+func (m *Manager) AddLabels(chartVersion string, us ...*unstructured.Unstructured) error {
 	for _, u := range us {
 		labels := u.GetLabels()
 		if len(labels) == 0 {
@@ -208,22 +232,25 @@ func (m *Manager) addLabelsInPodTemplate(u *unstructured.Unstructured) error {
 	return nil
 }
 
-func (m *Manager) setNamespace(us []*unstructured.Unstructured) {
+func (m *Manager) SetNamespace(us []*unstructured.Unstructured) {
 	for _, u := range us {
 		u.SetNamespace(config.ChartNamespace)
 	}
 }
 
-func (m *Manager) setConfigMapValues(secret *corev1.Secret, u *unstructured.Unstructured) error {
-	if err := unstructured.SetNestedField(u.Object, string(secret.Data[ClusterIdSecretKey]), "data", clusterIdConfigMapKey); err != nil {
+func (m *Manager) SetConfigMapValues(u *unstructured.Unstructured) error {
+	credentialsNamespace := m.driftDetector.CredentialsNamespaceFromManager()
+	clusterId := m.driftDetector.ClusterIdFromManager()
+
+	if err := unstructured.SetNestedField(u.Object, clusterId, "data", clusterIdConfigMapKey); err != nil {
 		return fmt.Errorf("failed to set cluster_id: %w", err)
 	}
 
-	if err := unstructured.SetNestedField(u.Object, m.credentialsContext.credentialsNamespaceFromSapBtpManagerSecret, "data", releaseNamespaceConfigMapKey); err != nil {
+	if err := unstructured.SetNestedField(u.Object, credentialsNamespace, "data", releaseNamespaceConfigMapKey); err != nil {
 		return fmt.Errorf("failed to set release namespace: %w", err)
 	}
 
-	if err := unstructured.SetNestedField(u.Object, m.credentialsContext.credentialsNamespaceFromSapBtpManagerSecret, "data", managementNamespaceConfigMapKey); err != nil {
+	if err := unstructured.SetNestedField(u.Object, credentialsNamespace, "data", managementNamespaceConfigMapKey); err != nil {
 		return fmt.Errorf("failed to set management namespace: %w", err)
 	}
 
@@ -234,8 +261,8 @@ func (m *Manager) setConfigMapValues(secret *corev1.Secret, u *unstructured.Unst
 	return nil
 }
 
-func (m *Manager) setSecretValues(secret *corev1.Secret, u *unstructured.Unstructured) error {
-	u.SetNamespace(m.credentialsContext.credentialsNamespaceFromSapBtpManagerSecret)
+func (m *Manager) SetSecretValues(secret *corev1.Secret, u *unstructured.Unstructured) error {
+	u.SetNamespace(m.driftDetector.CredentialsNamespaceFromManager())
 
 	for k := range secret.Data {
 		if k == ClusterIdSecretKey || k == CredentialsNamespaceSecretKey {
@@ -249,7 +276,7 @@ func (m *Manager) setSecretValues(secret *corev1.Secret, u *unstructured.Unstruc
 	return nil
 }
 
-func (m *Manager) setDeploymentImages(u *unstructured.Unstructured) error {
+func (m *Manager) SetDeploymentImages(u *unstructured.Unstructured) error {
 	sapBtpServiceOperatorImage := os.Getenv(SapBtpServiceOperatorEnv)
 	kubeRbacProxyImage := os.Getenv(KubeRbacProxyEnv)
 	if err := m.setContainerImage(u, sapBtpServiceOperatorContainerName, sapBtpServiceOperatorImage); err != nil {
@@ -293,19 +320,31 @@ func (m *Manager) setContainerImage(u *unstructured.Unstructured, containerName,
 }
 
 func (m *Manager) applyModuleResources(ctx context.Context) error {
-	objects, err := m.createUnstructuredObjectsFromManifestsDir(resourcesToApplyPath())
+	objects, err := m.CreateUnstructuredObjectsFromManifestsDir(GetResourcesToApplyPath())
 	if err != nil {
 		return nil
 	}
 
-	return m.applyOrUpdateResources(ctx, objects)
+	return m.ApplyOrUpdateResources(ctx, objects)
 }
 
-func resourcesToApplyPath() string {
+func GetResourcesToApplyPath() string {
 	return fmt.Sprintf("%s%capply", config.ResourcesPath, os.PathSeparator)
 }
 
-func (m *Manager) applyOrUpdateResources(ctx context.Context, us []*unstructured.Unstructured) error {
+func GetResourcesToDeletePath() string {
+	return fmt.Sprintf("%s%cdelete", config.ResourcesPath, os.PathSeparator)
+}
+
+func (m *Manager) GetResourcesToApplyPath() string {
+	return GetResourcesToApplyPath()
+}
+
+func (m *Manager) GetResourcesToDeletePath() string {
+	return GetResourcesToDeletePath()
+}
+
+func (m *Manager) ApplyOrUpdateResources(ctx context.Context, us []*unstructured.Unstructured) error {
 	for _, u := range us {
 		if err := m.applyOrUpdateResource(ctx, u); err != nil {
 			return err
@@ -341,20 +380,16 @@ func (m *Manager) updateResource(ctx context.Context, u *unstructured.Unstructur
 	return nil
 }
 
-func (m *Manager) deleteOutdatedResources(ctx context.Context) error {
-	objects, err := m.createUnstructuredObjectsFromManifestsDir(resourcesToDeletePath())
+func (m *Manager) DeleteOutdatedResources(ctx context.Context) error {
+	objects, err := m.CreateUnstructuredObjectsFromManifestsDir(GetResourcesToDeletePath())
 	if err != nil {
 		return nil
 	}
 
-	return m.deleteResources(ctx, objects)
+	return m.DeleteResources(ctx, objects)
 }
 
-func resourcesToDeletePath() string {
-	return fmt.Sprintf("%s%cdelete", config.ResourcesPath, os.PathSeparator)
-}
-
-func (m *Manager) deleteResources(ctx context.Context, us []*unstructured.Unstructured) error {
+func (m *Manager) DeleteResources(ctx context.Context, us []*unstructured.Unstructured) error {
 	var errs []string
 	for _, u := range us {
 		if err := m.client.Delete(ctx, u); err != nil {
@@ -369,7 +404,7 @@ func (m *Manager) deleteResources(ctx context.Context, us []*unstructured.Unstru
 	return nil
 }
 
-func (m *Manager) waitForResourcesReadiness(ctx context.Context, us []*unstructured.Unstructured) error {
+func (m *Manager) WaitForResourcesReadiness(ctx context.Context, us []*unstructured.Unstructured) error {
 	ctx, cancel := context.WithTimeout(ctx, config.ReadyTimeout)
 	defer cancel()
 

--- a/internal/manager/moduleresource/manager_test.go
+++ b/internal/manager/moduleresource/manager_test.go
@@ -43,8 +43,9 @@ const (
 )
 
 var (
-	fakeClient client.Client
-	scheme     *runtime.Scheme
+	fakeClient           client.Client
+	scheme               *runtime.Scheme
+	defaultStubDetector  *stubCredentialsProvider
 )
 
 func TestModuleResource(t *testing.T) {
@@ -60,6 +61,11 @@ var _ = BeforeSuite(func() {
 	fakeClient = fake.NewClientBuilder().
 		WithScheme(scheme).
 		Build()
+
+	defaultStubDetector = &stubCredentialsProvider{
+		credentialsNamespace: kymaNamespace,
+		clusterId:            "",
+	}
 })
 
 var _ = Describe("Module Resource Manager", func() {
@@ -70,89 +76,65 @@ var _ = Describe("Module Resource Manager", func() {
 			WithScheme(scheme).
 			Build()
 
-		manager = NewManager(fakeClient, scheme)
+		manager = NewManager(fakeClient, scheme, defaultStubDetector)
 	})
 
-	Describe("read required secret", func() {
-		It("should return error when required secret does not exist", func() {
-			secret, err := manager.getRequiredSecret(context.Background())
-			Expect(k8serrors.IsNotFound(err)).To(BeTrue())
-			Expect(secret).To(BeNil())
+
+	Describe("partition resources by kind", func() {
+		It("should return resources of the requested kind in matching and the rest in rest", func() {
+			objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
+			Expect(err).NotTo(HaveOccurred())
+
+			matching, rest := manager.ResourcesOfKinds(objects, configmapKind)
+
+			Expect(matching).To(HaveLen(1))
+			Expect(matching[0].GetKind()).To(Equal(configmapKind))
+			Expect(rest).To(HaveLen(2))
+			for _, r := range rest {
+				Expect(r.GetKind()).NotTo(Equal(configmapKind))
+			}
 		})
 
-		It("should get required secret", func() {
-			Expect(createRequiredSecret(fakeClient)).To(Succeed())
-			secret, err := manager.getRequiredSecret(context.Background())
+		It("should place resources appended after loading into rest regardless of kind", func() {
+			objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
+			Expect(err).NotTo(HaveOccurred())
 
-			Expect(err).To(BeNil())
-			Expect(secret.Name).To(Equal(requiredSecretName))
-			Expect(secret.Namespace).To(Equal(requiredSecretNamespace))
+			extra := &unstructured.Unstructured{}
+			extra.SetKind(configmapKind)
+			extra.SetName("extra-configmap")
+			objects = append(objects, extra)
+
+			matching, rest := manager.ResourcesOfKinds(objects, configmapKind)
+
+			Expect(matching).To(HaveLen(1))
+			Expect(matching[0].GetName()).To(Equal(configmapName))
+			Expect(rest).To(HaveLen(3))
 		})
 
-		It("should successfully verify required secret", func() {
-			Expect(createRequiredSecret(fakeClient)).To(Succeed())
-			secret, err := manager.getRequiredSecret(context.Background())
-			Expect(err).To(BeNil())
+		It("should return all resources in rest when no kind matches", func() {
+			objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
+			Expect(err).NotTo(HaveOccurred())
 
-			Expect(manager.verifySecret(secret)).To(Succeed())
+			matching, rest := manager.ResourcesOfKinds(objects, "NetworkPolicy")
+
+			Expect(matching).To(BeEmpty())
+			Expect(rest).To(HaveLen(len(objects)))
 		})
 
-		It("should return error when required secret does not contain required key", func() {
-			Expect(createRequiredSecret(fakeClient)).To(Succeed())
-			secret, err := manager.getRequiredSecret(context.Background())
-			Expect(err).To(BeNil())
+		It("should return all resources in rest when no kinds are specified", func() {
+			objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
+			Expect(err).NotTo(HaveOccurred())
 
-			delete(secret.Data, ClientIdSecretKey)
-			err = manager.verifySecret(secret)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(ClientIdSecretKey))
-		})
+			matching, rest := manager.ResourcesOfKinds(objects)
 
-		It("should return error when one of keys in required secret does not contain value", func() {
-			Expect(createRequiredSecret(fakeClient)).To(Succeed())
-			secret, err := manager.getRequiredSecret(context.Background())
-			Expect(err).To(BeNil())
-
-			secret.Data[ClientSecretKey] = []byte{}
-			err = manager.verifySecret(secret)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(ClientSecretKey))
-		})
-	})
-
-	Describe("setup credentials context", func() {
-		var secret *corev1.Secret
-
-		BeforeEach(func() {
-			secret = requiredSecret()
-		})
-
-		It("should set default credentials namespace when required secret does not contain credentials_namespace", func() {
-			manager.setCredentialsNamespace(secret)
-
-			Expect(manager.credentialsContext.credentialsNamespaceFromSapBtpManagerSecret).To(Equal(kymaNamespace))
-		})
-
-		It("should set credentials namespace from required secret", func() {
-			const expectedCredentialsNamespace = "new-credentials-namespace"
-			secret.Data[CredentialsNamespaceSecretKey] = []byte(expectedCredentialsNamespace)
-			manager.setCredentialsNamespace(secret)
-
-			Expect(manager.credentialsContext.credentialsNamespaceFromSapBtpManagerSecret).To(Equal(expectedCredentialsNamespace))
-		})
-
-		It("should set credentials ID from required secret", func() {
-			const expectedClusterID = "new-credentials-id"
-			secret.Data[ClusterIdSecretKey] = []byte(expectedClusterID)
-			manager.setClusterID(secret)
-
-			Expect(manager.credentialsContext.clusterIdFromSapBtpManagerSecret).To(Equal(expectedClusterID))
+			Expect(matching).To(BeEmpty())
+			Expect(rest).To(HaveLen(len(objects)))
 		})
 	})
 
 	Describe("create unstructured objects from manifests directory", func() {
 		It("should load and convert manifests to unstructured objects", func() {
-			objects, err := manager.createUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
+			objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(objects).To(HaveLen(3))
@@ -178,7 +160,7 @@ var _ = Describe("Module Resource Manager", func() {
 		})
 
 		It("should return error for non-existent directory", func() {
-			_, err := manager.createUnstructuredObjectsFromManifestsDir("./non-existent")
+			_, err := manager.CreateUnstructuredObjectsFromManifestsDir("./non-existent")
 
 			Expect(err).To(HaveOccurred())
 		})
@@ -186,11 +168,11 @@ var _ = Describe("Module Resource Manager", func() {
 
 	Describe("add labels", func() {
 		It("should add managed-by, chart version, and module labels to all resources", func() {
-			objects, err := manager.createUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
+			objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
 			Expect(err).NotTo(HaveOccurred())
 
 			chartVersion := "0.0.1"
-			Expect(manager.addLabels(chartVersion, objects...)).NotTo(HaveOccurred())
+			Expect(manager.AddLabels(chartVersion, objects...)).NotTo(HaveOccurred())
 
 			for _, obj := range objects {
 				labels := obj.GetLabels()
@@ -210,10 +192,10 @@ var _ = Describe("Module Resource Manager", func() {
 
 	Describe("set namespace", func() {
 		It("should set namespace in all resources", func() {
-			objects, err := manager.createUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
+			objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
 			Expect(err).NotTo(HaveOccurred())
 
-			manager.setNamespace(objects)
+			manager.SetNamespace(objects)
 
 			for _, obj := range objects {
 				Expect(obj.GetNamespace()).To(Equal(kymaNamespace))
@@ -222,25 +204,18 @@ var _ = Describe("Module Resource Manager", func() {
 	})
 
 	Describe("set ConfigMap values", func() {
-		It("should set ConfigMap values from Secret", func() {
+		It("should set ConfigMap values from the credentials provider", func() {
 			const (
-				expectedClientId                = "test-client"
 				expectedClusterId               = "test-cluster-123"
 				expectedCredentialsNamespace    = "test-creds-ns"
 				expectedEnableLimitedCacheValue = "true"
 			)
 
-			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      secretName,
-					Namespace: testNamespace,
-				},
-				Data: map[string][]byte{
-					ClientIdSecretKey:             []byte(expectedClientId),
-					ClusterIdSecretKey:            []byte(expectedClusterId),
-					CredentialsNamespaceSecretKey: []byte(expectedCredentialsNamespace),
-				},
+			stub := &stubCredentialsProvider{
+				credentialsNamespace: expectedCredentialsNamespace,
+				clusterId:            expectedClusterId,
 			}
+			manager = NewManager(fakeClient, scheme, stub)
 
 			restoreEnableLimitedCache := config.EnableLimitedCache
 			config.EnableLimitedCache = expectedEnableLimitedCacheValue
@@ -248,15 +223,14 @@ var _ = Describe("Module Resource Manager", func() {
 				config.EnableLimitedCache = restoreEnableLimitedCache
 			}()
 
-			objects, err := manager.createUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
+			objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
 			Expect(err).NotTo(HaveOccurred())
 
 			configmapIndex, found := manager.resourceIndices[Metadata{Kind: configmapKind, Name: configmapName}]
 			Expect(found).To(BeTrue())
 			configmap := objects[configmapIndex]
 
-			manager.setCredentialsContext(secret)
-			err = manager.setConfigMapValues(secret, configmap)
+			err = manager.SetConfigMapValues(configmap)
 			Expect(err).NotTo(HaveOccurred())
 
 			data, found, err := unstructured.NestedStringMap(configmap.Object, "data")
@@ -273,16 +247,16 @@ var _ = Describe("Module Resource Manager", func() {
 		It("should copy data with base64 encoding excluding cluster_id and credentials_namespace", func() {
 			const expectedCredentialsNamespace = "credentials-namespace"
 			secret := requiredSecret()
-			secret.Data[CredentialsNamespaceSecretKey] = []byte(expectedCredentialsNamespace)
+
+			stub := &stubCredentialsProvider{credentialsNamespace: expectedCredentialsNamespace}
+			manager = NewManager(fakeClient, scheme, stub)
 
 			secretObj := &unstructured.Unstructured{}
 			secretObj.SetKind(secretKind)
 			secretObj.SetName(SapBtpServiceOperatorName)
 			secretObj.SetNamespace(kymaNamespace)
 
-			manager.setCredentialsContext(secret)
-
-			Expect(manager.setSecretValues(secret, secretObj)).NotTo(HaveOccurred())
+			Expect(manager.SetSecretValues(secret, secretObj)).NotTo(HaveOccurred())
 			Expect(secretObj.GetNamespace()).To(Equal(expectedCredentialsNamespace))
 
 			data, found, err := unstructured.NestedStringMap(secretObj.Object, "data")
@@ -314,14 +288,14 @@ var _ = Describe("Module Resource Manager", func() {
 		})
 
 		It("should set container images for manager and kube-rbac-proxy", func() {
-			objects, err := manager.createUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
+			objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
 			Expect(err).NotTo(HaveOccurred())
 
 			deploymentIndex, found := manager.resourceIndices[Metadata{Kind: DeploymentKind, Name: deploymentName}]
 			Expect(found).To(BeTrue())
 			deployment := objects[deploymentIndex]
 
-			err = manager.setDeploymentImages(deployment)
+			err = manager.SetDeploymentImages(deployment)
 			Expect(err).NotTo(HaveOccurred())
 
 			containers, found, err := unstructured.NestedSlice(deployment.Object, "spec", "template", "spec", "containers")
@@ -354,7 +328,7 @@ var _ = Describe("Module Resource Manager", func() {
 				},
 			}
 
-			err := manager.setDeploymentImages(deployment)
+			err := manager.SetDeploymentImages(deployment)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("container manager not found"))
 		})
@@ -448,7 +422,7 @@ var _ = Describe("Module Resource Manager", func() {
 				}, configmap)
 				Expect(err).NotTo(HaveOccurred())
 
-				Expect(manager.deleteOutdatedResources(context.Background())).Should(Succeed())
+				Expect(manager.DeleteOutdatedResources(context.Background())).Should(Succeed())
 
 				err = fakeClient.Get(ctx, client.ObjectKey{
 					Name:      configmapName,
@@ -458,7 +432,7 @@ var _ = Describe("Module Resource Manager", func() {
 			})
 
 			It("should not error when deleting non-existent resources", func() {
-				Expect(manager.deleteOutdatedResources(context.Background())).Should(Succeed())
+				Expect(manager.DeleteOutdatedResources(context.Background())).Should(Succeed())
 			})
 
 			It("should return error when unable to delete resources", func() {
@@ -467,7 +441,7 @@ var _ = Describe("Module Resource Manager", func() {
 					expectedName2 = "configmap2"
 				)
 				client := &errorOnDeleteClient{fakeClient}
-				manager = NewManager(client, scheme)
+				manager = NewManager(client, scheme, defaultStubDetector)
 
 				us1 := &unstructured.Unstructured{}
 				us1.SetKind(configmapKind)
@@ -481,7 +455,7 @@ var _ = Describe("Module Resource Manager", func() {
 
 				objects := []*unstructured.Unstructured{us1, us2}
 
-				err := manager.deleteResources(ctx, objects)
+				err := manager.DeleteResources(ctx, objects)
 				Expect(err).To(HaveOccurred())
 
 				const errorFormat = "failed to delete %s %s"
@@ -513,7 +487,7 @@ var _ = Describe("Module Resource Manager", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			objects := []*unstructured.Unstructured{deployment}
-			err = manager.waitForResourcesReadiness(ctx, objects)
+			err = manager.WaitForResourcesReadiness(ctx, objects)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -525,7 +499,7 @@ var _ = Describe("Module Resource Manager", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			objects := []*unstructured.Unstructured{deployment}
-			err = manager.waitForResourcesReadiness(ctx, objects)
+			err = manager.WaitForResourcesReadiness(ctx, objects)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("timeout"))
 		})
@@ -538,7 +512,7 @@ var _ = Describe("Module Resource Manager", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			objects := []*unstructured.Unstructured{configmap}
-			err = manager.waitForResourcesReadiness(ctx, objects)
+			err = manager.WaitForResourcesReadiness(ctx, objects)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -553,7 +527,7 @@ var _ = Describe("Module Resource Manager", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			objects := []*unstructured.Unstructured{deployment, configmap}
-			err = manager.waitForResourcesReadiness(ctx, objects)
+			err = manager.WaitForResourcesReadiness(ctx, objects)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -579,6 +553,14 @@ func requiredSecret() *corev1.Secret {
 	}
 	return secret
 }
+
+type stubCredentialsProvider struct {
+	credentialsNamespace string
+	clusterId            string
+}
+
+func (s *stubCredentialsProvider) CredentialsNamespaceFromManager() string { return s.credentialsNamespace }
+func (s *stubCredentialsProvider) ClusterIdFromManager() string            { return s.clusterId }
 
 type errorOnDeleteClient struct {
 	client.Client


### PR DESCRIPTION
**Description**

Fixes the Docker build failure from #1433 and #1434. \`btpoperator_controller.go\` was not updated in either PR.

- Add import for \`internal/webhook/certificate\` — \`CertificateSignError\`/\`NewCertificateSignError\` moved there in #1433
- Replace \`CertificateSignError\` → \`certificate.CertificateSignError\`
- Replace \`NewCertificateSignError\` → \`certificate.NewCertificateSignError\`
- Fix nil-panic in \`verifyCASign\`: split \`err != nil || !ok\` into two checks so \`err.Error()\` is never called on nil
- Update \`errWithReason.reason\`/\`.message\` → \`errWithReason.Reason\`/\`.Message\` — \`ErrorWithReason\` moved to \`internal/conditions\` with exported fields in #1434

**Related issue(s)**
See #1433, #1434