### PR TITLE
Add CA Bundle Probe E2E Tests to Release Workflows

### DIFF
--- a/.github/workflows/create-release-with-version-submit.yaml
+++ b/.github/workflows/create-release-with-version-submit.yaml
@@ -94,6 +94,15 @@ jobs:
       context: .
       tags: ${{ inputs.name }}
 
+  run-e2e-ca-bundle-probe-tests:
+    name: CA bundle probe E2E tests
+    needs: [build-image, build-probe-image]
+    uses: "./.github/workflows/run-e2e-ca-bundle-probe-tests-reusable.yaml"
+    with:
+      release: "true"
+      image-registry: europe-docker.pkg.dev/kyma-project/prod/btp-manager
+      image-tag: ${{ github.event.inputs.name }}
+
   run-unit-tests:
     name: Unit tests
     uses: "./.github/workflows/run-unit-tests-reusable.yaml"
@@ -207,7 +216,7 @@ jobs:
 
   bump-sec-scanners-config:
     name: Bump sec-scanners-config
-    needs: [validate-release, run-unit-tests, run-e2e-tests, run-stress-tests, run-performance-tests, run-e2e-upgrade-tests, run-e2e-upgrade-while-deleting-tests, run-e2e-sap-btp-manager-secret-customization-test, build-probe-image]
+    needs: [validate-release, run-unit-tests, run-e2e-tests, run-stress-tests, run-performance-tests, run-e2e-upgrade-tests, run-e2e-upgrade-while-deleting-tests, run-e2e-sap-btp-manager-secret-customization-test, run-e2e-ca-bundle-probe-tests, build-probe-image]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -94,6 +94,15 @@ jobs:
       context: .
       tags: ${{ inputs.name }}
 
+  run-e2e-ca-bundle-probe-tests:
+    name: CA bundle probe E2E tests
+    needs: [build-image, build-probe-image]
+    uses: "./.github/workflows/run-e2e-ca-bundle-probe-tests-reusable.yaml"
+    with:
+      release: "true"
+      image-registry: europe-docker.pkg.dev/kyma-project/prod/btp-manager
+      image-tag: ${{ github.event.inputs.name }}
+
   run-unit-tests:
     name: Unit tests
     uses: "./.github/workflows/run-unit-tests-reusable.yaml"
@@ -206,7 +215,7 @@ jobs:
 
   bump-sec-scanners-config:
     name: Bump sec-scanners-config
