### PR TITLE
Treat Probe Job Not Found as Success in Wait Loop

### DIFF
--- a/controllers/probe_runner.go
+++ b/controllers/probe_runner.go
@@ -309,6 +309,9 @@ func (r *ProbeRunner) waitForJob(ctx context.Context) error {
 			Name:      probeJobName,
 			Namespace: config.KymaSystemNamespaceName,
 		}, job); err != nil {
+			if k8serrors.IsNotFound(err) {
+				return nil
+			}
 			return err
 		}
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Treat `NotFound` error in `waitForJob` as success — the job completed and was garbage collected before the next poll, which is a normal race condition on clusters with short Job TTLs
- Disable Istio sidecar injection on probe Job pod via `sidecar.istio.io/inject: "false"` annotation
- Return restart error from `runCycle` to allow retry on next probe cycle instead of swallowing it
- Skip `lastHash` patch when probe wrote an empty hash to avoid erasing previous hash and suppressing future restart detection

**Related issue(s)**