### PR TITLE
Exclude Release Bump PRs From CA Bundle Probe E2E Tests

### DIFF
--- a/.github/workflows/run-e2e-ca-bundle-probe-tests.yaml
+++ b/.github/workflows/run-e2e-ca-bundle-probe-tests.yaml
@@ -3,8 +3,12 @@ name: Run CA bundle probe E2E tests
 on:
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
-    branches-ignore:
-      - sec-scanners-config-*
+    paths-ignore:
+      - "**.md"
+      - "sec-scanners-config.yaml"
+      - "component-config.yaml"
+      - "external-images.yaml"
+      - "module-chart/**"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/run-e2e-ca-bundle-probe-tests.yaml
+++ b/.github/workflows/run-e2e-ca-bundle-probe-tests.yaml
@@ -3,6 +3,8 @@ name: Run CA bundle probe E2E tests
 on:
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
+    branches-ignore:
+      - sec-scanners-config-*
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/run-e2e-ca-bundle-probe-tests.yaml
+++ b/.github/workflows/run-e2e-ca-bundle-probe-tests.yaml
@@ -7,8 +7,6 @@ on:
       - "**.md"
       - "sec-scanners-config.yaml"
       - "component-config.yaml"
-      - "external-images.yaml"
-      - "module-chart/**"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `branches-ignore: sec-scanners-config-*` to the `pull_request` trigger in `run-e2e-ca-bundle-probe-tests.yaml` so the CA bundle probe E2E test does not run on the automated release bump PRs

**Related issue(s)**