### PR TITLE
Build CA Bundle Probe Image In PR Workflow

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -27,5 +27,5 @@ jobs:
           delay: '2'
           retries: '15'
           polling_interval: '1'
-          checks_exclude: 'markdown-link-check,enable-auto-merge,run-govulncheck,scan,run-e2e-sap-btp-manager-secret-customization-test,restricted-gate,build-image,run-ca-bundle-probe-e2e'
+          checks_exclude: 'markdown-link-check,enable-auto-merge,run-govulncheck,scan,run-e2e-sap-btp-manager-secret-customization-test,restricted-gate,build-image,run-ca-bundle-probe-e2e,build-probe-image'
           verbose: true

--- a/.github/workflows/pull-btp-manager-build.yaml
+++ b/.github/workflows/pull-btp-manager-build.yaml
@@ -26,3 +26,11 @@ jobs:
          name: btp-manager
          dockerfile: Dockerfile
          context: .
+
+   build-probe-image:
+      needs: restricted-gate
+      uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main # Usage: kyma-project/test-infra/.github/workflows/image-builder.yml@main
+      with:
+         name: ca-bundle-probe
+         dockerfile: tests/probe/Dockerfile
+         context: .


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `build-probe-image` job to the PR build workflow to build and publish the `ca-bundle-probe` image using the shared `image-builder` workflow

**Related issue(s)**