### PR TITLE
Move ErrorWithReason to internal/conditions

### DIFF
--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -334,15 +334,15 @@ func (r *BtpOperatorReconciler) HandleProcessingState(ctx context.Context, cr *v
 	r.setCredentialsNamespacesAndClusterId(requiredSecret)
 
 	if errWithReason := r.checkDefaultCredentialsSecretNamespace(ctx, logger, requiredSecret); errWithReason != nil {
-		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.reason, errWithReason.message)
+		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.Reason, errWithReason.Message)
 	}
 
 	if errWithReason := r.checkSapBtpServiceOperatorClusterIdConfigMap(ctx, logger, requiredSecret); errWithReason != nil {
-		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.reason, errWithReason.message)
+		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.Reason, errWithReason.Message)
 	}
 
 	if errWithReason := r.checkSapBtpServiceOperatorClusterIdSecret(ctx, logger, requiredSecret); errWithReason != nil {
-		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.reason, errWithReason.message)
+		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.Reason, errWithReason.Message)
 	}
 
 	if err := r.deleteOutdatedResources(ctx); err != nil {
@@ -366,7 +366,7 @@ func (r *BtpOperatorReconciler) HandleProcessingState(ctx context.Context, cr *v
 
 func (r *BtpOperatorReconciler) handleMissingSecret(ctx context.Context, cr *v1alpha1.BtpOperator, logger logr.Logger, errWithReason *ErrorWithReason) error {
 	logger.Info("secret verification failed: " + errWithReason.Error())
-	return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateWarning, errWithReason.reason, errWithReason.message)
+	return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateWarning, errWithReason.Reason, errWithReason.Message)
 }
 
 func (r *BtpOperatorReconciler) getAndVerifyRequiredSecret(ctx context.Context) (*corev1.Secret, *ErrorWithReason) {

--- a/controllers/errors.go
+++ b/controllers/errors.go
@@ -2,20 +2,10 @@ package controllers
 
 import "github.com/kyma-project/btp-manager/internal/conditions"
 
-type ErrorWithReason struct {
-	message string
-	reason  conditions.Reason
-}
+type ErrorWithReason = conditions.ErrorWithReason
 
 func NewErrorWithReason(reason conditions.Reason, message string) *ErrorWithReason {
-	return &ErrorWithReason{
-		message: message,
-		reason:  reason,
-	}
-}
-
-func (e *ErrorWithReason) Error() string {
-	return e.message
+	return conditions.NewErrorWithReason(reason, message)
 }
 
 type CertificateSignError struct {

--- a/internal/conditions/errors.go
+++ b/internal/conditions/errors.go
@@ -1,0 +1,17 @@
+package conditions
+
+type ErrorWithReason struct {
+	Message string
+	Reason  Reason
+}
+
+func NewErrorWithReason(reason Reason, message string) *ErrorWithReason {
+	return &ErrorWithReason{
+		Message: message,
+		Reason:  reason,
+	}
+}
+
+func (e *ErrorWithReason) Error() string {
+	return e.Message
+}


### PR DESCRIPTION
**Description**

This is the first of 5 PRs splitting [#1526](https://github.com/kyma-project/btp-manager/pull/1526) into individually-mergeable steps. Each PR leaves the app fully functional and all tests passing. Merge order: this PR → PR 2 (NetworkPolicyManager) → PR 3 (DriftDetector) → PR 4 (ModuleResourceManager) → PR 5 (WebhookCertificateManager).

Changes proposed in this pull request:

- Add `ErrorWithReason` struct with public fields `Message` and `Reason` to `internal/conditions`
- Replace `controllers.ErrorWithReason` struct with a type alias pointing to `conditions.ErrorWithReason`
- Update `controllers.NewErrorWithReason` to delegate to `conditions.NewErrorWithReason`
- Rename `.reason`/`.message` field accesses in `btpoperator_controller.go` to `.Reason`/`.Message`

**Related issue(s)**
See also #1313