### PR TITLE
Add CA Bundle Probe Runner to btp-manager

### DIFF
--- a/.github/workflows/run-e2e-ca-bundle-probe-tests.yaml
+++ b/.github/workflows/run-e2e-ca-bundle-probe-tests.yaml
@@ -42,7 +42,8 @@ jobs:
             -n kyma-system \
             -c manager \
             PROBE_IMAGE=localhost:5000/ca-bundle-probe:latest \
-            PROBE_INTERVAL=10s
+            PROBE_INTERVAL=10s \
+            PROBE_TOKENURL_OVERRIDE=https://fake-server.kyma-system.svc.cluster.local/health
           kubectl rollout status deployment/btp-manager-controller-manager \
             -n kyma-system --timeout=120s
 

--- a/.github/workflows/run-e2e-ca-bundle-probe-tests.yaml
+++ b/.github/workflows/run-e2e-ca-bundle-probe-tests.yaml
@@ -52,3 +52,20 @@ jobs:
           FAKE_SERVER_IMAGE: localhost:5000/fake-server:latest
           WEBHOOK_IMAGE: localhost:5000/ca-bundle-webhook:latest
         run: "./scripts/testing/run_e2e_ca_bundle_probe_test.sh"
+
+      - name: Dump debug info on failure
+        if: failure()
+        run: |
+          echo "=== btp-manager logs ==="
+          kubectl logs -n kyma-system -l app.kubernetes.io/name=btp-manager --tail=100 || true
+          echo "=== probe jobs ==="
+          kubectl get jobs -n kyma-system || true
+          kubectl describe jobs/ca-bundle-probe -n kyma-system 2>/dev/null || true
+          echo "=== probe job pods ==="
+          kubectl get pods -n kyma-system -l job-name=ca-bundle-probe || true
+          kubectl logs -n kyma-system -l job-name=ca-bundle-probe --tail=50 || true
+          echo "=== BtpOperator annotations ==="
+          kubectl get btpoperator/btpoperator -n kyma-system -o jsonpath='{.metadata.annotations}' | tr ',' '\n' || true
+          echo "=== btp-manager deployment env ==="
+          kubectl get deployment/btp-manager-controller-manager -n kyma-system \
+            -o jsonpath='{.spec.template.spec.containers[0].env}' | tr ',' '\n' || true

--- a/.github/workflows/run-e2e-ca-bundle-probe-tests.yaml
+++ b/.github/workflows/run-e2e-ca-bundle-probe-tests.yaml
@@ -56,8 +56,11 @@ jobs:
       - name: Dump debug info on failure
         if: failure()
         run: |
-          echo "=== btp-manager logs ==="
-          kubectl logs -n kyma-system -l app.kubernetes.io/name=btp-manager --tail=100 || true
+          echo "=== btp-manager pods ==="
+          kubectl get pods -n kyma-system -l app.kubernetes.io/component=btp-manager.kyma-project.io || true
+          echo "=== btp-manager logs (current + previous) ==="
+          kubectl logs -n kyma-system -l app.kubernetes.io/component=btp-manager.kyma-project.io --tail=150 || true
+          kubectl logs -n kyma-system -l app.kubernetes.io/component=btp-manager.kyma-project.io --tail=150 -p 2>/dev/null || true
           echo "=== probe jobs ==="
           kubectl get jobs -n kyma-system || true
           kubectl describe jobs/ca-bundle-probe -n kyma-system 2>/dev/null || true

--- a/.github/workflows/run-e2e-ca-bundle-probe-tests.yaml
+++ b/.github/workflows/run-e2e-ca-bundle-probe-tests.yaml
@@ -36,6 +36,16 @@ jobs:
           docker build -t localhost:5000/ca-bundle-webhook:latest -f tests/webhook/Dockerfile .
           docker push localhost:5000/ca-bundle-webhook:latest
 
+      - name: Configure probe runner in BTP Manager deployment
+        run: |
+          kubectl set env deployment/btp-manager-controller-manager \
+            -n kyma-system \
+            -c manager \
+            PROBE_IMAGE=localhost:5000/ca-bundle-probe:latest \
+            PROBE_INTERVAL=10s
+          kubectl rollout status deployment/btp-manager-controller-manager \
+            -n kyma-system --timeout=120s
+
       - name: Run CA bundle probe E2E tests
         env:
           PROBE_IMAGE: localhost:5000/ca-bundle-probe:latest

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -124,6 +124,8 @@ rules:
   - create
   - delete
   - get
