### PR TITLE
Add E2E Tests for Certificate Rotation and Secret Deletion Recovery

### DIFF
--- a/.github/workflows/run-e2e-tests-reusable.yaml
+++ b/.github/workflows/run-e2e-tests-reusable.yaml
@@ -54,7 +54,7 @@ jobs:
   run-e2e-matrix:
     runs-on: ubuntu-latest
     needs: prepare-tests
-    timeout-minutes: 20
+    timeout-minutes: 10
     strategy:
       matrix: ${{ fromJSON(needs.prepare-tests.outputs.versions) }}
     steps:

--- a/.github/workflows/run-e2e-tests-reusable.yaml
+++ b/.github/workflows/run-e2e-tests-reusable.yaml
@@ -54,7 +54,7 @@ jobs:
   run-e2e-matrix:
     runs-on: ubuntu-latest
     needs: prepare-tests
-    timeout-minutes: 10
+    timeout-minutes: 20
     strategy:
       matrix: ${{ fromJSON(needs.prepare-tests.outputs.versions) }}
     steps:

--- a/scripts/testing/run_e2e_module_tests.sh
+++ b/scripts/testing/run_e2e_module_tests.sh
@@ -445,19 +445,18 @@ until kubectl get secret ca-server-cert -n kyma-system >/dev/null 2>&1; do
   fi
   echo "Waiting for ca-server-cert to be recreated (${SECONDS}s/${TIMEOUT}s)"
   sleep 5
-  SECONDS=$((SECONDS + 5))
 done
 echo "ca-server-cert recreated"
 
 echo -e "\n--- Waiting for CA bundle in webhook configuration to be updated"
 SECONDS=0
+TIMEOUT=60
 until [[ "$(kubectl get mutatingwebhookconfiguration sap-btp-operator-mutating-webhook-configuration -o jsonpath='{.webhooks[0].clientConfig.caBundle}')" != "${CA_BUNDLE_BEFORE}" ]]; do
   if [[ ${SECONDS} -ge ${TIMEOUT} ]]; then
     echo "ERROR: CA bundle in webhook was not updated within ${TIMEOUT}s" && exit 1
   fi
   echo "Waiting for CA bundle to be updated (${SECONDS}s/${TIMEOUT}s)"
   sleep 5
-  SECONDS=$((SECONDS + 5))
 done
 echo "CA bundle updated in mutating webhook"
 
