### PR TITLE
Fix Component Config Name and Team

### DIFF
--- a/component-config.yaml
+++ b/component-config.yaml
@@ -1,5 +1,5 @@
 name: kyma-project.io/module/btp-manager
-team: kyma/gophers
+team: kyma/gopher
 images:
 - europe-docker.pkg.dev/kyma-project/prod/btp-manager:1.3.8
 - europe-docker.pkg.dev/kyma-project/prod/external/ghcr.io/sap/sap-btp-service-operator/controller:v0.11.6

--- a/component-config.yaml
+++ b/component-config.yaml
@@ -1,4 +1,4 @@
-name: kyma-project.io/module/btp-manager
+name: kyma-project.io/module/btp-operator
 team: kyma/gopher
 images:
 - europe-docker.pkg.dev/kyma-project/prod/btp-manager:1.3.8

--- a/component-config.yaml
+++ b/component-config.yaml
@@ -1,4 +1,4 @@
-name: kyma-project.io/kyma-runtime/kcp-components/btp-manager
+name: kyma-project.io/module/btp-manager
 team: kyma/gophers
 images:
 - europe-docker.pkg.dev/kyma-project/prod/btp-manager:1.3.8

--- a/scripts/create_component_config.sh
+++ b/scripts/create_component_config.sh
@@ -16,7 +16,7 @@ CONTROLLER_SOURCE=$(yq '.images[] | select(.source | contains("sap-btp-service-o
 echo "Updating component-config.yaml for release ${TAG}:"
 
 cat <<EOF | tee component-config.yaml
-name: kyma-project.io/kyma-runtime/kcp-components/btp-manager
+name: kyma-project.io/module/btp-manager
 team: kyma/gophers
 images:
 - europe-docker.pkg.dev/kyma-project/prod/btp-manager:${TAG}

--- a/scripts/create_component_config.sh
+++ b/scripts/create_component_config.sh
@@ -16,7 +16,7 @@ CONTROLLER_SOURCE=$(yq '.images[] | select(.source | contains("sap-btp-service-o
 echo "Updating component-config.yaml for release ${TAG}:"
 
 cat <<EOF | tee component-config.yaml
-name: kyma-project.io/module/btp-manager
+name: kyma-project.io/module/btp-operator
 team: kyma/gopher
 images:
 - europe-docker.pkg.dev/kyma-project/prod/btp-manager:${TAG}

--- a/scripts/create_component_config.sh
+++ b/scripts/create_component_config.sh
@@ -17,7 +17,7 @@ echo "Updating component-config.yaml for release ${TAG}:"
 
 cat <<EOF | tee component-config.yaml
 name: kyma-project.io/module/btp-manager
-team: kyma/gophers
+team: kyma/gopher
 images:
 - europe-docker.pkg.dev/kyma-project/prod/btp-manager:${TAG}
 - europe-docker.pkg.dev/kyma-project/prod/external/${CONTROLLER_SOURCE}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix component name from `kyma-project.io/kyma-runtime/kcp-components/btp-manager` to `kyma-project.io/module/btp-manager`
- Fix team name from `kyma/gophers` to `kyma/gopher`

**Related issue(s)**