### PR TITLE
Fix Probe Runner Reliability Issues

### DIFF
--- a/controllers/probe_runner.go
+++ b/controllers/probe_runner.go
@@ -269,6 +269,11 @@ func (r *ProbeRunner) createJob(ctx context.Context) error {
 		Spec: batchv1.JobSpec{
 			BackoffLimit: &backoffLimit,
 			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"sidecar.istio.io/inject": "false",
+					},
+				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyNever,
 					ServiceAccountName: probeJobName,

--- a/controllers/probe_runner.go
+++ b/controllers/probe_runner.go
@@ -155,16 +155,10 @@ func (r *ProbeRunner) runCycle(ctx context.Context) error {
 		r.statusGauge.Set(0)
 	}
 
-	// Restart btp-operator pods when: TLS ok (status=ok), hash changed, and lastHash was non-empty (not first run).
-	if status == probeStatusOK && hash != lastHash && lastHash != "" {
-		logger.Info("CA bundle hash changed with healthy TLS — restarting btp-operator pods")
-		if err := r.restartBtpOperatorPods(ctx); err != nil {
-			logger.Error(err, "failed to restart btp-operator pods")
-		}
-	}
-
 	// Advance tls-probe-last-hash only when probe wrote a non-empty hash.
 	// Overwriting with empty would erase the previous hash and suppress future restart detection.
+	// Patch before triggering the restart: deleting pods wakes the main reconciler which updates
+	// the CR, and a concurrent patch here would then fail with a resource-version conflict.
 	if hash == "" {
 		return nil
 	}
@@ -185,6 +179,14 @@ func (r *ProbeRunner) runCycle(ctx context.Context) error {
 	freshCR.Annotations[probeAnnotationLastHash] = hash
 	if err := r.client.Patch(ctx, freshCR, patch); err != nil {
 		return fmt.Errorf("patching tls-probe-last-hash: %w", err)
+	}
+
+	// Restart btp-operator pods when: TLS ok (status=ok), hash changed, and lastHash was non-empty (not first run).
+	if status == probeStatusOK && hash != lastHash && lastHash != "" {
+		logger.Info("CA bundle hash changed with healthy TLS — restarting btp-operator pods")
+		if err := r.restartBtpOperatorPods(ctx); err != nil {
+			logger.Error(err, "failed to restart btp-operator pods")
+		}
 	}
 
 	return nil

--- a/controllers/probe_runner.go
+++ b/controllers/probe_runner.go
@@ -157,11 +157,20 @@ func (r *ProbeRunner) runCycle(ctx context.Context) error {
 
 	// Advance tls-probe-last-hash only when probe wrote a non-empty hash.
 	// Overwriting with empty would erase the previous hash and suppress future restart detection.
-	// Patch before triggering the restart: deleting pods wakes the main reconciler which updates
-	// the CR, and a concurrent patch here would then fail with a resource-version conflict.
 	if hash == "" {
 		return nil
 	}
+
+	// Restart btp-operator pods when: TLS ok (status=ok), hash changed, and lastHash was non-empty (not first run).
+	// Do this before patching lastHash so that a restart failure leaves lastHash un-advanced:
+	// the next cycle will see hash != lastHash again and retry the restart.
+	if status == probeStatusOK && hash != lastHash && lastHash != "" {
+		logger.Info("CA bundle hash changed with healthy TLS — restarting btp-operator pods")
+		if err := r.restartBtpOperatorPods(ctx); err != nil {
+			return fmt.Errorf("restarting btp-operator pods: %w", err)
+		}
+	}
+
 	// Re-fetch the CR immediately before patching to avoid overwriting the probe-written
 	// annotations (tls-probe-status, tls-probe-hash, tls-probe-updated-at) with the stale
 	// base captured before the Job ran.
@@ -179,14 +188,6 @@ func (r *ProbeRunner) runCycle(ctx context.Context) error {
 	freshCR.Annotations[probeAnnotationLastHash] = hash
 	if err := r.client.Patch(ctx, freshCR, patch); err != nil {
 		return fmt.Errorf("patching tls-probe-last-hash: %w", err)
-	}
-
-	// Restart btp-operator pods when: TLS ok (status=ok), hash changed, and lastHash was non-empty (not first run).
-	if status == probeStatusOK && hash != lastHash && lastHash != "" {
-		logger.Info("CA bundle hash changed with healthy TLS — restarting btp-operator pods")
-		if err := r.restartBtpOperatorPods(ctx); err != nil {
-			logger.Error(err, "failed to restart btp-operator pods")
-		}
 	}
 
 	return nil


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Move `tls-probe-last-hash` patch after `restartBtpOperatorPods` and return the restart error instead of swallowing it: a restart failure now leaves `lastHash` un-advanced so the next cycle sees `hash != lastHash` and retries the restart.
- Disable Istio sidecar injection on the probe job pod (`sidecar.istio.io/inject: "false"`) to prevent the `istio-proxy` sidecar from keeping the pod alive after the probe container exits, which caused `waitForJob` to fail with "job not found" when the next cycle's `deleteOldJob` removed the still-running job.

**Related issue(s)**