### PR TITLE
Add Probe RBAC Resources to Kustomize Manifest

### DIFF
--- a/.github/workflows/run-e2e-ca-bundle-probe-tests-reusable.yaml
+++ b/.github/workflows/run-e2e-ca-bundle-probe-tests-reusable.yaml
@@ -85,10 +85,10 @@ jobs:
           kubectl logs -n kyma-system -l app.kubernetes.io/component=btp-manager.kyma-project.io --tail=150 -p 2>/dev/null || true
           echo "=== probe jobs ==="
           kubectl get jobs -n kyma-system || true
-          kubectl describe jobs/ca-bundle-probe -n kyma-system 2>/dev/null || true
+          kubectl describe jobs/btp-manager-ca-bundle-probe -n kyma-system 2>/dev/null || true
           echo "=== probe job pods ==="
-          kubectl get pods -n kyma-system -l job-name=ca-bundle-probe || true
-          kubectl logs -n kyma-system -l job-name=ca-bundle-probe --tail=50 || true
+          kubectl get pods -n kyma-system -l job-name=btp-manager-ca-bundle-probe || true
+          kubectl logs -n kyma-system -l job-name=btp-manager-ca-bundle-probe --tail=50 || true
           echo "=== BtpOperator annotations ==="
           kubectl get btpoperator/btpoperator -n kyma-system -o jsonpath='{.metadata.annotations}' | tr ',' '\n' || true
           echo "=== btp-manager deployment env ==="

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+- probe_rbac.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.

--- a/config/rbac/probe_rbac.yaml
+++ b/config/rbac/probe_rbac.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: btp-manager-ca-bundle-probe
-  namespace: kyma-system
+  name: ca-bundle-probe
+  namespace: system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: btp-manager-ca-bundle-probe
+  name: ca-bundle-probe
 rules:
   - apiGroups: ["operator.kyma-project.io"]
     resources: ["btpoperators"]
@@ -19,12 +19,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: btp-manager-ca-bundle-probe
+  name: ca-bundle-probe
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: btp-manager-ca-bundle-probe
+  name: ca-bundle-probe
 subjects:
   - kind: ServiceAccount
-    name: btp-manager-ca-bundle-probe
-    namespace: kyma-system
+    name: ca-bundle-probe
+    namespace: system

--- a/controllers/probe_runner.go
+++ b/controllers/probe_runner.go
@@ -23,7 +23,7 @@ import (
 //+kubebuilder:rbac:groups="batch",resources="jobs",verbs=get;list;watch;create;delete
 
 const (
-	probeJobName             = "ca-bundle-probe"
+	probeJobName             = "btp-manager-ca-bundle-probe"
 	probeAnnotationStatus    = "tls-probe-status"
 	probeAnnotationHash      = "tls-probe-hash"
 	probeAnnotationLastHash  = "tls-probe-last-hash"

--- a/scripts/testing/run_e2e_ca_bundle_probe_test.sh
+++ b/scripts/testing/run_e2e_ca_bundle_probe_test.sh
@@ -331,9 +331,9 @@ kubectl delete deployment/ca-bundle-webhook deployment/fake-server -n "$NAMESPAC
 kubectl delete service/ca-bundle-webhook service/fake-server -n "$NAMESPACE" --ignore-not-found
 kubectl delete mutatingwebhookconfiguration/ca-bundle-webhook --ignore-not-found
 kubectl delete secret/ca-bundle secret/fake-server-tls secret/ca-bundle-webhook-tls -n "$NAMESPACE" --ignore-not-found
-kubectl delete clusterrole/ca-bundle-probe clusterrole/ca-bundle-webhook --ignore-not-found
-kubectl delete clusterrolebinding/ca-bundle-probe clusterrolebinding/ca-bundle-webhook --ignore-not-found
-kubectl delete serviceaccount/ca-bundle-probe serviceaccount/ca-bundle-webhook -n "$NAMESPACE" --ignore-not-found
+kubectl delete clusterrole/btp-manager-ca-bundle-probe clusterrole/ca-bundle-webhook --ignore-not-found
+kubectl delete clusterrolebinding/btp-manager-ca-bundle-probe clusterrolebinding/ca-bundle-webhook --ignore-not-found
+kubectl delete serviceaccount/btp-manager-ca-bundle-probe serviceaccount/ca-bundle-webhook -n "$NAMESPACE" --ignore-not-found
 
 echo ""
 echo "╔══════════════════════════════════════════════════════════════════╗"

--- a/scripts/testing/simulate_btp_manager.sh
+++ b/scripts/testing/simulate_btp_manager.sh
@@ -66,7 +66,7 @@ metadata:
 spec:
   template:
     spec:
-      serviceAccountName: ca-bundle-probe
+      serviceAccountName: btp-manager-ca-bundle-probe
       restartPolicy: Never
       containers:
         - name: probe

--- a/scripts/testing/simulate_btp_manager.sh
+++ b/scripts/testing/simulate_btp_manager.sh
@@ -101,9 +101,11 @@ reconcile() {
       --wait=false 2>/dev/null || true
   fi
 
-  # Advance last-hash unconditionally
-  kubectl annotate btpoperator/"$BTPOPERATOR_NAME" -n "$NAMESPACE" \
-    --overwrite "tls-probe-last-hash=$hash" 2>/dev/null
+  # Advance last-hash only when probe wrote a non-empty hash (matches probe_runner.go behaviour)
+  if [[ -n "$hash" ]]; then
+    kubectl annotate btpoperator/"$BTPOPERATOR_NAME" -n "$NAMESPACE" \
+      --overwrite "tls-probe-last-hash=$hash" 2>/dev/null
+  fi
 }
 
 runCycle() {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `config/rbac/probe_rbac.yaml` with ServiceAccount, ClusterRole, and ClusterRoleBinding for the CA bundle probe job
- Include `probe_rbac.yaml` in `config/rbac/kustomization.yaml` so resources are included in the built manifest
- Rename probe job and service account from `ca-bundle-probe` to `btp-manager-ca-bundle-probe` to align with the kustomize `namePrefix: btp-manager-` convention
- Update `tests/probe/manifests/rbac.yaml` to use the new prefixed names
- Update teardown in `run_e2e_ca_bundle_probe_test.sh` to delete resources under the new names
- Update `simulate_btp_manager.sh` and `simulate-rt-bootstrapper.sh` to reference the new service account and job names
- Update debug dump in `run-e2e-ca-bundle-probe-tests-reusable.yaml` to use the new job name

**Related issue(s)**