### PR TITLE
Use GITHUB_TOKEN to Publish Release Draft

### DIFF
--- a/.github/workflows/create-release-with-version-submit.yaml
+++ b/.github/workflows/create-release-with-version-submit.yaml
@@ -402,7 +402,7 @@ jobs:
 
       - name: Publish release
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release edit ${{ inputs.name }} --draft=false
 

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -400,6 +400,6 @@ jobs:
 
       - name: Publish release
         env:
-          GITHUB_TOKEN: ${{ secrets.BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release edit ${{ inputs.name }} --draft=false


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Replace `secrets.BOT_TOKEN` with `secrets.GITHUB_TOKEN` in the `Publish release` step of both release workflows — `BOT_TOKEN` lacks the scope to find and edit draft releases, causing `gh release edit --draft=false` to fail with "release not found"

**Related issue(s)**