### PR TITLE
Add NetworkPolicyManager and Wire into Controller

### DIFF
--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kyma-project/btp-manager/controllers/config"
 	"github.com/kyma-project/btp-manager/internal/certs"
 	"github.com/kyma-project/btp-manager/internal/conditions"
+	"github.com/kyma-project/btp-manager/internal/k8s/networkpolicy"
 	"github.com/kyma-project/btp-manager/internal/manifest"
 	"github.com/kyma-project/btp-manager/internal/metrics"
 	"github.com/kyma-project/btp-manager/internal/ymlutils"
@@ -120,9 +121,6 @@ const (
 
 	deploymentAvailableConditionType   = "Available"
 	deploymentProgressingConditionType = "Progressing"
-
-	// TODO: remove old webhook network policy name after some time
-	oldWebhookNetworkPolicyName = "kyma-project.io--btp-operator-allow-to-webhook"
 )
 
 const (
@@ -161,6 +159,7 @@ type BtpOperatorReconciler struct {
 	webhookMetrics                                      *metrics.WebhookMetrics
 	instanceBindingService                              InstanceBindingSerivce
 	workqueueSize                                       int
+	networkPolicyManager                                networkpolicy.NetworkPolicyManager
 	previousCredentialsNamespace                        string
 	clusterIdFromSapBtpManagerSecret                    string
 	clusterIdFromSapBtpServiceOperatorConfigMap         string
@@ -177,7 +176,7 @@ type ResourceReadiness struct {
 	Ready     bool
 }
 
-func NewBtpOperatorReconciler(client client.Client, apiServerClient client.Client, scheme *runtime.Scheme, instanceBindingSerivice InstanceBindingSerivce, metrics *metrics.WebhookMetrics, watchHandlers []config.WatchHandler) *BtpOperatorReconciler {
+func NewBtpOperatorReconciler(client client.Client, apiServerClient client.Client, scheme *runtime.Scheme, instanceBindingSerivice InstanceBindingSerivce, metrics *metrics.WebhookMetrics, watchHandlers []config.WatchHandler, networkPolicyManager networkpolicy.NetworkPolicyManager) *BtpOperatorReconciler {
 	return &BtpOperatorReconciler{
 		Client:                 client,
 		apiServerClient:        apiServerClient,
@@ -186,6 +185,7 @@ func NewBtpOperatorReconciler(client client.Client, apiServerClient client.Clien
 		instanceBindingService: instanceBindingSerivice,
 		webhookMetrics:         metrics,
 		watchHandlers:          watchHandlers,
+		networkPolicyManager:   networkPolicyManager,
 	}
 }
 
@@ -466,17 +466,9 @@ func (r *BtpOperatorReconciler) getResourcesToDeletePath() string {
 	return fmt.Sprintf("%s%cdelete", config.ResourcesPath, os.PathSeparator)
 }
 
-func (r *BtpOperatorReconciler) getNetworkPoliciesPath() string {
-	return fmt.Sprintf("%s%cnetwork-policies", config.ManagerResourcesPath, os.PathSeparator)
-}
-
-func (r *BtpOperatorReconciler) loadNetworkPolicies() ([]*unstructured.Unstructured, error) {
-	return r.createUnstructuredObjectsFromManifestsDir(r.getNetworkPoliciesPath())
-}
-
 func (r *BtpOperatorReconciler) addNetworkPoliciesToResources(ctx context.Context, resourcesToApply *[]*unstructured.Unstructured) error {
 	logger := log.FromContext(ctx)
-	networkPolicies, err := r.loadNetworkPolicies()
+	networkPolicies, err := r.networkPolicyManager.LoadNetworkPolicies()
 	if err != nil {
 		logger.Error(err, "while loading network policies")
 		return fmt.Errorf("failed to load network policies: %w", err)
@@ -643,35 +635,11 @@ func (r *BtpOperatorReconciler) prepareModuleResourcesFromManifests(ctx context.
 }
 
 func (r *BtpOperatorReconciler) cleanupNetworkPolicies(ctx context.Context) error {
-	logger := log.FromContext(ctx)
-	logger.Info("deleting all managed network policies")
-	if err := r.DeleteAllOf(ctx, &networkingv1.NetworkPolicy{}, client.InNamespace(config.ChartNamespace), managedByLabelFilter); err != nil {
-		if !(k8serrors.IsNotFound(err) || k8serrors.IsMethodNotSupported(err) || meta.IsNoMatchError(err)) {
-			return fmt.Errorf("failed to delete network policies: %w", err)
-		}
-	}
-
-	return nil
+	return r.networkPolicyManager.CleanupNetworkPolicies(ctx)
 }
 
 func (r *BtpOperatorReconciler) deleteOldWebhookNetworkPolicy(ctx context.Context) error {
-	logger := log.FromContext(ctx)
-	oldPolicy := &networkingv1.NetworkPolicy{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      oldWebhookNetworkPolicyName,
-			Namespace: config.ChartNamespace,
-		},
-	}
-
-	if err := r.Delete(ctx, oldPolicy); err != nil {
-		if !k8serrors.IsNotFound(err) {
-			logger.Error(err, "failed to delete old webhook network policy during migration", "policyName", oldWebhookNetworkPolicyName)
-			return fmt.Errorf("failed to delete old webhook network policy: %w", err)
-		}
-		logger.Info("old webhook network policy not found, skipping deletion", "policyName", oldWebhookNetworkPolicyName)
-	}
-
-	return nil
+	return r.networkPolicyManager.DeleteOldWebhookNetworkPolicy(ctx)
 }
 
 func (r *BtpOperatorReconciler) addLabels(chartVer string, us ...*unstructured.Unstructured) error {
@@ -1580,33 +1548,24 @@ func (r *BtpOperatorReconciler) watchDeploymentPredicates() predicate.Funcs {
 	}
 }
 
-func (r *BtpOperatorReconciler) getNetworkPolicyNamesFromManifests() (map[string]struct{}, error) {
-	names := make(map[string]struct{})
-	us, err := r.loadNetworkPolicies()
-	if err != nil {
-		return names, err
-	}
-	for _, u := range us {
-		if n := u.GetName(); n != "" {
-			names[n] = struct{}{}
-		}
-	}
-	return names, nil
-}
-
 func (r *BtpOperatorReconciler) watchNetworkPolicyPredicates() predicate.Funcs {
-	nameSet, _ := r.getNetworkPolicyNamesFromManifests()
-	isManaged := func(obj *networkingv1.NetworkPolicy) bool {
-		labels := obj.GetLabels()
-		if labels != nil {
-			if labels[managedByLabelKey] == operatorName && labels[kymaProjectModuleLabelKey] == moduleName {
-				return true
+	nameSet := make(map[string]struct{})
+	if r.networkPolicyManager != nil {
+		if policies, err := r.networkPolicyManager.LoadNetworkPolicies(); err == nil {
+			for _, p := range policies {
+				if n := p.GetName(); n != "" {
+					nameSet[n] = struct{}{}
+				}
 			}
 		}
-		if _, ok := nameSet[obj.GetName()]; ok {
+	}
+	isManaged := func(obj *networkingv1.NetworkPolicy) bool {
+		labels := obj.GetLabels()
+		if labels != nil && labels[managedByLabelKey] == operatorName && labels[kymaProjectModuleLabelKey] == moduleName {
 			return true
 		}
-		return false
+		_, ok := nameSet[obj.GetName()]
+		return ok
 	}
 
 	return predicate.Funcs{

--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -467,6 +467,9 @@ func (r *BtpOperatorReconciler) getResourcesToDeletePath() string {
 }
 
 func (r *BtpOperatorReconciler) addNetworkPoliciesToResources(ctx context.Context, resourcesToApply *[]*unstructured.Unstructured) error {
+	if r.networkPolicyManager == nil {
+		return nil
+	}
 	logger := log.FromContext(ctx)
 	networkPolicies, err := r.networkPolicyManager.LoadNetworkPolicies()
 	if err != nil {
@@ -635,10 +638,16 @@ func (r *BtpOperatorReconciler) prepareModuleResourcesFromManifests(ctx context.
 }
 
 func (r *BtpOperatorReconciler) cleanupNetworkPolicies(ctx context.Context) error {
+	if r.networkPolicyManager == nil {
+		return nil
+	}
 	return r.networkPolicyManager.CleanupNetworkPolicies(ctx)
 }
 
 func (r *BtpOperatorReconciler) deleteOldWebhookNetworkPolicy(ctx context.Context) error {
+	if r.networkPolicyManager == nil {
+		return nil
+	}
 	return r.networkPolicyManager.DeleteOldWebhookNetworkPolicy(ctx)
 }
 

--- a/controllers/btpoperator_controller_network_policies_test.go
+++ b/controllers/btpoperator_controller_network_policies_test.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"context"
-	"os"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -14,6 +13,7 @@ import (
 	"github.com/kyma-project/btp-manager/api/v1alpha1"
 	"github.com/kyma-project/btp-manager/controllers/config"
 	"github.com/kyma-project/btp-manager/internal/conditions"
+	"github.com/kyma-project/btp-manager/internal/k8s/networkpolicy"
 	"github.com/kyma-project/btp-manager/internal/manifest"
 )
 
@@ -42,21 +42,10 @@ var expectedPolicyNames = []string{
 }
 
 var _ = Describe("BTP Operator Network Policies", func() {
-	Context("When testing network policies path functions", func() {
-		It("Should return correct network policies path", func() {
-			reconciler := &BtpOperatorReconciler{}
-			path := reconciler.getNetworkPoliciesPath()
-			expected := config.ManagerResourcesPath + string(os.PathSeparator) + "network-policies"
-			Expect(path).To(Equal(expected))
-		})
-	})
-
 	Context("When testing loadNetworkPolicies function", func() {
 		It("Should load network policies from manager-resources directory", func() {
-			reconciler := &BtpOperatorReconciler{
-				manifestHandler: &manifest.Handler{Scheme: k8sManager.GetScheme()},
-			}
-			policies, err := reconciler.loadNetworkPolicies()
+			npMgr := networkpolicy.NewManager(k8sClient, &manifest.Handler{Scheme: k8sManager.GetScheme()})
+			policies, err := npMgr.LoadNetworkPolicies()
 			Expect(err).NotTo(HaveOccurred())
 			expectedPolicyCount := 4
 			Expect(policies).To(HaveLen(expectedPolicyCount))
@@ -76,10 +65,11 @@ var _ = Describe("BTP Operator Network Policies", func() {
 
 		BeforeEach(func() {
 			ctx = context.Background()
+			npMgr := networkpolicy.NewManager(k8sClient, &manifest.Handler{Scheme: k8sManager.GetScheme()})
 			reconciler = &BtpOperatorReconciler{
-				Client:          k8sClient,
-				Scheme:          k8sClient.Scheme(),
-				manifestHandler: &manifest.Handler{Scheme: k8sManager.GetScheme()},
+				Client:               k8sClient,
+				Scheme:               k8sClient.Scheme(),
+				networkPolicyManager: npMgr,
 			}
 			btpOperator = &v1alpha1.BtpOperator{}
 			btpOperator.Name = "test-btpoperator"
@@ -88,7 +78,7 @@ var _ = Describe("BTP Operator Network Policies", func() {
 		})
 
 		It("Should load and prepare network policies", func() {
-			policies, err := reconciler.loadNetworkPolicies()
+			policies, err := reconciler.networkPolicyManager.LoadNetworkPolicies()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(policies).To(HaveLen(4))
 			for _, policy := range policies {
@@ -109,10 +99,10 @@ var _ = Describe("BTP Operator Network Policies", func() {
 		It("Should call cleanupNetworkPolicies", func() {
 			for _, name := range expectedPolicyNames {
 				policy := createMockNetworkPolicy(name)
-				labels := map[string]string{
-					managedByLabelKey: operatorName,
-				}
-				policy.SetLabels(labels)
+				policy.SetLabels(map[string]string{
+					managedByLabelKey:         operatorName,
+					kymaProjectModuleLabelKey: moduleName,
+				})
 				Expect(k8sClient.Create(ctx, policy)).To(Succeed())
 			}
 			err := reconciler.cleanupNetworkPolicies(ctx)
@@ -154,22 +144,26 @@ var _ = Describe("BTP Operator Network Policies", func() {
 
 	Context("When testing cleanupNetworkPolicies", func() {
 		It("Should not fail when no managed network policies exist", func() {
+			npMgr := networkpolicy.NewManager(k8sClient, &manifest.Handler{Scheme: k8sManager.GetScheme()})
 			reconciler := &BtpOperatorReconciler{
-				Client: k8sClient,
+				Client:               k8sClient,
+				networkPolicyManager: npMgr,
 			}
 			err := reconciler.cleanupNetworkPolicies(context.Background())
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("Should cleanup existing network policies with managed-by btp-manager label", func() {
+			npMgr := networkpolicy.NewManager(k8sClient, &manifest.Handler{Scheme: k8sManager.GetScheme()})
 			reconciler := &BtpOperatorReconciler{
-				Client: k8sClient,
+				Client:               k8sClient,
+				networkPolicyManager: npMgr,
 			}
 			testPolicy := createMockNetworkPolicy("test-cleanup-policy")
-			labels := map[string]string{
-				managedByLabelKey: operatorName,
-			}
-			testPolicy.SetLabels(labels)
+			testPolicy.SetLabels(map[string]string{
+				managedByLabelKey:         operatorName,
+				kymaProjectModuleLabelKey: moduleName,
+			})
 			Expect(k8sClient.Create(context.Background(), testPolicy)).To(Succeed())
 			err := reconciler.cleanupNetworkPolicies(context.Background())
 			Expect(err).NotTo(HaveOccurred())
@@ -178,8 +172,10 @@ var _ = Describe("BTP Operator Network Policies", func() {
 		})
 
 		It("Should not cleanup network policies without managed-by btp-manager label", func() {
+			npMgr := networkpolicy.NewManager(k8sClient, &manifest.Handler{Scheme: k8sManager.GetScheme()})
 			reconciler := &BtpOperatorReconciler{
-				Client: k8sClient,
+				Client:               k8sClient,
+				networkPolicyManager: npMgr,
 			}
 			testPolicy := createMockNetworkPolicy("test-unmanaged-policy")
 			Expect(k8sClient.Create(context.Background(), testPolicy)).To(Succeed())
@@ -333,8 +329,10 @@ var _ = Describe("BTP Operator Network Policies", func() {
 
 	Context("When testing migration logic", func() {
 		It("should delete the old webhook network policy during migration", func() {
+			npMgr := networkpolicy.NewManager(k8sClient, &manifest.Handler{Scheme: k8sManager.GetScheme()})
 			reconciler := &BtpOperatorReconciler{
-				Client: k8sClient,
+				Client:               k8sClient,
+				networkPolicyManager: npMgr,
 			}
 			oldPolicy := createMockNetworkPolicy("kyma-project.io--btp-operator-allow-to-webhook")
 			Expect(k8sClient.Create(context.Background(), oldPolicy)).To(Succeed())

--- a/controllers/btpoperator_controller_test.go
+++ b/controllers/btpoperator_controller_test.go
@@ -34,7 +34,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should return error from client.Get", func(t *testing.T) {
 		// given
 		retryK8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{})
+		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil)
 		retryK8sClient.EnableErrorOnGet()
 
 		// when
@@ -57,7 +57,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should return error from client.Update", func(t *testing.T) {
 		// given
 		retryK8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{})
+		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil)
 		retryK8sClient.EnableErrorOnUpdate()
 
 		// when
@@ -80,7 +80,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should time out", func(t *testing.T) {
 		// given
 		disabledUpdatek8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(disabledUpdatek8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{})
+		btpOperatorReconciler := NewBtpOperatorReconciler(disabledUpdatek8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil)
 		disabledUpdatek8sClient.DisableUpdate()
 
 		// when
@@ -102,7 +102,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should update BtpOperator status after a few retries", func(t *testing.T) {
 		// given
 		retryK8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{})
+		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil)
 
 		// when
 		err := btpOperatorReconciler.UpdateBtpOperatorStatus(ctx, btpOperator, v1alpha1.StateProcessing, conditions.Initialized, "test")
@@ -124,7 +124,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should update BtpOperator status three times", func(t *testing.T) {
 		// given
 		retryK8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{})
+		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil)
 		conditionMsg1 := "test1"
 		conditionMsg2 := "test2"
 		conditionMsg3 := "test3"

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/kyma-project/btp-manager/api/v1alpha1"
 	"github.com/kyma-project/btp-manager/controllers/config"
 	"github.com/kyma-project/btp-manager/internal/certs"
+	"github.com/kyma-project/btp-manager/internal/k8s/networkpolicy"
+	"github.com/kyma-project/btp-manager/internal/manifest"
 	btpmanagermetrics "github.com/kyma-project/btp-manager/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -179,6 +181,8 @@ var _ = SynchronizedBeforeSuite(func() {
 	metrics := btpmanagermetrics.NewWebhookMetrics(testRegistry)
 	configMetrics := btpmanagermetrics.NewConfigMetrics(testRegistry)
 	cleanupReconciler := NewInstanceBindingControllerManager(ctx, k8sManager.GetClient(), k8sManager.GetScheme(), cfg)
+	manifestHandler := &manifest.Handler{Scheme: k8sManager.GetScheme()}
+	networkPolicyManager := networkpolicy.NewManager(k8sManager.GetClient(), manifestHandler)
 	reconciler = NewBtpOperatorReconciler(
 		k8sManager.GetClient(),
 		k8sClient,
@@ -188,6 +192,7 @@ var _ = SynchronizedBeforeSuite(func() {
 		[]config.WatchHandler{
 			config.NewHandler(k8sManager.GetClient(), k8sManager.GetScheme(), configMetrics),
 		},
+		networkPolicyManager,
 	)
 
 	k8sClientFromManager = k8sManager.GetClient()

--- a/controllers/testdata/test-manager-resources/network-policies/network-policies.yaml
+++ b/controllers/testdata/test-manager-resources/network-policies/network-policies.yaml
@@ -1,0 +1,108 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  namespace: kyma-system
+  name: kyma-project.io--btp-operator-allow-to-apiserver
+  labels:
+    kyma-project.io/module: btp-operator
+spec:
+  podSelector:
+    matchLabels:
+      kyma-project.io/module: btp-operator
+  policyTypes:
+  - Egress
+  egress:
+  - ports:
+    - port: 443
+      protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  namespace: kyma-system
+  name: kyma-project.io--btp-operator-to-dns
+  labels:
+    kyma-project.io/module: btp-operator
+    purpose: dns
+spec:
+  podSelector:
+    matchLabels:
+      kyma-project.io/module: btp-operator
+  policyTypes:
+    - Egress
+  egress:
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+    - ports:
+        - port: 8053
+          protocol: UDP
+        - port: 8053
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              gardener.cloud/purpose: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+    - ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+      to:
+        - namespaceSelector:
+            matchLabels:
+              gardener.cloud/purpose: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: node-local-dns
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  namespace: kyma-system
+  name: kyma-project.io--allow-btp-operator-metrics
+  labels:
+    kyma-project.io/module: btp-operator
+spec:
+  podSelector:
+    matchLabels:
+      kyma-project.io/module: btp-operator
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kyma-system
+      podSelector:
+        matchLabels:
+          networking.kyma-project.io/metrics-scraping: allowed
+    ports:
+    - protocol: TCP
+      port: 8080
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  namespace: kyma-system
+  name: kyma-project.io--allow-btp-operator-webhook
+spec:
+  podSelector:
+    matchLabels:
+      kyma-project.io/module: btp-operator
+      app.kubernetes.io/instance: sap-btp-operator
+  policyTypes:
+  - Ingress
+  ingress:
+  - ports:
+      - protocol: TCP
+        port: 9443

--- a/internal/k8s/networkpolicy/manager.go
+++ b/internal/k8s/networkpolicy/manager.go
@@ -18,10 +18,8 @@ import (
 
 const (
 	operatorName = "btp-manager"
-	moduleName   = "btp-operator"
 
-	managedByLabelKey         = "app.kubernetes.io/managed-by"
-	kymaProjectModuleLabelKey = "kyma-project.io/module"
+	managedByLabelKey = "app.kubernetes.io/managed-by"
 
 	oldWebhookNetworkPolicyName = "kyma-project.io--btp-operator-allow-to-webhook"
 )
@@ -31,7 +29,6 @@ var managedLabelsFilter = client.MatchingLabels{managedByLabelKey: operatorName}
 type NetworkPolicyManager interface {
 	CleanupNetworkPolicies(ctx context.Context) error
 	DeleteOldWebhookNetworkPolicy(ctx context.Context) error
-	IsManaged(obj *networkingv1.NetworkPolicy) (bool, error)
 	LoadNetworkPolicies() ([]*unstructured.Unstructured, error)
 }
 
@@ -88,33 +85,4 @@ func (m *Manager) DeleteOldWebhookNetworkPolicy(ctx context.Context) error {
 		logger.Info("old webhook network policy not found, skipping deletion", "policyName", oldWebhookNetworkPolicyName)
 	}
 	return nil
-}
-
-func (m *Manager) IsManaged(obj *networkingv1.NetworkPolicy) (bool, error) {
-	labels := obj.GetLabels()
-	if labels != nil {
-		if labels[managedByLabelKey] == operatorName && labels[kymaProjectModuleLabelKey] == moduleName {
-			return true, nil
-		}
-	}
-	nameSet, err := m.getNetworkPolicyNamesFromManifests()
-	if err != nil {
-		return false, err
-	}
-	_, ok := nameSet[obj.GetName()]
-	return ok, nil
-}
-
-func (m *Manager) getNetworkPolicyNamesFromManifests() (map[string]struct{}, error) {
-	names := make(map[string]struct{})
-	us, err := m.LoadNetworkPolicies()
-	if err != nil {
-		return names, err
-	}
-	for _, u := range us {
-		if n := u.GetName(); n != "" {
-			names[n] = struct{}{}
-		}
-	}
-	return names, nil
 }

--- a/internal/k8s/networkpolicy/manager.go
+++ b/internal/k8s/networkpolicy/manager.go
@@ -1,0 +1,120 @@
+package networkpolicy
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/kyma-project/btp-manager/controllers/config"
+	"github.com/kyma-project/btp-manager/internal/manifest"
+	networkingv1 "k8s.io/api/networking/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	operatorName = "btp-manager"
+	moduleName   = "btp-operator"
+
+	managedByLabelKey         = "app.kubernetes.io/managed-by"
+	kymaProjectModuleLabelKey = "kyma-project.io/module"
+
+	oldWebhookNetworkPolicyName = "kyma-project.io--btp-operator-allow-to-webhook"
+)
+
+var managedLabelsFilter = client.MatchingLabels{managedByLabelKey: operatorName}
+
+type NetworkPolicyManager interface {
+	CleanupNetworkPolicies(ctx context.Context) error
+	DeleteOldWebhookNetworkPolicy(ctx context.Context) error
+	IsManaged(obj *networkingv1.NetworkPolicy) (bool, error)
+	LoadNetworkPolicies() ([]*unstructured.Unstructured, error)
+}
+
+type Manager struct {
+	client          client.Client
+	manifestHandler *manifest.Handler
+}
+
+func NewManager(k8sClient client.Client, manifestHandler *manifest.Handler) *Manager {
+	return &Manager{
+		client:          k8sClient,
+		manifestHandler: manifestHandler,
+	}
+}
+
+var _ NetworkPolicyManager = (*Manager)(nil)
+
+func (m *Manager) getNetworkPoliciesPath() string {
+	return fmt.Sprintf("%s%cnetwork-policies", config.ManagerResourcesPath, os.PathSeparator)
+}
+
+func (m *Manager) LoadNetworkPolicies() ([]*unstructured.Unstructured, error) {
+	objects, err := m.manifestHandler.CollectObjectsFromDir(m.getNetworkPoliciesPath())
+	if err != nil {
+		return nil, err
+	}
+	return m.manifestHandler.ObjectsToUnstructured(objects)
+}
+
+func (m *Manager) CleanupNetworkPolicies(ctx context.Context) error {
+	logger := log.FromContext(ctx)
+	logger.Info("deleting all managed network policies")
+	if err := m.client.DeleteAllOf(ctx, &networkingv1.NetworkPolicy{}, client.InNamespace(config.ChartNamespace), managedLabelsFilter); err != nil {
+		if !(k8serrors.IsNotFound(err) || k8serrors.IsMethodNotSupported(err) || meta.IsNoMatchError(err)) {
+			return fmt.Errorf("failed to delete network policies: %w", err)
+		}
+	}
+	return nil
+}
+
+func (m *Manager) DeleteOldWebhookNetworkPolicy(ctx context.Context) error {
+	logger := log.FromContext(ctx)
+	oldPolicy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      oldWebhookNetworkPolicyName,
+			Namespace: config.ChartNamespace,
+		},
+	}
+	if err := m.client.Delete(ctx, oldPolicy); err != nil {
+		if !k8serrors.IsNotFound(err) {
+			logger.Error(err, "failed to delete old webhook network policy during migration", "policyName", oldWebhookNetworkPolicyName)
+			return fmt.Errorf("failed to delete old webhook network policy: %w", err)
+		}
+		logger.Info("old webhook network policy not found, skipping deletion", "policyName", oldWebhookNetworkPolicyName)
+	}
+	return nil
+}
+
+func (m *Manager) IsManaged(obj *networkingv1.NetworkPolicy) (bool, error) {
+	labels := obj.GetLabels()
+	if labels != nil {
+		if labels[managedByLabelKey] == operatorName && labels[kymaProjectModuleLabelKey] == moduleName {
+			return true, nil
+		}
+	}
+	nameSet, err := m.getNetworkPolicyNamesFromManifests()
+	if err != nil {
+		return false, err
+	}
+	_, ok := nameSet[obj.GetName()]
+	return ok, nil
+}
+
+func (m *Manager) getNetworkPolicyNamesFromManifests() (map[string]struct{}, error) {
+	names := make(map[string]struct{})
+	us, err := m.LoadNetworkPolicies()
+	if err != nil {
+		return names, err
+	}
+	for _, u := range us {
+		if n := u.GetName(); n != "" {
+			names[n] = struct{}{}
+		}
+	}
+	return names, nil
+}

--- a/internal/k8s/networkpolicy/manager_test.go
+++ b/internal/k8s/networkpolicy/manager_test.go
@@ -50,50 +50,6 @@ var _ = Describe("Network Policy Manager", func() {
 		})
 	})
 
-	Describe("IsManaged", func() {
-		It("should return true for a policy with managed-by and module labels", func() {
-			policy := managedNetworkPolicy("any-name")
-
-			managed, err := mgr.IsManaged(policy)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(managed).To(BeTrue())
-		})
-
-		It("should return true for a policy whose name appears in the manifests, even without labels", func() {
-			policy := unmanagedNetworkPolicy(policyName1)
-
-			managed, err := mgr.IsManaged(policy)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(managed).To(BeTrue())
-		})
-
-		It("should return false for a policy without managed-by labels and whose name is not in manifests", func() {
-			policy := unmanagedNetworkPolicy("some-other-policy")
-
-			managed, err := mgr.IsManaged(policy)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(managed).To(BeFalse())
-		})
-
-		It("should return false for a policy with only the managed-by label but not the module label", func() {
-			policy := unmanagedNetworkPolicy("partial-label-policy")
-			policy.Labels = map[string]string{managedByLabelKey: operatorName}
-
-			managed, err := mgr.IsManaged(policy)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(managed).To(BeFalse())
-		})
-
-		It("should return false for a policy with only the module label but not the managed-by label", func() {
-			policy := unmanagedNetworkPolicy("partial-label-policy")
-			policy.Labels = map[string]string{kymaProjectModuleLabelKey: moduleName}
-
-			managed, err := mgr.IsManaged(policy)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(managed).To(BeFalse())
-		})
-	})
-
 	Describe("CleanupNetworkPolicies", func() {
 		It("should delete all managed network policies from the cluster", func() {
 			policy1 := managedNetworkPolicy(policyName1)

--- a/internal/k8s/networkpolicy/manager_test.go
+++ b/internal/k8s/networkpolicy/manager_test.go
@@ -1,0 +1,172 @@
+package networkpolicy_test
+
+import (
+	"context"
+
+	"github.com/kyma-project/btp-manager/controllers/config"
+	"github.com/kyma-project/btp-manager/internal/k8s/networkpolicy"
+	"github.com/kyma-project/btp-manager/internal/manifest"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const testManagerResourcesPath = "./testdata"
+
+var _ = Describe("Network Policy Manager", func() {
+	var (
+		mgr *networkpolicy.Manager
+		ctx context.Context
+	)
+
+	BeforeEach(func() {
+		config.ManagerResourcesPath = testManagerResourcesPath
+
+		fakeClient = newFakeClient()
+		mgr = networkpolicy.NewManager(fakeClient, &manifest.Handler{Scheme: scheme})
+		ctx = context.Background()
+	})
+
+	Describe("LoadNetworkPolicies", func() {
+		It("should return unstructured network policies from the manifests directory", func() {
+			policies, err := mgr.LoadNetworkPolicies()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(policies).To(HaveLen(2))
+
+			names := extractNames(policies)
+			Expect(names).To(ContainElements(policyName1, policyName2))
+		})
+
+		It("should return an error when the manifests directory does not exist", func() {
+			config.ManagerResourcesPath = "./non-existent"
+
+			_, err := mgr.LoadNetworkPolicies()
+
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("IsManaged", func() {
+		It("should return true for a policy with managed-by and module labels", func() {
+			policy := managedNetworkPolicy("any-name")
+
+			managed, err := mgr.IsManaged(policy)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(managed).To(BeTrue())
+		})
+
+		It("should return true for a policy whose name appears in the manifests, even without labels", func() {
+			policy := unmanagedNetworkPolicy(policyName1)
+
+			managed, err := mgr.IsManaged(policy)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(managed).To(BeTrue())
+		})
+
+		It("should return false for a policy without managed-by labels and whose name is not in manifests", func() {
+			policy := unmanagedNetworkPolicy("some-other-policy")
+
+			managed, err := mgr.IsManaged(policy)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(managed).To(BeFalse())
+		})
+
+		It("should return false for a policy with only the managed-by label but not the module label", func() {
+			policy := unmanagedNetworkPolicy("partial-label-policy")
+			policy.Labels = map[string]string{managedByLabelKey: operatorName}
+
+			managed, err := mgr.IsManaged(policy)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(managed).To(BeFalse())
+		})
+
+		It("should return false for a policy with only the module label but not the managed-by label", func() {
+			policy := unmanagedNetworkPolicy("partial-label-policy")
+			policy.Labels = map[string]string{kymaProjectModuleLabelKey: moduleName}
+
+			managed, err := mgr.IsManaged(policy)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(managed).To(BeFalse())
+		})
+	})
+
+	Describe("CleanupNetworkPolicies", func() {
+		It("should delete all managed network policies from the cluster", func() {
+			policy1 := managedNetworkPolicy(policyName1)
+			policy2 := managedNetworkPolicy(policyName2)
+			fakeClient = newFakeClient(policy1, policy2)
+			mgr = networkpolicy.NewManager(fakeClient, &manifest.Handler{Scheme: scheme})
+
+			err := mgr.CleanupNetworkPolicies(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+
+			remaining := &networkingv1.NetworkPolicyList{}
+			Expect(fakeClient.List(ctx, remaining, client.InNamespace(kymaNamespace))).To(Succeed())
+			Expect(remaining.Items).To(BeEmpty())
+		})
+
+		It("should succeed when no managed network policies exist", func() {
+			err := mgr.CleanupNetworkPolicies(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should not delete unmanaged network policies", func() {
+			managedPolicy := managedNetworkPolicy(policyName1)
+			unmanagedPolicy := unmanagedNetworkPolicy("user-defined-policy")
+			fakeClient = newFakeClient(managedPolicy, unmanagedPolicy)
+			mgr = networkpolicy.NewManager(fakeClient, &manifest.Handler{Scheme: scheme})
+
+			err := mgr.CleanupNetworkPolicies(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+
+			remaining := &networkingv1.NetworkPolicyList{}
+			Expect(fakeClient.List(ctx, remaining, client.InNamespace(kymaNamespace))).To(Succeed())
+			Expect(remaining.Items).To(HaveLen(1))
+			Expect(remaining.Items[0].Name).To(Equal(unmanagedPolicy.Name))
+		})
+	})
+
+	Describe("DeleteOldWebhookNetworkPolicy", func() {
+		const oldWebhookPolicyName = "kyma-project.io--btp-operator-allow-to-webhook"
+
+		It("should delete the old webhook network policy when it exists", func() {
+			oldPolicy := &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      oldWebhookPolicyName,
+					Namespace: kymaNamespace,
+				},
+			}
+			fakeClient = newFakeClient(oldPolicy)
+			mgr = networkpolicy.NewManager(fakeClient, &manifest.Handler{Scheme: scheme})
+
+			err := mgr.DeleteOldWebhookNetworkPolicy(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+
+			remaining := &networkingv1.NetworkPolicy{}
+			getErr := fakeClient.Get(ctx, client.ObjectKeyFromObject(oldPolicy), remaining)
+			Expect(getErr).To(HaveOccurred())
+		})
+
+		It("should succeed without an error when the old webhook policy does not exist", func() {
+			err := mgr.DeleteOldWebhookNetworkPolicy(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})
+
+func extractNames(us []*unstructured.Unstructured) []string {
+	names := make([]string, 0, len(us))
+	for _, u := range us {
+		names = append(names, u.GetName())
+	}
+	return names
+}

--- a/internal/k8s/networkpolicy/suite_test.go
+++ b/internal/k8s/networkpolicy/suite_test.go
@@ -1,0 +1,72 @@
+package networkpolicy_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	kymaNamespace = "kyma-system"
+
+	policyName1 = "kyma-project.io--btp-operator-allow-to-apiserver"
+	policyName2 = "kyma-project.io--btp-operator-to-dns"
+
+	managedByLabelKey         = "app.kubernetes.io/managed-by"
+	kymaProjectModuleLabelKey = "kyma-project.io/module"
+	operatorName              = "btp-manager"
+	moduleName                = "btp-operator"
+)
+
+var (
+	fakeClient client.Client
+	scheme     *runtime.Scheme
+)
+
+func TestNetworkPolicyManager(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Network Policy Manager Suite")
+}
+
+var _ = BeforeSuite(func() {
+	scheme = runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(networkingv1.AddToScheme(scheme))
+})
+
+func managedNetworkPolicy(name string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: kymaNamespace,
+			Labels: map[string]string{
+				managedByLabelKey:         operatorName,
+				kymaProjectModuleLabelKey: moduleName,
+			},
+		},
+	}
+}
+
+func unmanagedNetworkPolicy(name string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: kymaNamespace,
+		},
+	}
+}
+
+func newFakeClient(objects ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		Build()
+}

--- a/internal/k8s/networkpolicy/testdata/network-policies/network-policies.yaml
+++ b/internal/k8s/networkpolicy/testdata/network-policies/network-policies.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  namespace: kyma-system
+  name: kyma-project.io--btp-operator-allow-to-apiserver
+  labels:
+    app.kubernetes.io/managed-by: btp-manager
+    kyma-project.io/module: btp-operator
+spec:
+  podSelector:
+    matchLabels:
+      kyma-project.io/module: btp-operator
+  policyTypes:
+  - Egress
+  egress:
+  - ports:
+    - port: 443
+      protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  namespace: kyma-system
+  name: kyma-project.io--btp-operator-to-dns
+  labels:
+    app.kubernetes.io/managed-by: btp-manager
+    kyma-project.io/module: btp-operator
+spec:
+  podSelector:
+    matchLabels:
+      kyma-project.io/module: btp-operator
+  policyTypes:
+  - Egress
+  egress:
+  - ports:
+    - port: 53
+      protocol: UDP

--- a/main.go
+++ b/main.go
@@ -42,6 +42,8 @@ import (
 	"github.com/kyma-project/btp-manager/api/v1alpha1"
 	"github.com/kyma-project/btp-manager/controllers"
 	"github.com/kyma-project/btp-manager/controllers/config"
+	"github.com/kyma-project/btp-manager/internal/k8s/networkpolicy"
+	"github.com/kyma-project/btp-manager/internal/manifest"
 	btpmanagermetrics "github.com/kyma-project/btp-manager/internal/metrics"
 	//+kubebuilder:scaffold:imports
 )
@@ -127,6 +129,8 @@ func main() {
 	configMetrics := btpmanagermetrics.NewConfigMetrics(ctrlmetrics.Registry)
 	cleanupReconciler := controllers.NewInstanceBindingControllerManager(signalContext, mgr.GetClient(), mgr.GetScheme(), restCfg)
 	configHandler := config.NewHandler(mgr.GetClient(), scheme, configMetrics)
+	manifestHandler := &manifest.Handler{Scheme: scheme}
+	networkPolicyManager := networkpolicy.NewManager(mgr.GetClient(), manifestHandler)
 	reconciler := controllers.NewBtpOperatorReconciler(
 		mgr.GetClient(),
 		apiServerClient,
@@ -136,6 +140,7 @@ func main() {
 		[]config.WatchHandler{
 			configHandler,
 		},
+		networkPolicyManager,
 	)
 
 	if err = reconciler.SetupWithManager(mgr); err != nil {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `internal/k8s/networkpolicy` package with `NetworkPolicyManager` interface and `Manager` implementation
- Delegate network policy operations (`LoadNetworkPolicies`, `CleanupNetworkPolicies`, `DeleteOldWebhookNetworkPolicy`) from the controller to `NetworkPolicyManager`
- Wire `NetworkPolicyManager` into `NewBtpOperatorReconciler`, `main.go`, and test suite setup
- Remove 3 private network-policy methods from the controller (`loadNetworkPolicies`, `getNetworkPoliciesPath`, `getNetworkPolicyNamesFromManifests`) and the unused `oldWebhookNetworkPolicyName` constant
- Update `btpoperator_controller_network_policies_test.go` to test through `NetworkPolicyManager` directly

**Related issue(s)**
See also #1313

---

> **Note:** This is PR 2/5 in a split of [#1526](https://github.com/kyma-project/btp-manager/pull/1526). Each PR leaves the codebase fully functional with all tests passing.
>
> Merge order: [#1561](https://github.com/kyma-project/btp-manager/pull/1561) (merged) → **this PR** → PR 3 (DriftDetector) → PR 4 (ModuleResourceManager) → PR 5 (ObjectManager + SecretManager + WebhookCertificateManager)