@@ -499,7 +498,6 @@ until [[ "$(kubectl get btpoperators/btpoperator -n kyma-system -o jsonpath='{.s
   fi
   echo "Waiting for CR to leave Ready state (${SECONDS}s/${TIMEOUT}s)"
   sleep 5
-  SECONDS=$((SECONDS + 5))
 done
 echo "BtpOperator CR left Ready state after secret deletion"
 

--- a/scripts/testing/run_e2e_module_tests.sh
+++ b/scripts/testing/run_e2e_module_tests.sh
@@ -451,7 +451,8 @@ echo "ca-server-cert recreated"
 echo -e "\n--- Waiting for CA bundle in webhook configuration to be updated"
 SECONDS=0
 TIMEOUT=60
-until [[ "$(kubectl get mutatingwebhookconfiguration sap-btp-operator-mutating-webhook-configuration -o jsonpath='{.webhooks[0].clientConfig.caBundle}')" != "${CA_BUNDLE_BEFORE}" ]]; do
+until [[ -n "$(kubectl get mutatingwebhookconfiguration sap-btp-operator-mutating-webhook-configuration -o jsonpath='{.webhooks[0].clientConfig.caBundle}' 2>/dev/null)" ]] && \
+  [[ "$(kubectl get mutatingwebhookconfiguration sap-btp-operator-mutating-webhook-configuration -o jsonpath='{.webhooks[0].clientConfig.caBundle}')" != "${CA_BUNDLE_BEFORE}" ]]; do
   if [[ ${SECONDS} -ge ${TIMEOUT} ]]; then
     echo "ERROR: CA bundle in webhook was not updated within ${TIMEOUT}s" && exit 1
   fi

--- a/scripts/testing/run_e2e_module_tests.sh
+++ b/scripts/testing/run_e2e_module_tests.sh
@@ -486,6 +486,10 @@ echo "Certificate rotation test completed successfully"
 
 echo -e "\n--- Testing sap-btp-manager secret deletion and recovery"
 
+echo -e "\n--- Saving sap-btp-manager secret before deletion"
+SECRET_JSON=$(kubectl get secret sap-btp-manager -n kyma-system -o json | \
+  jq 'del(.metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.annotations, .metadata.managedFields)')
+
 echo -e "\n--- Deleting sap-btp-manager secret while CR is in Ready state"
 kubectl delete secret sap-btp-manager -n kyma-system
 
@@ -502,9 +506,8 @@ until [[ "$(kubectl get btpoperators/btpoperator -n kyma-system -o jsonpath='{.s
 done
 echo "BtpOperator CR left Ready state after secret deletion"
 
-echo -e "\n--- Recreating sap-btp-manager secret"
-YAML_DIR="scripts/testing/yaml"
-envsubst <${YAML_DIR}/e2e-test-secret.yaml | kubectl apply -f -
+echo -e "\n--- Recreating sap-btp-manager secret from saved copy"
+echo "${SECRET_JSON}" | kubectl apply -f -
 
 echo -e "\n--- Waiting for BtpOperator CR to recover to Ready state"
 waitForBtpOperatorCrReadiness 120

--- a/scripts/testing/run_e2e_module_tests.sh
+++ b/scripts/testing/run_e2e_module_tests.sh
@@ -388,9 +388,6 @@ done
 
 echo -e "\n--- EnableLimitedCache ConfigMap propagation test completed successfully"
 
-echo -e "\n--- Setting ReadyCheckInterval=5s to speed up readiness polling for the following tests"
-kubectl patch configmap sap-btp-manager -n kyma-system --type merge -p '{"data":{"ReadyCheckInterval":"5s"}}'
-
 echo -e "\n--- Removing sap-btp-manager configmap"
 kubectl delete -f ${YAML_DIR}/e2e-test-configmap.yaml
 
@@ -488,7 +485,7 @@ echo -e "\n--- Testing sap-btp-manager secret deletion and recovery"
 
 echo -e "\n--- Saving sap-btp-manager secret before deletion"
 SECRET_JSON=$(kubectl get secret sap-btp-manager -n kyma-system -o json | \
-  jq 'del(.metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.annotations, .metadata.managedFields)')
+  jq 'del(.metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.annotations, .metadata.managedFields, .metadata.ownerReferences)')
 
 echo -e "\n--- Deleting sap-btp-manager secret while CR is in Ready state"
 kubectl delete secret sap-btp-manager -n kyma-system

--- a/scripts/testing/run_e2e_module_tests.sh
+++ b/scripts/testing/run_e2e_module_tests.sh
@@ -417,6 +417,88 @@ if [[ "${CREDENTIALS}" == "real" ]]; then
   echo -e "\n-- Service Instance has been updated - reconciliation after parameters change succeeded"
 fi
 
+echo -e "\n--- Testing certificate rotation"
+
+echo -e "\n--- Saving current CA bundle from mutating webhook"
+CA_BUNDLE_BEFORE=$(kubectl get mutatingwebhookconfiguration sap-btp-operator-mutating-webhook-configuration -o jsonpath='{.webhooks[0].clientConfig.caBundle}')
+if [[ -z "${CA_BUNDLE_BEFORE}" ]]; then
+  echo "ERROR: caBundle is empty before cert rotation test" && exit 1
+fi
+
+echo -e "\n--- Deleting ca-server-cert secret to trigger cert rotation"
+kubectl delete secret ca-server-cert -n kyma-system
+
+echo -e "\n--- Waiting for ca-server-cert to be recreated"
+SECONDS=0
+TIMEOUT=60
+until kubectl get secret ca-server-cert -n kyma-system >/dev/null 2>&1; do
+  if [[ ${SECONDS} -ge ${TIMEOUT} ]]; then
+    echo "ERROR: ca-server-cert was not recreated within ${TIMEOUT}s" && exit 1
+  fi
+  echo "Waiting for ca-server-cert to be recreated (${SECONDS}s/${TIMEOUT}s)"
+  sleep 5
+  SECONDS=$((SECONDS + 5))
+done
+echo "ca-server-cert recreated"
+
+echo -e "\n--- Waiting for CA bundle in webhook configuration to be updated"
+SECONDS=0
+until [[ "$(kubectl get mutatingwebhookconfiguration sap-btp-operator-mutating-webhook-configuration -o jsonpath='{.webhooks[0].clientConfig.caBundle}')" != "${CA_BUNDLE_BEFORE}" ]]; do
+  if [[ ${SECONDS} -ge ${TIMEOUT} ]]; then
+    echo "ERROR: CA bundle in webhook was not updated within ${TIMEOUT}s" && exit 1
+  fi
+  echo "Waiting for CA bundle to be updated (${SECONDS}s/${TIMEOUT}s)"
+  sleep 5
+  SECONDS=$((SECONDS + 5))
+done
+echo "CA bundle updated in mutating webhook"
+
+echo -e "\n--- Verifying CA bundle in webhook is a valid certificate (not a private key)"
+CA_BUNDLE_AFTER=$(kubectl get mutatingwebhookconfiguration sap-btp-operator-mutating-webhook-configuration -o jsonpath='{.webhooks[0].clientConfig.caBundle}')
+CA_BUNDLE_DECODED=$(echo "${CA_BUNDLE_AFTER}" | base64 -d)
+if echo "${CA_BUNDLE_DECODED}" | grep -q "BEGIN CERTIFICATE"; then
+  echo "CA bundle contains a valid certificate"
+else
+  echo "ERROR: CA bundle does not contain a certificate - may contain a private key instead" && exit 1
+fi
+
+echo -e "\n--- Verifying validating webhook also has the updated CA bundle"
+CA_BUNDLE_VALIDATING=$(kubectl get validatingwebhookconfiguration sap-btp-operator-validating-webhook-configuration -o jsonpath='{.webhooks[0].clientConfig.caBundle}')
+if [[ "${CA_BUNDLE_VALIDATING}" == "${CA_BUNDLE_AFTER}" ]]; then
+  echo "Validating webhook CA bundle matches mutating webhook CA bundle"
+else
+  echo "ERROR: Validating webhook CA bundle does not match mutating webhook CA bundle" && exit 1
+fi
+
+waitForBtpOperatorCrReadiness
+echo "Certificate rotation test completed successfully"
+
+echo -e "\n--- Testing sap-btp-manager secret deletion and recovery"
+
+echo -e "\n--- Deleting sap-btp-manager secret while CR is in Ready state"
+kubectl delete secret sap-btp-manager -n kyma-system
+
+echo -e "\n--- Waiting for BtpOperator CR to leave Ready state"
+SECONDS=0
+TIMEOUT=60
+until [[ "$(kubectl get btpoperators/btpoperator -n kyma-system -o jsonpath='{.status.state}')" != "Ready" ]]; do
+  if [[ ${SECONDS} -ge ${TIMEOUT} ]]; then
+    echo "ERROR: BtpOperator CR did not leave Ready state within ${TIMEOUT}s after secret deletion" && exit 1
+  fi
+  echo "Waiting for CR to leave Ready state (${SECONDS}s/${TIMEOUT}s)"
+  sleep 5
+  SECONDS=$((SECONDS + 5))
+done
+echo "BtpOperator CR left Ready state after secret deletion"
+
+echo -e "\n--- Recreating sap-btp-manager secret"
+YAML_DIR="scripts/testing/yaml"
+envsubst <${YAML_DIR}/e2e-test-secret.yaml | kubectl apply -f -
+
+echo -e "\n--- Waiting for BtpOperator CR to recover to Ready state"
+waitForBtpOperatorCrReadiness
+echo "BtpOperator CR recovered to Ready after secret recreation"
+
 echo -e "\n---Uninstalling..."
 
 # remove btp-operator (ServiceInstance and ServiceBinding should be deleted as well)

--- a/scripts/testing/run_e2e_module_tests.sh
+++ b/scripts/testing/run_e2e_module_tests.sh
@@ -17,15 +17,23 @@ set -E          # needs to be set if we want the ERR trap
 set -o pipefail # prevents errors in a pipeline from being masked
 
 waitForBtpOperatorCrReadiness () {
-  echo -e "\n--- Waiting for BtpOperator CR to be ready"
+  local timeout=${1:-300}
+  echo -e "\n--- Waiting for BtpOperator CR to be ready (timeout: ${timeout}s)"
+  local seconds=0
   while true; do
     operator_status=$(kubectl get btpoperators/btpoperator -n kyma-system -o json)
     state_status=$(echo $operator_status | jq -r '.status.state')
     if [[ $state_status == "Ready" ]]; then
       break
-    else
-      echo -e "\n--- Waiting for BtpOperator CR to be ready"; sleep 5;
     fi
+    if [[ ${seconds} -ge ${timeout} ]]; then
+      reason=$(echo $operator_status | jq -r '.status.conditions[] | select(.type=="Ready") | .reason')
+      message=$(echo $operator_status | jq -r '.status.conditions[] | select(.type=="Ready") | .message')
+      echo -e "\n--- ERROR: BtpOperator CR did not reach Ready within ${timeout}s (state=${state_status}, reason=${reason}, message=${message})"
+      exit 1
+    fi
+    echo -e "\n--- Waiting for BtpOperator CR to be ready (state=${state_status}, ${seconds}s/${timeout}s)"; sleep 5;
+    seconds=$((seconds + 5))
   done
 }
 
@@ -417,6 +425,9 @@ if [[ "${CREDENTIALS}" == "real" ]]; then
   echo -e "\n-- Service Instance has been updated - reconciliation after parameters change succeeded"
 fi
 
+echo -e "\n--- Setting ReadyCheckInterval=5s to speed up readiness polling for the following tests"
+kubectl patch configmap sap-btp-manager -n kyma-system --type merge -p '{"data":{"ReadyCheckInterval":"5s"}}'
+
 echo -e "\n--- Testing certificate rotation"
 
 echo -e "\n--- Saving current CA bundle from mutating webhook"
@@ -470,7 +481,7 @@ else
   echo "ERROR: Validating webhook CA bundle does not match mutating webhook CA bundle" && exit 1
 fi
 
-waitForBtpOperatorCrReadiness
+waitForBtpOperatorCrReadiness 120
 echo "Certificate rotation test completed successfully"
 
 echo -e "\n--- Testing sap-btp-manager secret deletion and recovery"
@@ -496,8 +507,11 @@ YAML_DIR="scripts/testing/yaml"
 envsubst <${YAML_DIR}/e2e-test-secret.yaml | kubectl apply -f -
 
 echo -e "\n--- Waiting for BtpOperator CR to recover to Ready state"
-waitForBtpOperatorCrReadiness
+waitForBtpOperatorCrReadiness 120
 echo "BtpOperator CR recovered to Ready after secret recreation"
+
+echo -e "\n--- Restoring ReadyCheckInterval to default"
+kubectl patch configmap sap-btp-manager -n kyma-system --type merge -p '{"data":{"ReadyCheckInterval":"30s"}}'
 
 echo -e "\n---Uninstalling..."
 

--- a/scripts/testing/run_e2e_module_tests.sh
+++ b/scripts/testing/run_e2e_module_tests.sh
@@ -388,6 +388,9 @@ done
 
 echo -e "\n--- EnableLimitedCache ConfigMap propagation test completed successfully"
 
+echo -e "\n--- Setting ReadyCheckInterval=5s to speed up readiness polling for the following tests"
+kubectl patch configmap sap-btp-manager -n kyma-system --type merge -p '{"data":{"ReadyCheckInterval":"5s"}}'
+
 echo -e "\n--- Removing sap-btp-manager configmap"
 kubectl delete -f ${YAML_DIR}/e2e-test-configmap.yaml
 
@@ -424,9 +427,6 @@ if [[ "${CREDENTIALS}" == "real" ]]; then
 
   echo -e "\n-- Service Instance has been updated - reconciliation after parameters change succeeded"
 fi
-
-echo -e "\n--- Setting ReadyCheckInterval=5s to speed up readiness polling for the following tests"
-kubectl patch configmap sap-btp-manager -n kyma-system --type merge -p '{"data":{"ReadyCheckInterval":"5s"}}'
 
 echo -e "\n--- Testing certificate rotation"
 
@@ -509,9 +509,6 @@ envsubst <${YAML_DIR}/e2e-test-secret.yaml | kubectl apply -f -
 echo -e "\n--- Waiting for BtpOperator CR to recover to Ready state"
 waitForBtpOperatorCrReadiness 120
 echo "BtpOperator CR recovered to Ready after secret recreation"
-
-echo -e "\n--- Restoring ReadyCheckInterval to default"
-kubectl patch configmap sap-btp-manager -n kyma-system --type merge -p '{"data":{"ReadyCheckInterval":"30s"}}'
 
 echo -e "\n---Uninstalling..."
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add e2e test that deletes `ca-server-cert` and verifies the controller recreates it and updates the CA bundle in both mutating and validating webhook configurations with a valid certificate
- Add e2e test that deletes the `sap-btp-manager` secret while the CR is in Ready state and verifies the CR leaves Ready, then recovers after the secret is recreated

**Related issue(s)**
See #1313