+  - list
+  - watch
 - apiGroups:
   - coordination.k8s.io
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -117,6 +117,14 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases

--- a/controllers/probe_runner.go
+++ b/controllers/probe_runner.go
@@ -23,15 +23,17 @@ import (
 //+kubebuilder:rbac:groups="batch",resources="jobs",verbs=get;create;delete
 
 const (
-	probeJobName              = "ca-bundle-probe"
-	probeAnnotationStatus     = "tls-probe-status"
-	probeAnnotationHash       = "tls-probe-hash"
-	probeAnnotationLastHash   = "tls-probe-last-hash"
-	probeAnnotationUpdatedAt  = "tls-probe-updated-at"
+	probeJobName             = "ca-bundle-probe"
+	probeAnnotationStatus    = "tls-probe-status"
+	probeAnnotationHash      = "tls-probe-hash"
+	probeAnnotationLastHash  = "tls-probe-last-hash"
+	probeAnnotationUpdatedAt = "tls-probe-updated-at"
 
 	probeStatusOK    = "ok"
 	probeStatusAlert = "alert"
 )
+
+var jobWaitTimeout = 5 * time.Minute
 
 // ProbeRunner is a controller-runtime Runnable that periodically spawns a tls-probe Job
 // and reads back signals from BtpOperator CR annotations. It is disabled when ProbeInterval is 0.
@@ -212,9 +214,33 @@ func (r *ProbeRunner) deleteOldJob(ctx context.Context) error {
 		return err
 	}
 	propagation := metav1.DeletePropagationBackground
-	return r.client.Delete(ctx, job, &client.DeleteOptions{
+	if err := r.client.Delete(ctx, job, &client.DeleteOptions{
 		PropagationPolicy: &propagation,
-	})
+	}); err != nil {
+		return err
+	}
+	// Poll until the object is fully removed so the subsequent createJob call does not
+	// receive an "object is being deleted" AlreadyExists error.
+	deleteCtx, cancel := context.WithTimeout(ctx, jobWaitTimeout)
+	defer cancel()
+	for {
+		select {
+		case <-deleteCtx.Done():
+			return deleteCtx.Err()
+		default:
+		}
+		err := r.client.Get(deleteCtx, types.NamespacedName{
+			Name:      probeJobName,
+			Namespace: config.KymaSystemNamespaceName,
+		}, &batchv1.Job{})
+		if k8serrors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		time.Sleep(2 * time.Second)
+	}
 }
 
 func (r *ProbeRunner) createJob(ctx context.Context) error {
@@ -252,16 +278,18 @@ func (r *ProbeRunner) createJob(ctx context.Context) error {
 
 func (r *ProbeRunner) waitForJob(ctx context.Context) error {
 	logger := log.FromContext(ctx).WithName("probe-runner")
-	// Poll until the job completes (succeeded or failed) or context is cancelled.
+	waitCtx, cancel := context.WithTimeout(ctx, jobWaitTimeout)
+	defer cancel()
+	// Poll until the job completes (succeeded or failed) or the deadline is exceeded.
 	for {
 		select {
-		case <-ctx.Done():
-			return ctx.Err()
+		case <-waitCtx.Done():
+			return waitCtx.Err()
 		default:
 		}
 
 		job := &batchv1.Job{}
-		if err := r.client.Get(ctx, types.NamespacedName{
+		if err := r.client.Get(waitCtx, types.NamespacedName{
 			Name:      probeJobName,
 			Namespace: config.KymaSystemNamespaceName,
 		}, job); err != nil {

--- a/controllers/probe_runner.go
+++ b/controllers/probe_runner.go
@@ -239,7 +239,11 @@ func (r *ProbeRunner) deleteOldJob(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		time.Sleep(2 * time.Second)
+		select {
+		case <-deleteCtx.Done():
+			return deleteCtx.Err()
+		case <-time.After(2 * time.Second):
+		}
 	}
 }
 
@@ -305,7 +309,11 @@ func (r *ProbeRunner) waitForJob(ctx context.Context) error {
 			return nil
 		}
 
-		time.Sleep(2 * time.Second)
+		select {
+		case <-waitCtx.Done():
+			return waitCtx.Err()
+		case <-time.After(2 * time.Second):
+		}
 	}
 }
 

--- a/controllers/probe_runner.go
+++ b/controllers/probe_runner.go
@@ -20,7 +20,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-//+kubebuilder:rbac:groups="batch",resources="jobs",verbs=get;create;delete
+//+kubebuilder:rbac:groups="batch",resources="jobs",verbs=get;list;watch;create;delete
 
 const (
 	probeJobName             = "ca-bundle-probe"

--- a/controllers/probe_runner.go
+++ b/controllers/probe_runner.go
@@ -261,7 +261,8 @@ func (r *ProbeRunner) createJob(ctx context.Context) error {
 			BackoffLimit: &backoffLimit,
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy: corev1.RestartPolicyNever,
+					RestartPolicy:      corev1.RestartPolicyNever,
+					ServiceAccountName: probeJobName,
 					Containers: []corev1.Container{
 						{
 							Name:  "probe",

--- a/controllers/probe_runner.go
+++ b/controllers/probe_runner.go
@@ -29,7 +29,8 @@ const (
 	probeAnnotationLastHash   = "tls-probe-last-hash"
 	probeAnnotationUpdatedAt  = "tls-probe-updated-at"
 
-	probeStatusOK = "ok"
+	probeStatusOK    = "ok"
+	probeStatusAlert = "alert"
 )
 
 // ProbeRunner is a controller-runtime Runnable that periodically spawns a tls-probe Job
@@ -50,7 +51,7 @@ func NewProbeRunner(c client.Client, registry prometheus.Registerer) *ProbeRunne
 	gauge := promauto.With(registry).NewGauge(prometheus.GaugeOpts{
 		Namespace: "btpmanager",
 		Name:      "credential_probe_status",
-		Help:      "CA bundle probe status: 0=ok, 1=any problem signal (alert/warning/error)",
+		Help:      "CA bundle probe status: 0=ok or error, 1=alert (CA mounted but cert not trusted)",
 	})
 
 	return &ProbeRunner{
@@ -154,11 +155,12 @@ func (r *ProbeRunner) runCycle(ctx context.Context) error {
 		return nil
 	}
 
-	// Update metric: 0 if TLS healthy (ok), 1 if any problem signal (alert/warning/error).
-	if status == probeStatusOK {
-		r.statusGauge.Set(0)
-	} else {
+	// Update metric: 1 if alert (CA mounted but cert not trusted — actionable), 0 otherwise.
+	// error signals (connectivity failures, no mount) are logged but do not fire the metric.
+	if status == probeStatusAlert {
 		r.statusGauge.Set(1)
+	} else {
+		r.statusGauge.Set(0)
 	}
 
 	// Restart btp-operator pods when: TLS ok (status=ok), hash changed, and lastHash was non-empty (not first run).

--- a/controllers/probe_runner.go
+++ b/controllers/probe_runner.go
@@ -23,14 +23,13 @@ import (
 //+kubebuilder:rbac:groups="batch",resources="jobs",verbs=get;create;delete
 
 const (
-	probeJobName             = "ca-bundle-probe"
-	probeAnnotationTLSResult = "tls-probe-tls-result"
-	probeAnnotationHash      = "tls-probe-hash"
-	probeAnnotationLastHash  = "tls-probe-last-hash"
-	probeAnnotationSignal    = "tls-probe-signal"
+	probeJobName              = "ca-bundle-probe"
+	probeAnnotationStatus     = "tls-probe-status"
+	probeAnnotationHash       = "tls-probe-hash"
+	probeAnnotationLastHash   = "tls-probe-last-hash"
+	probeAnnotationUpdatedAt  = "tls-probe-updated-at"
 
-	probeSignalAlert = "alert"
-	probeTLSResultOK = "ok"
+	probeStatusOK = "ok"
 )
 
 // ProbeRunner is a controller-runtime Runnable that periodically spawns a tls-probe Job
@@ -51,7 +50,7 @@ func NewProbeRunner(c client.Client, registry prometheus.Registerer) *ProbeRunne
 	gauge := promauto.With(registry).NewGauge(prometheus.GaugeOpts{
 		Namespace: "btpmanager",
 		Name:      "credential_probe_status",
-		Help:      "CA bundle probe status: 0=healthy, 1=unhealthy (alert-level signal)",
+		Help:      "CA bundle probe status: 0=ok, 1=any problem signal (alert/warning/error)",
 	})
 
 	return &ProbeRunner{
@@ -109,6 +108,13 @@ func (r *ProbeRunner) runCycle(ctx context.Context) error {
 		return fmt.Errorf("deleting old probe job: %w", err)
 	}
 
+	// Record tls-probe-updated-at before running the job so we can detect whether the probe
+	// wrote new annotations this cycle (it silently exits without writing when no mount + TLS ok).
+	prevUpdatedAt, err := r.getUpdatedAt(ctx)
+	if err != nil {
+		return fmt.Errorf("reading tls-probe-updated-at: %w", err)
+	}
+
 	if err := r.createJob(ctx); err != nil {
 		return fmt.Errorf("creating probe job: %w", err)
 	}
@@ -130,34 +136,44 @@ func (r *ProbeRunner) runCycle(ctx context.Context) error {
 		annotations = map[string]string{}
 	}
 
-	signal := annotations[probeAnnotationSignal]
-	tlsResult := annotations[probeAnnotationTLSResult]
+	status := annotations[probeAnnotationStatus]
 	hash := annotations[probeAnnotationHash]
 	lastHash := annotations[probeAnnotationLastHash]
+	updatedAt := annotations[probeAnnotationUpdatedAt]
 
 	logger.Info("probe cycle result",
-		"signal", signal,
-		"tls-result", tlsResult,
+		"status", status,
 		"hash", hash,
 		"lastHash", lastHash,
+		"updatedAt", updatedAt,
 	)
 
-	// Update metric: 1 if alert, 0 otherwise.
-	if signal == probeSignalAlert {
-		r.statusGauge.Set(1)
-	} else {
-		r.statusGauge.Set(0)
+	// If tls-probe-updated-at did not advance, the probe silently exited (no mount + TLS ok).
+	// Nothing to process this cycle.
+	if updatedAt == prevUpdatedAt {
+		return nil
 	}
 
-	// Restart btp-operator pods when: hash changed, TLS ok, and lastHash was non-empty (not first run).
-	if tlsResult == probeTLSResultOK && hash != lastHash && lastHash != "" {
+	// Update metric: 0 if TLS healthy (ok), 1 if any problem signal (alert/warning/error).
+	if status == probeStatusOK {
+		r.statusGauge.Set(0)
+	} else {
+		r.statusGauge.Set(1)
+	}
+
+	// Restart btp-operator pods when: TLS ok (status=ok), hash changed, and lastHash was non-empty (not first run).
+	if status == probeStatusOK && hash != lastHash && lastHash != "" {
 		logger.Info("CA bundle hash changed with healthy TLS — restarting btp-operator pods")
 		if err := r.restartBtpOperatorPods(ctx); err != nil {
 			logger.Error(err, "failed to restart btp-operator pods")
 		}
 	}
 
-	// Advance tls-probe-last-hash after processing.
+	// Advance tls-probe-last-hash only when probe wrote a non-empty hash.
+	// Overwriting with empty would erase the previous hash and suppress future restart detection.
+	if hash == "" {
+		return nil
+	}
 	patch := client.MergeFrom(cr.DeepCopy())
 	if cr.Annotations == nil {
 		cr.Annotations = map[string]string{}
@@ -168,6 +184,17 @@ func (r *ProbeRunner) runCycle(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func (r *ProbeRunner) getUpdatedAt(ctx context.Context) (string, error) {
+	cr := &v1alpha1.BtpOperator{}
+	if err := r.client.Get(ctx, types.NamespacedName{
+		Name:      config.BtpOperatorCrName,
+		Namespace: config.KymaSystemNamespaceName,
+	}, cr); err != nil {
+		return "", fmt.Errorf("getting BtpOperator CR: %w", err)
+	}
+	return cr.GetAnnotations()[probeAnnotationUpdatedAt], nil
 }
 
 func (r *ProbeRunner) deleteOldJob(ctx context.Context) error {

--- a/controllers/probe_runner.go
+++ b/controllers/probe_runner.go
@@ -1,0 +1,269 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/kyma-project/btp-manager/api/v1alpha1"
+	"github.com/kyma-project/btp-manager/controllers/config"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+//+kubebuilder:rbac:groups="batch",resources="jobs",verbs=get;create;delete
+
+const (
+	probeJobName             = "ca-bundle-probe"
+	probeAnnotationTLSResult = "tls-probe-tls-result"
+	probeAnnotationHash      = "tls-probe-hash"
+	probeAnnotationLastHash  = "tls-probe-last-hash"
+	probeAnnotationSignal    = "tls-probe-signal"
+
+	probeSignalAlert = "alert"
+	probeTLSResultOK = "ok"
+)
+
+// ProbeRunner is a controller-runtime Runnable that periodically spawns a tls-probe Job
+// and reads back signals from BtpOperator CR annotations. It is disabled when ProbeInterval is 0.
+type ProbeRunner struct {
+	client           client.Client
+	probeInterval    time.Duration
+	probeImage       string
+	tokenURLOverride string
+	statusGauge      prometheus.Gauge
+}
+
+func NewProbeRunner(c client.Client, registry prometheus.Registerer) *ProbeRunner {
+	interval := parseProbeInterval(os.Getenv("PROBE_INTERVAL"))
+	image := os.Getenv("PROBE_IMAGE")
+	override := os.Getenv("PROBE_TOKENURL_OVERRIDE")
+
+	gauge := promauto.With(registry).NewGauge(prometheus.GaugeOpts{
+		Namespace: "btpmanager",
+		Name:      "credential_probe_status",
+		Help:      "CA bundle probe status: 0=healthy, 1=unhealthy (alert-level signal)",
+	})
+
+	return &ProbeRunner{
+		client:           c,
+		probeInterval:    interval,
+		probeImage:       image,
+		tokenURLOverride: override,
+		statusGauge:      gauge,
+	}
+}
+
+func parseProbeInterval(raw string) time.Duration {
+	if raw == "" || raw == "0" || raw == "0s" {
+		return 0
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil || d <= 0 {
+		return 0
+	}
+	return d
+}
+
+// Start implements manager.Runnable. Returns immediately if probe is disabled.
+//
+//nolint:cyclop
+func (r *ProbeRunner) Start(ctx context.Context) error {
+	logger := log.FromContext(ctx).WithName("probe-runner")
+
+	if r.probeInterval == 0 || r.probeImage == "" {
+		logger.Info("CA bundle probe disabled", "interval", r.probeInterval, "image", r.probeImage)
+		return nil
+	}
+
+	logger.Info("CA bundle probe runner started", "interval", r.probeInterval, "image", r.probeImage)
+
+	ticker := time.NewTicker(r.probeInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := r.runCycle(ctx); err != nil {
+				logger.Error(err, "probe cycle failed")
+			}
+		}
+	}
+}
+
+func (r *ProbeRunner) runCycle(ctx context.Context) error {
+	logger := log.FromContext(ctx).WithName("probe-runner")
+
+	if err := r.deleteOldJob(ctx); err != nil {
+		return fmt.Errorf("deleting old probe job: %w", err)
+	}
+
+	if err := r.createJob(ctx); err != nil {
+		return fmt.Errorf("creating probe job: %w", err)
+	}
+
+	if err := r.waitForJob(ctx); err != nil {
+		return fmt.Errorf("waiting for probe job: %w", err)
+	}
+
+	cr := &v1alpha1.BtpOperator{}
+	if err := r.client.Get(ctx, types.NamespacedName{
+		Name:      config.BtpOperatorCrName,
+		Namespace: config.KymaSystemNamespaceName,
+	}, cr); err != nil {
+		return fmt.Errorf("getting BtpOperator CR: %w", err)
+	}
+
+	annotations := cr.GetAnnotations()
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+
+	signal := annotations[probeAnnotationSignal]
+	tlsResult := annotations[probeAnnotationTLSResult]
+	hash := annotations[probeAnnotationHash]
+	lastHash := annotations[probeAnnotationLastHash]
+
+	logger.Info("probe cycle result",
+		"signal", signal,
+		"tls-result", tlsResult,
+		"hash", hash,
+		"lastHash", lastHash,
+	)
+
+	// Update metric: 1 if alert, 0 otherwise.
+	if signal == probeSignalAlert {
+		r.statusGauge.Set(1)
+	} else {
+		r.statusGauge.Set(0)
+	}
+
+	// Restart btp-operator pods when: hash changed, TLS ok, and lastHash was non-empty (not first run).
+	if tlsResult == probeTLSResultOK && hash != lastHash && lastHash != "" {
+		logger.Info("CA bundle hash changed with healthy TLS — restarting btp-operator pods")
+		if err := r.restartBtpOperatorPods(ctx); err != nil {
+			logger.Error(err, "failed to restart btp-operator pods")
+		}
+	}
+
+	// Advance tls-probe-last-hash after processing.
+	patch := client.MergeFrom(cr.DeepCopy())
+	if cr.Annotations == nil {
+		cr.Annotations = map[string]string{}
+	}
+	cr.Annotations[probeAnnotationLastHash] = hash
+	if err := r.client.Patch(ctx, cr, patch); err != nil {
+		return fmt.Errorf("patching tls-probe-last-hash: %w", err)
+	}
+
+	return nil
+}
+
+func (r *ProbeRunner) deleteOldJob(ctx context.Context) error {
+	job := &batchv1.Job{}
+	err := r.client.Get(ctx, types.NamespacedName{
+		Name:      probeJobName,
+		Namespace: config.KymaSystemNamespaceName,
+	}, job)
+	if k8serrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	propagation := metav1.DeletePropagationBackground
+	return r.client.Delete(ctx, job, &client.DeleteOptions{
+		PropagationPolicy: &propagation,
+	})
+}
+
+func (r *ProbeRunner) createJob(ctx context.Context) error {
+	backoffLimit := int32(0)
+	env := []corev1.EnvVar{
+		{Name: "PROBE_NAMESPACE", Value: config.KymaSystemNamespaceName},
+	}
+	if r.tokenURLOverride != "" {
+		env = append(env, corev1.EnvVar{Name: "PROBE_TOKENURL_OVERRIDE", Value: r.tokenURLOverride})
+	}
+
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      probeJobName,
+			Namespace: config.KymaSystemNamespaceName,
+		},
+		Spec: batchv1.JobSpec{
+			BackoffLimit: &backoffLimit,
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					RestartPolicy: corev1.RestartPolicyNever,
+					Containers: []corev1.Container{
+						{
+							Name:  "probe",
+							Image: r.probeImage,
+							Env:   env,
+						},
+					},
+				},
+			},
+		},
+	}
+	return r.client.Create(ctx, job)
+}
+
+func (r *ProbeRunner) waitForJob(ctx context.Context) error {
+	logger := log.FromContext(ctx).WithName("probe-runner")
+	// Poll until the job completes (succeeded or failed) or context is cancelled.
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		job := &batchv1.Job{}
+		if err := r.client.Get(ctx, types.NamespacedName{
+			Name:      probeJobName,
+			Namespace: config.KymaSystemNamespaceName,
+		}, job); err != nil {
+			return err
+		}
+
+		if job.Status.Succeeded > 0 {
+			return nil
+		}
+		if job.Status.Failed > 0 {
+			logger.Info("probe job failed; reading annotations anyway")
+			return nil
+		}
+
+		time.Sleep(2 * time.Second)
+	}
+}
+
+func (r *ProbeRunner) restartBtpOperatorPods(ctx context.Context) error {
+	podList := &corev1.PodList{}
+	if err := r.client.List(ctx, podList,
+		client.InNamespace(config.KymaSystemNamespaceName),
+		client.MatchingLabels{"control-plane": "controller-manager"},
+	); err != nil {
+		return err
+	}
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if err := r.client.Delete(ctx, pod); err != nil && !k8serrors.IsNotFound(err) {
+			return err
+		}
+	}
+	return nil
+}

--- a/controllers/probe_runner.go
+++ b/controllers/probe_runner.go
@@ -178,12 +178,22 @@ func (r *ProbeRunner) runCycle(ctx context.Context) error {
 	if hash == "" {
 		return nil
 	}
-	patch := client.MergeFrom(cr.DeepCopy())
-	if cr.Annotations == nil {
-		cr.Annotations = map[string]string{}
+	// Re-fetch the CR immediately before patching to avoid overwriting the probe-written
+	// annotations (tls-probe-status, tls-probe-hash, tls-probe-updated-at) with the stale
+	// base captured before the Job ran.
+	freshCR := &v1alpha1.BtpOperator{}
+	if err := r.client.Get(ctx, types.NamespacedName{
+		Name:      config.BtpOperatorCrName,
+		Namespace: config.KymaSystemNamespaceName,
+	}, freshCR); err != nil {
+		return fmt.Errorf("re-fetching BtpOperator CR for patch: %w", err)
 	}
-	cr.Annotations[probeAnnotationLastHash] = hash
-	if err := r.client.Patch(ctx, cr, patch); err != nil {
+	patch := client.MergeFrom(freshCR.DeepCopy())
+	if freshCR.Annotations == nil {
+		freshCR.Annotations = map[string]string{}
+	}
+	freshCR.Annotations[probeAnnotationLastHash] = hash
+	if err := r.client.Patch(ctx, freshCR, patch); err != nil {
 		return fmt.Errorf("patching tls-probe-last-hash: %w", err)
 	}
 
@@ -321,7 +331,7 @@ func (r *ProbeRunner) restartBtpOperatorPods(ctx context.Context) error {
 	podList := &corev1.PodList{}
 	if err := r.client.List(ctx, podList,
 		client.InNamespace(config.KymaSystemNamespaceName),
-		client.MatchingLabels{"control-plane": "controller-manager"},
+		client.MatchingLabels{"app.kubernetes.io/instance": "sap-btp-operator"},
 	); err != nil {
 		return err
 	}

--- a/controllers/probe_runner.go
+++ b/controllers/probe_runner.go
@@ -66,7 +66,10 @@ func NewProbeRunner(c client.Client, registry prometheus.Registerer) *ProbeRunne
 }
 
 func parseProbeInterval(raw string) time.Duration {
-	if raw == "" || raw == "0" || raw == "0s" {
+	if raw == "" {
+		return 30 * time.Minute
+	}
+	if raw == "0" || raw == "0s" {
 		return 0
 	}
 	d, err := time.ParseDuration(raw)

--- a/controllers/probe_runner_test.go
+++ b/controllers/probe_runner_test.go
@@ -1,0 +1,96 @@
+package controllers
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kyma-project/btp-manager/controllers/config"
+)
+
+var _ = Describe("ProbeRunner", Label("probe-runner"), func() {
+	var runner *ProbeRunner
+
+	BeforeEach(func() {
+		runner = &ProbeRunner{client: k8sClient}
+	})
+
+	AfterEach(func() {
+		job := &batchv1.Job{}
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: probeJobName, Namespace: config.KymaSystemNamespaceName}, job)
+		if err == nil {
+			propagation := metav1.DeletePropagationBackground
+			_ = k8sClient.Delete(ctx, job, &client.DeleteOptions{PropagationPolicy: &propagation})
+		}
+	})
+
+	Describe("waitForJob", func() {
+		It("times out internally when the job stays pending and no external deadline is set", func() {
+			origTimeout := jobWaitTimeout
+			jobWaitTimeout = 300 * time.Millisecond
+			defer func() { jobWaitTimeout = origTimeout }()
+
+			backoffLimit := int32(0)
+			job := &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      probeJobName,
+					Namespace: config.KymaSystemNamespaceName,
+				},
+				Spec: batchv1.JobSpec{
+					BackoffLimit: &backoffLimit,
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							RestartPolicy: corev1.RestartPolicyNever,
+							Containers: []corev1.Container{
+								{Name: "probe", Image: "busybox:latest"},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, job)).To(Succeed())
+
+			// Pass a background context with no deadline — waitForJob must impose its own.
+			err := runner.waitForJob(ctx)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("deleteOldJob", func() {
+		It("does not return AlreadyExists when createJob is called immediately after deleteOldJob", func() {
+			origTimeout := jobWaitTimeout
+			jobWaitTimeout = 5 * time.Second
+			defer func() { jobWaitTimeout = origTimeout }()
+
+			backoffLimit := int32(0)
+			job := &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      probeJobName,
+					Namespace: config.KymaSystemNamespaceName,
+				},
+				Spec: batchv1.JobSpec{
+					BackoffLimit: &backoffLimit,
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							RestartPolicy: corev1.RestartPolicyNever,
+							Containers: []corev1.Container{
+								{Name: "probe", Image: "busybox:latest"},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, job)).To(Succeed())
+
+			Expect(runner.deleteOldJob(ctx)).To(Succeed())
+			runner.probeImage = "busybox:latest"
+			Expect(runner.createJob(ctx)).To(Succeed())
+		})
+	})
+})

--- a/main.go
+++ b/main.go
@@ -146,6 +146,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	probeRunner := controllers.NewProbeRunner(mgr.GetClient(), ctrlmetrics.Registry)
+	if err := mgr.Add(probeRunner); err != nil {
+		setupLog.Error(err, "unable to register probe runner as runnable")
+		os.Exit(1)
+	}
+
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/tests/probe/main.go
+++ b/tests/probe/main.go
@@ -32,9 +32,9 @@ const (
 	tlsResultOK     = "ok"
 	tlsResultX509   = "failed-x509"
 	tlsResultOther  = "failed-other"
-	signalOK    = "ok"
-	signalAlert = "alert"
-	signalError = "error"
+	signalOK        = "ok"
+	signalAlert     = "alert"
+	signalError     = "error"
 )
 
 type config struct {

--- a/tests/probe/main.go
+++ b/tests/probe/main.go
@@ -32,10 +32,9 @@ const (
 	tlsResultOK     = "ok"
 	tlsResultX509   = "failed-x509"
 	tlsResultOther  = "failed-other"
-	signalOK        = "ok"
-	signalAlert     = "alert"
-	signalError     = "error"
-	signalWarning   = "warning"
+	signalOK    = "ok"
+	signalAlert = "alert"
+	signalError = "error"
 )
 
 type config struct {
@@ -165,9 +164,6 @@ func computeSignal(mountPresent bool, tlsResult string) string {
 		}
 		return signalError
 	default: // failed-other
-		if mountPresent {
-			return signalWarning
-		}
 		return signalError
 	}
 }

--- a/tests/probe/main_test.go
+++ b/tests/probe/main_test.go
@@ -123,7 +123,7 @@ func TestComputeSignal(t *testing.T) {
 		{false, tlsResultOther, signalError},
 		{true, tlsResultOK, signalOK},
 		{true, tlsResultX509, signalAlert},
-		{true, tlsResultOther, signalWarning},
+		{true, tlsResultOther, signalError},
 	}
 	for _, c := range cases {
 		assert.Equal(t, c.expected, computeSignal(c.mount, c.tls), "mount=%v tls=%s", c.mount, c.tls)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `ProbeRunner`, a controller-runtime `Runnable` that periodically spawns a `ca-bundle-probe` Job at a configurable interval (`PROBE_INTERVAL` env var) and processes its results
- Disable the probe entirely when `PROBE_INTERVAL` is empty or zero, or `PROBE_IMAGE` is unset
- Read `tls-probe-signal`, `tls-probe-tls-result`, `tls-probe-hash`, and `tls-probe-last-hash` annotations from the BtpOperator CR after each probe Job completes
- Expose `btpmanager_credential_probe_status` gauge metric (0=healthy, 1=alert) on btp-manager's existing `:8080/metrics` endpoint
- Restart sap-btp-operator pods (via pod deletion) when the CA bundle hash changes and TLS is healthy, skipping the first run (empty `lastHash`)
- Pass `PROBE_TOKENURL_OVERRIDE` through to the probe Job env for test environments
- Add RBAC rule for `batch/jobs` (`get`, `create`, `delete`) to `config/rbac/role.yaml`
- Wire `ProbeRunner` into `main.go` via `mgr.Add()`

**Related issue(s)**