### PR TITLE
Fix Release Workflow PR Labeling Using GITHUB_TOKEN

### DIFF
--- a/.github/workflows/create-release-with-version-submit.yaml
+++ b/.github/workflows/create-release-with-version-submit.yaml
@@ -210,6 +210,8 @@ jobs:
     name: Bump sec-scanners-config
     needs: [validate-release, run-unit-tests, run-e2e-tests, run-stress-tests, run-performance-tests, run-e2e-upgrade-tests, run-e2e-upgrade-while-deleting-tests, run-e2e-sap-btp-manager-secret-customization-test, build-probe-image]
     runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: -1
 
     steps:
       - name: Checkout code

--- a/.github/workflows/create-release-with-version-submit.yaml
+++ b/.github/workflows/create-release-with-version-submit.yaml
@@ -11,6 +11,7 @@ env:
 permissions:
   contents: write
   id-token: write
+  pull-requests: write
 
 on:
   workflow_dispatch:
@@ -256,7 +257,18 @@ jobs:
             echo "PR_NUMBER=-1" >> $GITHUB_ENV
           else
             PR_STATUS=$(scripts/create_sec_scanner_bump_pr.sh ${{ inputs.name }})
-            echo "PR_NUMBER=$(echo "$PR_STATUS" | tail -n 1)" >> $GITHUB_ENV          
+            echo "PR_NUMBER=$(echo "$PR_STATUS" | tail -n 1)" >> $GITHUB_ENV
+          fi
+
+      - name: Label PR
+        if: ${{ !inputs.skip-sec-file-bump }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "$PR_NUMBER" -gt 0 ]; then
+            gh pr edit "$PR_NUMBER" --add-label kind/enhancement
+          else
+            echo "Step skipped"
           fi
 
       - name: Merge PR

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -11,7 +11,8 @@ env:
 permissions:
   contents: write
   id-token: write
-  
+  pull-requests: write
+
 on:
   workflow_dispatch:
     inputs:
@@ -255,7 +256,18 @@ jobs:
             echo "PR_NUMBER=-1" >> $GITHUB_ENV
           else
             PR_STATUS=$(scripts/create_sec_scanner_bump_pr.sh ${{ inputs.name }})
-            echo "PR_NUMBER=$(echo "$PR_STATUS" | tail -n 1)" >> $GITHUB_ENV          
+            echo "PR_NUMBER=$(echo "$PR_STATUS" | tail -n 1)" >> $GITHUB_ENV
+          fi
+
+      - name: Label PR
+        if: ${{ !inputs.skip-sec-file-bump }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "$PR_NUMBER" -gt 0 ]; then
+            gh pr edit "$PR_NUMBER" --add-label kind/enhancement
+          else
+            echo "Step skipped"
           fi
 
       - name: Merge PR

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -209,6 +209,8 @@ jobs:
     name: Bump sec-scanners-config
     needs: [validate-release, run-unit-tests, run-e2e-tests, run-stress-tests, run-performance-tests, run-e2e-upgrade-tests, run-e2e-upgrade-while-deleting-tests, run-e2e-sap-btp-manager-secret-customization-test, build-probe-image]
     runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: -1
 
     steps:
       - name: Checkout code

--- a/scripts/create_sec_scanner_bump_pr.sh
+++ b/scripts/create_sec_scanner_bump_pr.sh
@@ -49,5 +49,4 @@ pr_link=$(gh pr create -B main --title "Bump sec-scanners-config.yaml and compon
 echo "Link for created PR: ${pr_link}"
 
 pr_number=$(echo "$pr_link" | awk -F'/' '{print $NF}')
-gh pr edit $pr_number --add-label kind/enhancement
 echo "$pr_number"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Remove `gh pr edit --add-label kind/enhancement` from `scripts/create_sec_scanner_bump_pr.sh` (ran as `kyma-gopher-bot` via `BOT_TOKEN`, which lost `addLabelsToLabelable` GraphQL permission)
- Add a dedicated `Label PR` step in both release workflows using `GITHUB_TOKEN` instead
- Add `pull-requests: write` permission to both `create-release.yaml` and `create-release-with-version-submit.yaml`

**Related issue(s)**