### PR TITLE
Align Probe Dockerfile With Main Dockerfile

### DIFF
--- a/tests/probe/Dockerfile
+++ b/tests/probe/Dockerfile
@@ -1,11 +1,15 @@
-FROM golang:1.26.4-alpine3.22 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine3.22 AS builder
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 GOFIPS140=v1.0.0 go build -o /probe ./tests/probe/
+ARG TARGETOS TARGETARCH
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    CGO_ENABLED=0 GOFIPS140=v1.0.0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /probe ./tests/probe/
 
 FROM gcr.io/distroless/static:nonroot
 ENV GODEBUG=fips140=only,tlsmlkem=0
-COPY --from=builder /probe /probe
+COPY --chown=65532:65532 --from=builder /probe /probe
+USER 65532:65532
 ENTRYPOINT ["/probe"]


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `--platform=$BUILDPLATFORM` to builder stage for correct cross-compilation on non-amd64 hosts
- Add `ARG TARGETOS TARGETARCH` and pass `GOOS`/`GOARCH` to the build command
- Add build cache mounts for Go build cache and module cache
- Add `--chown=65532:65532` and `USER 65532:65532` to the final stage

**Related issue(s)**