-    needs: [validate-release, run-unit-tests, run-e2e-tests, run-stress-tests, run-performance-tests, run-e2e-upgrade-tests, run-e2e-upgrade-while-deleting-tests, run-e2e-sap-btp-manager-secret-customization-test, build-probe-image]
+    needs: [validate-release, run-unit-tests, run-e2e-tests, run-stress-tests, run-performance-tests, run-e2e-upgrade-tests, run-e2e-upgrade-while-deleting-tests, run-e2e-sap-btp-manager-secret-customization-test, run-e2e-ca-bundle-probe-tests, build-probe-image]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/run-e2e-ca-bundle-probe-tests-reusable.yaml
+++ b/.github/workflows/run-e2e-ca-bundle-probe-tests-reusable.yaml
@@ -1,0 +1,98 @@
+name: Run CA bundle probe E2E tests (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      release:
+        description: Determines if the workflow is called from release
+        default: "false"
+        type: string
+      image-registry:
+        description: BTP Manager image registry
+        required: true
+        type: string
+      image-tag:
+        description: BTP Manager image tag
+        required: true
+        type: string
+
+jobs:
+  run-ca-bundle-probe-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Prepare K3s cluster and docker registry
+        run: "./scripts/testing/k3s-setup.sh --wait"
+
+      - name: Build and push BTP Manager image to local registry
+        if: ${{ inputs.release == 'false' }}
+        run: ./scripts/testing/build-and-push-image.sh ${{ inputs.image-registry }}:${{ inputs.image-tag }}
+
+      - name: Build and push probe image to local registry
+        if: ${{ inputs.release == 'false' }}
+        run: |
+          docker build -t localhost:5000/ca-bundle-probe:${{ inputs.image-tag }} -f tests/probe/Dockerfile .
+          docker push localhost:5000/ca-bundle-probe:${{ inputs.image-tag }}
+
+      - name: Build and push test infrastructure images to local registry
+        run: |
+          docker build -t localhost:5000/fake-server:${{ inputs.image-tag }} -f tests/fake-server/Dockerfile .
+          docker push localhost:5000/fake-server:${{ inputs.image-tag }}
+          docker build -t localhost:5000/ca-bundle-webhook:${{ inputs.image-tag }} -f tests/webhook/Dockerfile .
+          docker push localhost:5000/ca-bundle-webhook:${{ inputs.image-tag }}
+
+      - name: Install BTP operator (dummy credentials)
+        run: "./scripts/testing/install_module.sh ${{ inputs.image-registry }}:${{ inputs.image-tag }} dummy"
+
+      - name: Configure probe runner in BTP Manager deployment
+        run: |
+          if [[ "${{ inputs.release }}" == "true" ]]; then
+            PROBE_IMAGE=europe-docker.pkg.dev/kyma-project/prod/ca-bundle-probe:${{ inputs.image-tag }}
+          else
+            PROBE_IMAGE=localhost:5000/ca-bundle-probe:${{ inputs.image-tag }}
+          fi
+          kubectl patch configmap sap-btp-manager -n kyma-system \
+            --type merge -p '{"data":{"ProbeInterval":"10s"}}'
+          kubectl set env deployment/btp-manager-controller-manager \
+            -n kyma-system \
+            -c manager \
+            PROBE_IMAGE=$PROBE_IMAGE \
+            PROBE_TOKENURL_OVERRIDE=https://fake-server.kyma-system.svc.cluster.local/health
+          kubectl rollout restart deployment/btp-manager-controller-manager -n kyma-system
+          kubectl rollout status deployment/btp-manager-controller-manager \
+            -n kyma-system --timeout=120s
+
+      - name: Run CA bundle probe E2E tests
+        env:
+          PROBE_IMAGE: ${{ inputs.release == 'true' && format('europe-docker.pkg.dev/kyma-project/prod/ca-bundle-probe:{0}', inputs.image-tag) || format('localhost:5000/ca-bundle-probe:{0}', inputs.image-tag) }}
+          FAKE_SERVER_IMAGE: localhost:5000/fake-server:${{ inputs.image-tag }}
+          WEBHOOK_IMAGE: localhost:5000/ca-bundle-webhook:${{ inputs.image-tag }}
+        run: "./scripts/testing/run_e2e_ca_bundle_probe_test.sh"
+
+      - name: Dump debug info on failure
+        if: failure()
+        run: |
+          echo "=== btp-manager pods ==="
+          kubectl get pods -n kyma-system -l app.kubernetes.io/component=btp-manager.kyma-project.io || true
+          echo "=== btp-manager logs (current + previous) ==="
+          kubectl logs -n kyma-system -l app.kubernetes.io/component=btp-manager.kyma-project.io --tail=150 || true
+          kubectl logs -n kyma-system -l app.kubernetes.io/component=btp-manager.kyma-project.io --tail=150 -p 2>/dev/null || true
+          echo "=== probe jobs ==="
+          kubectl get jobs -n kyma-system || true
+          kubectl describe jobs/ca-bundle-probe -n kyma-system 2>/dev/null || true
+          echo "=== probe job pods ==="
+          kubectl get pods -n kyma-system -l job-name=ca-bundle-probe || true
+          kubectl logs -n kyma-system -l job-name=ca-bundle-probe --tail=50 || true
+          echo "=== BtpOperator annotations ==="
+          kubectl get btpoperator/btpoperator -n kyma-system -o jsonpath='{.metadata.annotations}' | tr ',' '\n' || true
+          echo "=== btp-manager deployment env ==="
+          kubectl get deployment/btp-manager-controller-manager -n kyma-system \
+            -o jsonpath='{.spec.template.spec.containers[0].env}' | tr ',' '\n' || true

--- a/.github/workflows/run-e2e-ca-bundle-probe-tests.yaml
+++ b/.github/workflows/run-e2e-ca-bundle-probe-tests.yaml
@@ -3,75 +3,16 @@ name: Run CA bundle probe E2E tests
 on:
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
+    paths-ignore:
+      - "**.md"
+      - "sec-scanners-config.yaml"
+      - "component-config.yaml"
   workflow_dispatch:
 
 jobs:
   run-ca-bundle-probe-e2e:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7
-
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: Prepare K3s cluster and docker registry
-        run: "./scripts/testing/k3s-setup.sh --wait"
-
-      - name: Build and push BTP Manager image to local registry
-        run: ./scripts/testing/build-and-push-image.sh localhost:5000/btp-manager:latest
-
-      - name: Install BTP operator (dummy credentials)
-        run: "./scripts/testing/install_module.sh localhost:5000/btp-manager:latest dummy"
-
-      - name: Build and push probe images to local registry
-        run: |
-          docker build -t localhost:5000/ca-bundle-probe:latest -f tests/probe/Dockerfile .
-          docker push localhost:5000/ca-bundle-probe:latest
-          docker build -t localhost:5000/fake-server:latest -f tests/fake-server/Dockerfile .
-          docker push localhost:5000/fake-server:latest
-          docker build -t localhost:5000/ca-bundle-webhook:latest -f tests/webhook/Dockerfile .
-          docker push localhost:5000/ca-bundle-webhook:latest
-
-      - name: Configure probe runner in BTP Manager deployment
-        run: |
-          kubectl patch configmap sap-btp-manager -n kyma-system \
-            --type merge -p '{"data":{"ProbeInterval":"10s"}}'
-          kubectl set env deployment/btp-manager-controller-manager \
-            -n kyma-system \
-            -c manager \
-            PROBE_IMAGE=localhost:5000/ca-bundle-probe:latest \
-            PROBE_TOKENURL_OVERRIDE=https://fake-server.kyma-system.svc.cluster.local/health
-          kubectl rollout restart deployment/btp-manager-controller-manager -n kyma-system
-          kubectl rollout status deployment/btp-manager-controller-manager \
-            -n kyma-system --timeout=120s
-
-      - name: Run CA bundle probe E2E tests
-        env:
-          PROBE_IMAGE: localhost:5000/ca-bundle-probe:latest
-          FAKE_SERVER_IMAGE: localhost:5000/fake-server:latest
-          WEBHOOK_IMAGE: localhost:5000/ca-bundle-webhook:latest
-        run: "./scripts/testing/run_e2e_ca_bundle_probe_test.sh"
-
-      - name: Dump debug info on failure
-        if: failure()
-        run: |
-          echo "=== btp-manager pods ==="
-          kubectl get pods -n kyma-system -l app.kubernetes.io/component=btp-manager.kyma-project.io || true
-          echo "=== btp-manager logs (current + previous) ==="
-          kubectl logs -n kyma-system -l app.kubernetes.io/component=btp-manager.kyma-project.io --tail=150 || true
-          kubectl logs -n kyma-system -l app.kubernetes.io/component=btp-manager.kyma-project.io --tail=150 -p 2>/dev/null || true
-          echo "=== probe jobs ==="
-          kubectl get jobs -n kyma-system || true
-          kubectl describe jobs/ca-bundle-probe -n kyma-system 2>/dev/null || true
-          echo "=== probe job pods ==="
-          kubectl get pods -n kyma-system -l job-name=ca-bundle-probe || true
-          kubectl logs -n kyma-system -l job-name=ca-bundle-probe --tail=50 || true
-          echo "=== BtpOperator annotations ==="
-          kubectl get btpoperator/btpoperator -n kyma-system -o jsonpath='{.metadata.annotations}' | tr ',' '\n' || true
-          echo "=== btp-manager deployment env ==="
-          kubectl get deployment/btp-manager-controller-manager -n kyma-system \
-            -o jsonpath='{.spec.template.spec.containers[0].env}' | tr ',' '\n' || true
+    uses: "./.github/workflows/run-e2e-ca-bundle-probe-tests-reusable.yaml"
+    with:
+      release: "false"
+      image-registry: localhost:5000/btp-manager
+      image-tag: latest


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Extract probe E2E test steps into a new reusable workflow `run-e2e-ca-bundle-probe-tests-reusable.yaml` with `release`, `image-registry`, and `image-tag` inputs
- For release mode: use prod registry images for `btp-manager` and `ca-bundle-probe`; always build `fake-server` and `ca-bundle-webhook` locally (test infrastructure only)
- Update `run-e2e-ca-bundle-probe-tests.yaml` (PR trigger) to delegate to the reusable workflow; add `paths-ignore` to skip the test on sec-scanners-config bump PRs
- Add `run-e2e-ca-bundle-probe-tests` job to both `create-release.yaml` and `create-release-with-version-submit.yaml`, gated on `build-image` and `build-probe-image`, and added as a dependency of `bump-sec-scanners-config`

**Related issue(s)**