### PR TITLE
Add CredentialsDriftDetector and Wire Into Controller

### DIFF
--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -338,7 +338,7 @@ func (r *BtpOperatorReconciler) HandleProcessingState(ctx context.Context, cr *v
 		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.Reason, errWithReason.Message)
 	}
 
-	if errWithReason := r.driftDetector.CheckClusterIdSecretDrift(ctx, requiredSecret); errWithReason != nil {
+	if errWithReason := r.driftDetector.ResolveClusterIdSecretDrift(ctx, requiredSecret); errWithReason != nil {
 		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.Reason, errWithReason.Message)
 	}
 

--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kyma-project/btp-manager/controllers/config"
 	"github.com/kyma-project/btp-manager/internal/certs"
 	"github.com/kyma-project/btp-manager/internal/conditions"
+	"github.com/kyma-project/btp-manager/internal/credentials/drift"
 	"github.com/kyma-project/btp-manager/internal/k8s/networkpolicy"
 	"github.com/kyma-project/btp-manager/internal/manifest"
 	"github.com/kyma-project/btp-manager/internal/metrics"
@@ -153,20 +154,15 @@ type InstanceBindingSerivce interface {
 type BtpOperatorReconciler struct {
 	client.Client
 	*rest.Config
-	apiServerClient                                     client.Client
-	Scheme                                              *runtime.Scheme
-	manifestHandler                                     *manifest.Handler
-	webhookMetrics                                      *metrics.WebhookMetrics
-	instanceBindingService                              InstanceBindingSerivce
-	workqueueSize                                       int
-	networkPolicyManager                                networkpolicy.NetworkPolicyManager
-	previousCredentialsNamespace                        string
-	clusterIdFromSapBtpManagerSecret                    string
-	clusterIdFromSapBtpServiceOperatorConfigMap         string
-	clusterIdFromSapBtpServiceOperatorClusterIdSecret   string
-	credentialsNamespaceFromSapBtpManagerSecret         string
-	credentialsNamespaceFromSapBtpServiceOperatorSecret string
-	watchHandlers                                       []config.WatchHandler
+	apiServerClient        client.Client
+	Scheme                 *runtime.Scheme
+	manifestHandler        *manifest.Handler
+	webhookMetrics         *metrics.WebhookMetrics
+	instanceBindingService InstanceBindingSerivce
+	workqueueSize          int
+	networkPolicyManager   networkpolicy.NetworkPolicyManager
+	driftDetector          drift.Detector
+	watchHandlers          []config.WatchHandler
 }
 
 type ResourceReadiness struct {
@@ -176,7 +172,7 @@ type ResourceReadiness struct {
 	Ready     bool
 }
 
-func NewBtpOperatorReconciler(client client.Client, apiServerClient client.Client, scheme *runtime.Scheme, instanceBindingSerivice InstanceBindingSerivce, metrics *metrics.WebhookMetrics, watchHandlers []config.WatchHandler, networkPolicyManager networkpolicy.NetworkPolicyManager) *BtpOperatorReconciler {
+func NewBtpOperatorReconciler(client client.Client, apiServerClient client.Client, scheme *runtime.Scheme, instanceBindingSerivice InstanceBindingSerivce, metrics *metrics.WebhookMetrics, watchHandlers []config.WatchHandler, networkPolicyManager networkpolicy.NetworkPolicyManager, driftDetector drift.Detector) *BtpOperatorReconciler {
 	return &BtpOperatorReconciler{
 		Client:                 client,
 		apiServerClient:        apiServerClient,
@@ -186,6 +182,7 @@ func NewBtpOperatorReconciler(client client.Client, apiServerClient client.Clien
 		webhookMetrics:         metrics,
 		watchHandlers:          watchHandlers,
 		networkPolicyManager:   networkPolicyManager,
+		driftDetector:          driftDetector,
 	}
 }
 
@@ -331,17 +328,17 @@ func (r *BtpOperatorReconciler) HandleProcessingState(ctx context.Context, cr *v
 		return r.handleMissingSecret(ctx, cr, logger, errWithReason)
 	}
 
-	r.setCredentialsNamespacesAndClusterId(requiredSecret)
+	r.driftDetector.InitializeFromSecret(requiredSecret)
 
-	if errWithReason := r.checkDefaultCredentialsSecretNamespace(ctx, logger, requiredSecret); errWithReason != nil {
+	if errWithReason := r.driftDetector.CheckCredentialsNamespaceDrift(ctx, requiredSecret); errWithReason != nil {
 		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.Reason, errWithReason.Message)
 	}
 
-	if errWithReason := r.checkSapBtpServiceOperatorClusterIdConfigMap(ctx, logger, requiredSecret); errWithReason != nil {
+	if errWithReason := r.driftDetector.CheckClusterIdConfigMapDrift(ctx, requiredSecret); errWithReason != nil {
 		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.Reason, errWithReason.Message)
 	}
 
-	if errWithReason := r.checkSapBtpServiceOperatorClusterIdSecret(ctx, logger, requiredSecret); errWithReason != nil {
+	if errWithReason := r.driftDetector.CheckClusterIdSecretDrift(ctx, requiredSecret); errWithReason != nil {
 		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.Reason, errWithReason.Message)
 	}
 
@@ -353,7 +350,7 @@ func (r *BtpOperatorReconciler) HandleProcessingState(ctx context.Context, cr *v
 		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, conditions.ProvisioningFailed, err.Error())
 	}
 
-	if err := r.deleteResourcesIfBtpManagerSecretChanged(ctx); err != nil {
+	if err := r.driftDetector.DeleteChangedResources(ctx); err != nil {
 		logger.Error(err, "while deleting resources")
 		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, conditions.ResourceRemovalFailed, err.Error())
 	}
@@ -559,26 +556,6 @@ func (r *BtpOperatorReconciler) reconcileResources(ctx context.Context, cr *v1al
 	return nil
 }
 
-func (r *BtpOperatorReconciler) restartSapBtpServiceOperatorPodIfNotReady(ctx context.Context, logger logr.Logger) error {
-	pod, err := r.getSapBtpServiceOperatorPod(ctx)
-	if err != nil {
-		logger.Error(err, "while getting SAP BTP service operator pod")
-		return err
-	}
-	if pod != nil {
-		for _, condition := range pod.Status.Conditions {
-			if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionFalse {
-				if err := r.deleteObject(ctx, pod); err != nil {
-					logger.Error(err, fmt.Sprintf("while deleting not ready %s pod", pod.Name))
-					return err
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
 func (r *BtpOperatorReconciler) getResourcesToApplyPath() string {
 	return fmt.Sprintf("%s%capply", config.ResourcesPath, os.PathSeparator)
 }
@@ -698,8 +675,8 @@ func (r *BtpOperatorReconciler) setConfigMapValues(secret *corev1.Secret, u *uns
 		val any
 	}{
 		{ClusterIdConfigMapKey, string(secret.Data[ClusterIdSecretKey])},
-		{ReleaseNamespaceConfigMapKey, r.credentialsNamespaceFromSapBtpManagerSecret},
-		{ManagementNamespaceConfigMapKey, r.credentialsNamespaceFromSapBtpManagerSecret},
+		{ReleaseNamespaceConfigMapKey, r.driftDetector.CredentialsNamespaceFromManager()},
+		{ManagementNamespaceConfigMapKey, r.driftDetector.CredentialsNamespaceFromManager()},
 		{EnableLimitedCacheConfigMapKey, config.EnableLimitedCache},
 	}
 	for _, e := range entries {
@@ -711,7 +688,7 @@ func (r *BtpOperatorReconciler) setConfigMapValues(secret *corev1.Secret, u *uns
 }
 
 func (r *BtpOperatorReconciler) setSecretValues(secret *corev1.Secret, u *unstructured.Unstructured) error {
-	u.SetNamespace(r.credentialsNamespaceFromSapBtpManagerSecret)
+	u.SetNamespace(r.driftDetector.CredentialsNamespaceFromManager())
 	for k := range secret.Data {
 		if k == ClusterIdSecretKey || k == CredentialsNamespaceSecretKey {
 			continue
@@ -899,7 +876,7 @@ func (r *BtpOperatorReconciler) handleDeleting(ctx context.Context, cr *v1alpha1
 		return fmt.Errorf("failed to get the required secret: %w", err)
 	}
 
-	r.setCredentialsNamespacesAndClusterId(requiredSecret)
+	r.driftDetector.InitializeFromSecret(requiredSecret)
 
 	if len(cr.GetFinalizers()) == 0 {
 		logger.Info("BtpOperator CR without finalizers - nothing to do, waiting for deletion")
@@ -1208,16 +1185,9 @@ func (r *BtpOperatorReconciler) deleteBtpOperatorResources(ctx context.Context) 
 		return fmt.Errorf("failed to cleanup network policies during hard delete: %w", err)
 	}
 
-	clusterIdSecret, err := r.getSecretByNameAndNamespace(ctx, sapBtpServiceOperatorClusterIdSecretName, r.credentialsNamespaceFromSapBtpManagerSecret)
-	if err != nil {
-		logger.Error(err, fmt.Sprintf("while getting %s secret in %s namespace", sapBtpServiceOperatorClusterIdSecretName, r.credentialsNamespaceFromSapBtpManagerSecret))
-		return fmt.Errorf("failed to get cluster ID secret: %w", err)
-	}
-	if clusterIdSecret != nil {
-		if err := r.deleteObject(ctx, clusterIdSecret); err != nil {
-			logger.Error(err, fmt.Sprintf("while deleting %s secret from %s namespace", sapBtpServiceOperatorClusterIdSecretName, r.credentialsNamespaceFromSapBtpManagerSecret))
-			return fmt.Errorf("failed to delete cluster ID secret: %w", err)
-		}
+	if err := r.driftDetector.DeleteClusterIdSecret(ctx); err != nil {
+		logger.Error(err, "while deleting cluster ID secret")
+		return fmt.Errorf("failed to delete cluster ID secret: %w", err)
 	}
 
 	return nil
@@ -1380,33 +1350,33 @@ func (r *BtpOperatorReconciler) HandleReadyState(ctx context.Context, cr *v1alph
 		return r.handleMissingSecret(ctx, cr, logger, errWithReason)
 	}
 
-	r.setCredentialsNamespacesAndClusterId(requiredSecret)
+	r.driftDetector.InitializeFromSecret(requiredSecret)
 
-	defaultCredentialsSecret, err := r.getDefaultCredentialsSecret(ctx)
+	defaultCredentialsSecret, err := r.driftDetector.GetDefaultCredentialsSecret(ctx)
 	if err != nil {
 		logger.Error(err, fmt.Sprintf("while getting %s Secret", sapBtpServiceOperatorSecretName))
 		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, conditions.GettingDefaultCredentialsSecretFailed, err.Error())
 	}
 
 	if defaultCredentialsSecret != nil {
-		r.credentialsNamespaceFromSapBtpServiceOperatorSecret = defaultCredentialsSecret.Namespace
-		if r.credentialsNamespaceFromSapBtpManagerSecret != r.credentialsNamespaceFromSapBtpServiceOperatorSecret {
-			msg := fmt.Sprintf("credentials namespace changed from %s to %s", r.credentialsNamespaceFromSapBtpServiceOperatorSecret, r.credentialsNamespaceFromSapBtpManagerSecret)
+		managerNs := r.driftDetector.CredentialsNamespaceFromManager()
+		if managerNs != defaultCredentialsSecret.Namespace {
+			msg := fmt.Sprintf("credentials namespace changed from %s to %s", defaultCredentialsSecret.Namespace, managerNs)
 			logger.Info(msg)
 			return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateProcessing, conditions.CredentialsNamespaceChanged, msg)
 		}
 	}
 
-	sapBtpOperatorConfigMap, err := r.getSapBtpServiceOperatorConfigMap(ctx)
+	sapBtpOperatorConfigMap, err := r.driftDetector.GetSapBtpServiceOperatorConfigMap(ctx)
 	if err != nil {
 		logger.Error(err, fmt.Sprintf("while getting %s ConfigMap", sapBtpServiceOperatorConfigMapName))
 		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, conditions.GettingSapBtpServiceOperatorConfigMapFailed, err.Error())
 	}
 
 	if sapBtpOperatorConfigMap != nil {
-		r.clusterIdFromSapBtpServiceOperatorConfigMap = sapBtpOperatorConfigMap.Data[strings.ToUpper(ClusterIdSecretKey)]
-		if r.clusterIdFromSapBtpManagerSecret != r.clusterIdFromSapBtpServiceOperatorConfigMap {
-			msg := fmt.Sprintf("cluster ID changed from %s to %s", r.clusterIdFromSapBtpServiceOperatorConfigMap, r.credentialsNamespaceFromSapBtpManagerSecret)
+		clusterIdFromCM := sapBtpOperatorConfigMap.Data[strings.ToUpper(ClusterIdSecretKey)]
+		if r.driftDetector.ClusterIdFromManager() != clusterIdFromCM {
+			msg := fmt.Sprintf("cluster ID changed from %s to %s", clusterIdFromCM, r.driftDetector.ClusterIdFromManager())
 			logger.Info(msg)
 			return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateProcessing, conditions.ClusterIdChanged, msg)
 		}
@@ -1992,178 +1962,6 @@ func (r *BtpOperatorReconciler) isCertSecret(s *corev1.Secret) bool {
 	return s.Namespace == config.ChartNamespace && (s.Name == caCertSecretName || s.Name == webhookCertSecretName)
 }
 
-func (r *BtpOperatorReconciler) setCredentialsNamespacesAndClusterId(s *corev1.Secret) {
-	credentialsNamespace := config.ChartNamespace
-	if s != nil {
-		if v, ok := s.Data[CredentialsNamespaceSecretKey]; ok && len(v) > 0 {
-			credentialsNamespace = string(v)
-		}
-		r.clusterIdFromSapBtpManagerSecret = string(s.Data[ClusterIdSecretKey])
-		r.previousCredentialsNamespace = s.Annotations[previousCredentialsNamespaceAnnotationKey]
-	}
-	r.credentialsNamespaceFromSapBtpManagerSecret = credentialsNamespace
-	r.credentialsNamespaceFromSapBtpServiceOperatorSecret = credentialsNamespace
-}
-
-func (r *BtpOperatorReconciler) checkDefaultCredentialsSecretNamespace(ctx context.Context, logger logr.Logger, requiredSecret *corev1.Secret) *ErrorWithReason {
-	defaultCredentialsSecret, err := r.getDefaultCredentialsSecret(ctx)
-	if err != nil {
-		logger.Error(err, fmt.Sprintf("while getting %s secret", sapBtpServiceOperatorSecretName))
-		return NewErrorWithReason(conditions.GettingDefaultCredentialsSecretFailed, err.Error())
-	}
-
-	if defaultCredentialsSecret != nil {
-		r.credentialsNamespaceFromSapBtpServiceOperatorSecret = defaultCredentialsSecret.Namespace
-		if r.credentialsNamespaceFromSapBtpManagerSecret != r.credentialsNamespaceFromSapBtpServiceOperatorSecret {
-			logger.Info(fmt.Sprintf("credentials namespaces between %s secret and %s secret don't match", config.SecretName, sapBtpServiceOperatorSecretName))
-			if err := r.annotateSecret(ctx, requiredSecret, previousCredentialsNamespaceAnnotationKey, r.credentialsNamespaceFromSapBtpServiceOperatorSecret); err != nil {
-				return NewErrorWithReason(conditions.AnnotatingSecretFailed, err.Error())
-			}
-		}
-	}
-
-	return nil
-}
-
-func (r *BtpOperatorReconciler) checkSapBtpServiceOperatorClusterIdConfigMap(ctx context.Context, logger logr.Logger, requiredSecret *corev1.Secret) *ErrorWithReason {
-	sapBtpOperatorConfigMap, err := r.getSapBtpServiceOperatorConfigMap(ctx)
-	if err != nil {
-		logger.Error(err, fmt.Sprintf("while getting %s ConfigMap", sapBtpServiceOperatorConfigMapName))
-		return NewErrorWithReason(conditions.GettingSapBtpServiceOperatorConfigMapFailed, err.Error())
-	}
-
-	if sapBtpOperatorConfigMap != nil {
-		r.clusterIdFromSapBtpServiceOperatorConfigMap = sapBtpOperatorConfigMap.Data[strings.ToUpper(ClusterIdSecretKey)]
-		r.clusterIdFromSapBtpServiceOperatorClusterIdSecret = r.clusterIdFromSapBtpServiceOperatorConfigMap //default value in case of missing cluster ID secret
-		if r.clusterIdFromSapBtpManagerSecret != r.clusterIdFromSapBtpServiceOperatorConfigMap {
-			logger.Info(fmt.Sprintf("cluster IDs between %s secret and %s configmap don't match", config.SecretName, sapBtpServiceOperatorConfigMapName))
-			if err := r.annotateSecret(ctx, requiredSecret, previousClusterIdAnnotationKey, r.clusterIdFromSapBtpServiceOperatorConfigMap); err != nil {
-				return NewErrorWithReason(conditions.AnnotatingSecretFailed, err.Error())
-			}
-		}
-	}
-
-	return nil
-}
-
-func (r *BtpOperatorReconciler) checkSapBtpServiceOperatorClusterIdSecret(ctx context.Context, logger logr.Logger, requiredSecret *corev1.Secret) *ErrorWithReason {
-	clusterIdSecret, err := r.getSecretByNameAndNamespace(ctx, sapBtpServiceOperatorClusterIdSecretName, r.credentialsNamespaceFromSapBtpServiceOperatorSecret)
-	if err != nil {
-		logger.Error(err, fmt.Sprintf("while getting %s secret", sapBtpServiceOperatorClusterIdSecretName))
-		return NewErrorWithReason(conditions.GettingSapBtpServiceOperatorClusterIdSecretFailed, err.Error())
-	}
-
-	if clusterIdSecret != nil {
-		if clusterIdFromSecret, ok := clusterIdSecret.Data[InitialClusterIdSecretKey]; ok && len(clusterIdFromSecret) > 0 {
-			r.clusterIdFromSapBtpServiceOperatorClusterIdSecret = string(clusterIdFromSecret)
-		}
-		if r.clusterIdFromSapBtpServiceOperatorConfigMap != r.clusterIdFromSapBtpServiceOperatorClusterIdSecret {
-			logger.Info(fmt.Sprintf("cluster IDs between %s configmap and %s secret don't match", sapBtpServiceOperatorConfigMapName, sapBtpServiceOperatorClusterIdSecretName))
-			if err = r.annotateSecret(ctx, requiredSecret, previousClusterIdAnnotationKey, r.clusterIdFromSapBtpServiceOperatorClusterIdSecret); err != nil {
-				logger.Error(err, fmt.Sprintf("while annotating %s secret", requiredSecret.Name))
-				return NewErrorWithReason(conditions.AnnotatingSecretFailed, err.Error())
-			}
-			logger.Info(fmt.Sprintf("deleting %s secret from %s namespace due to invalid cluster ID", clusterIdSecret.Name, clusterIdSecret.Namespace))
-			if err = r.deleteObject(ctx, clusterIdSecret); err != nil {
-				logger.Error(err, fmt.Sprintf("while deleting %s secret", clusterIdSecret.Name))
-				return NewErrorWithReason(conditions.DeletionOfOrphanedResourcesFailed, err.Error())
-			}
-			if err = r.restartSapBtpServiceOperatorPodIfNotReady(ctx, logger); err != nil {
-				return NewErrorWithReason(conditions.ResourceRemovalFailed, fmt.Sprintf("while restarting SAP BTP service operator pod: %s", err))
-			}
-		}
-	}
-
-	return nil
-}
-
-func (r *BtpOperatorReconciler) getDefaultCredentialsSecret(ctx context.Context) (*corev1.Secret, error) {
-	var defaultCredentialsSecret *corev1.Secret
-	secrets := &corev1.SecretList{}
-	if err := r.List(ctx, secrets, client.MatchingLabels{managedByLabelKey: operatorName}); err != nil {
-		return nil, fmt.Errorf("unable to list managed secrets: %w", err)
-	}
-	if len(secrets.Items) == 0 {
-		return nil, nil
-	}
-	for i, s := range secrets.Items {
-		if s.Name == sapBtpServiceOperatorSecretName && s.Namespace == r.previousCredentialsNamespace {
-			defaultCredentialsSecret = &secrets.Items[i]
-			break
-		} else if s.Name == sapBtpServiceOperatorSecretName {
-			defaultCredentialsSecret = &secrets.Items[i]
-		}
-	}
-	return defaultCredentialsSecret, nil
-}
-
-func (r *BtpOperatorReconciler) annotateSecret(ctx context.Context, s *corev1.Secret, key, value string) error {
-	annotations := s.GetAnnotations()
-	if annotations == nil {
-		annotations = make(map[string]string)
-	}
-	if annotations[key] == value {
-		return nil
-	}
-	annotations[key] = value
-	s.SetAnnotations(annotations)
-	return r.Update(ctx, s, client.FieldOwner(operatorName))
-}
-
-func (r *BtpOperatorReconciler) getSapBtpServiceOperatorConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {
-	cm := &corev1.ConfigMap{}
-	if err := r.Get(ctx, client.ObjectKey{Namespace: config.ChartNamespace, Name: sapBtpServiceOperatorConfigMapName}, cm); err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	return cm, nil
-}
-
-func (r *BtpOperatorReconciler) deleteResourcesIfBtpManagerSecretChanged(ctx context.Context) error {
-	clusterIdSecret, err := r.getSecretByNameAndNamespace(ctx, sapBtpServiceOperatorClusterIdSecretName, r.credentialsNamespaceFromSapBtpServiceOperatorSecret)
-	if err != nil {
-		return err
-	}
-	pod, err := r.getSapBtpServiceOperatorPod(ctx)
-	if err != nil {
-		return err
-	}
-	credentialsSecret, err := r.getSecretByNameAndNamespace(ctx, sapBtpServiceOperatorSecretName, r.credentialsNamespaceFromSapBtpServiceOperatorSecret)
-	if err != nil {
-		return err
-	}
-
-	isCredentialsNamespaceChanged := r.credentialsNamespaceFromSapBtpServiceOperatorSecret != "" &&
-		r.credentialsNamespaceFromSapBtpManagerSecret != r.credentialsNamespaceFromSapBtpServiceOperatorSecret
-
-	isClusterIdChanged := r.clusterIdFromSapBtpServiceOperatorConfigMap != "" &&
-		(r.clusterIdFromSapBtpManagerSecret != r.clusterIdFromSapBtpServiceOperatorConfigMap ||
-			r.clusterIdFromSapBtpServiceOperatorConfigMap != r.clusterIdFromSapBtpServiceOperatorClusterIdSecret)
-
-	if isCredentialsNamespaceChanged || isClusterIdChanged {
-		if clusterIdSecret != nil {
-			if err = r.deleteObject(ctx, clusterIdSecret); err != nil {
-				return err
-			}
-		}
-		if pod != nil {
-			if err = r.deleteObject(ctx, pod); err != nil {
-				return err
-			}
-		}
-	}
-
-	if isCredentialsNamespaceChanged && credentialsSecret != nil {
-		if err = r.deleteObject(ctx, credentialsSecret); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func (r *BtpOperatorReconciler) deleteObject(ctx context.Context, obj client.Object) error {
 	if err := r.apiServerClient.Delete(ctx, obj); err != nil {
 		return fmt.Errorf("while deleting %s %s from %s namespace: %w", obj.GetName(), obj.GetObjectKind().GroupVersionKind().Kind, obj.GetNamespace(), err)
@@ -2180,24 +1978,6 @@ func (r *BtpOperatorReconciler) getSecretByNameAndNamespace(ctx context.Context,
 		return nil, fmt.Errorf("while getting %s secret from %s namespace: %w", name, namespace, err)
 	}
 	return secret, nil
-}
-
-func (r *BtpOperatorReconciler) getSapBtpServiceOperatorPod(ctx context.Context) (*corev1.Pod, error) {
-	var pod *corev1.Pod
-	pods := &corev1.PodList{}
-	if err := r.apiServerClient.List(ctx, pods, client.MatchingLabels{instanceLabelKey: operandName}); err != nil {
-		return nil, fmt.Errorf("unable to list SAP BTP service operator pods: %w", err)
-	}
-	if len(pods.Items) == 0 {
-		return nil, nil
-	}
-	for i, p := range pods.Items {
-		if strings.HasPrefix(p.Name, operandName) && p.Namespace == config.ChartNamespace {
-			pod = &pods.Items[i]
-			break
-		}
-	}
-	return pod, nil
 }
 
 func (r *BtpOperatorReconciler) validateCert(secret *corev1.Secret) error {

--- a/controllers/btpoperator_controller_test.go
+++ b/controllers/btpoperator_controller_test.go
@@ -34,7 +34,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should return error from client.Get", func(t *testing.T) {
 		// given
 		retryK8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil)
+		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil)
 		retryK8sClient.EnableErrorOnGet()
 
 		// when
@@ -57,7 +57,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should return error from client.Update", func(t *testing.T) {
 		// given
 		retryK8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil)
+		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil)
 		retryK8sClient.EnableErrorOnUpdate()
 
 		// when
@@ -80,7 +80,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should time out", func(t *testing.T) {
 		// given
 		disabledUpdatek8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(disabledUpdatek8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil)
+		btpOperatorReconciler := NewBtpOperatorReconciler(disabledUpdatek8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil)
 		disabledUpdatek8sClient.DisableUpdate()
 
 		// when
@@ -102,7 +102,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should update BtpOperator status after a few retries", func(t *testing.T) {
 		// given
 		retryK8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil)
+		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil)
 
 		// when
 		err := btpOperatorReconciler.UpdateBtpOperatorStatus(ctx, btpOperator, v1alpha1.StateProcessing, conditions.Initialized, "test")
@@ -124,7 +124,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should update BtpOperator status three times", func(t *testing.T) {
 		// given
 		retryK8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil)
+		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil)
 		conditionMsg1 := "test1"
 		conditionMsg2 := "test2"
 		conditionMsg3 := "test3"

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kyma-project/btp-manager/api/v1alpha1"
 	"github.com/kyma-project/btp-manager/controllers/config"
 	"github.com/kyma-project/btp-manager/internal/certs"
+	"github.com/kyma-project/btp-manager/internal/credentials/drift"
 	"github.com/kyma-project/btp-manager/internal/k8s/networkpolicy"
 	"github.com/kyma-project/btp-manager/internal/manifest"
 	btpmanagermetrics "github.com/kyma-project/btp-manager/internal/metrics"
@@ -183,6 +184,7 @@ var _ = SynchronizedBeforeSuite(func() {
 	cleanupReconciler := NewInstanceBindingControllerManager(ctx, k8sManager.GetClient(), k8sManager.GetScheme(), cfg)
 	manifestHandler := &manifest.Handler{Scheme: k8sManager.GetScheme()}
 	networkPolicyManager := networkpolicy.NewManager(k8sManager.GetClient(), manifestHandler)
+	driftDetector := drift.NewDetector(k8sManager.GetClient(), k8sClient)
 	reconciler = NewBtpOperatorReconciler(
 		k8sManager.GetClient(),
 		k8sClient,
@@ -193,6 +195,7 @@ var _ = SynchronizedBeforeSuite(func() {
 			config.NewHandler(k8sManager.GetClient(), k8sManager.GetScheme(), configMetrics),
 		},
 		networkPolicyManager,
+		driftDetector,
 	)
 
 	k8sClientFromManager = k8sManager.GetClient()

--- a/internal/credentials/drift/detector.go
+++ b/internal/credentials/drift/detector.go
@@ -3,6 +3,7 @@ package drift
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -44,7 +45,7 @@ type Detector interface {
 	PreviousCredentialsNamespace() string
 	CheckCredentialsNamespaceDrift(ctx context.Context, requiredSecret *corev1.Secret) *conditions.ErrorWithReason
 	CheckClusterIdConfigMapDrift(ctx context.Context, requiredSecret *corev1.Secret) *conditions.ErrorWithReason
-	CheckClusterIdSecretDrift(ctx context.Context, requiredSecret *corev1.Secret) *conditions.ErrorWithReason
+	ResolveClusterIdSecretDrift(ctx context.Context, requiredSecret *corev1.Secret) *conditions.ErrorWithReason
 	GetDefaultCredentialsSecret(ctx context.Context) (*corev1.Secret, error)
 	GetSapBtpServiceOperatorConfigMap(ctx context.Context) (*corev1.ConfigMap, error)
 	DeleteClusterIdSecret(ctx context.Context) error
@@ -160,7 +161,7 @@ func (d *DriftDetector) CheckClusterIdConfigMapDrift(ctx context.Context, requir
 	return nil
 }
 
-func (d *DriftDetector) CheckClusterIdSecretDrift(ctx context.Context, requiredSecret *corev1.Secret) *conditions.ErrorWithReason {
+func (d *DriftDetector) ResolveClusterIdSecretDrift(ctx context.Context, requiredSecret *corev1.Secret) *conditions.ErrorWithReason {
 	logger := log.FromContext(ctx)
 
 	clusterIdSecret, err := d.getSecretByNameAndNamespace(ctx, sapBtpServiceOperatorClusterIdSecretName, d.credentialsNamespaceFromSapBtpServiceOperatorSecret)
@@ -258,11 +259,19 @@ func (d *DriftDetector) GetDefaultCredentialsSecret(ctx context.Context) (*corev
 	if len(secrets.Items) == 0 {
 		return nil, nil
 	}
+	// Sort by namespace so that, when more than one operator secret exists, the
+	// fallback pick is deterministic rather than dependent on List ordering.
+	sort.Slice(secrets.Items, func(i, j int) bool {
+		return secrets.Items[i].Namespace < secrets.Items[j].Namespace
+	})
 	for i, s := range secrets.Items {
-		if s.Name == sapBtpServiceOperatorSecretName && s.Namespace == d.previousCredentialsNamespace {
-			defaultCredentialsSecret = &secrets.Items[i]
-			break
-		} else if s.Name == sapBtpServiceOperatorSecretName {
+		if s.Name != sapBtpServiceOperatorSecretName {
+			continue
+		}
+		if s.Namespace == d.previousCredentialsNamespace {
+			return &secrets.Items[i], nil
+		}
+		if defaultCredentialsSecret == nil {
 			defaultCredentialsSecret = &secrets.Items[i]
 		}
 	}

--- a/internal/credentials/drift/detector.go
+++ b/internal/credentials/drift/detector.go
@@ -111,10 +111,6 @@ func (d *DriftDetector) PreviousCredentialsNamespace() string {
 	return d.previousCredentialsNamespace
 }
 
-func (d *DriftDetector) SetCredentialsNamespaceFromOperator(ns string) {
-	d.credentialsNamespaceFromSapBtpServiceOperatorSecret = ns
-}
-
 func (d *DriftDetector) SetClusterIdFromOperatorConfigMap(id string) {
 	d.clusterIdFromSapBtpServiceOperatorConfigMap = id
 }

--- a/internal/credentials/drift/detector.go
+++ b/internal/credentials/drift/detector.go
@@ -1,0 +1,354 @@
+package drift
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/kyma-project/btp-manager/controllers/config"
+	"github.com/kyma-project/btp-manager/internal/conditions"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	clusterIdSecretKey            = "cluster_id"
+	credentialsNamespaceSecretKey = "credentials_namespace"
+	initialClusterIdSecretKey     = "INITIAL_CLUSTER_ID"
+
+	operatorName = "btp-manager"
+	operandName  = "sap-btp-operator"
+
+	sapBtpServiceOperatorSecretName          = "sap-btp-service-operator"
+	sapBtpServiceOperatorClusterIdSecretName = operandName + "-clusterid"
+	sapBtpServiceOperatorConfigMapName       = operandName + "-config"
+
+	operatorLabelPrefix                       = "operator.kyma-project.io/"
+	previousClusterIdAnnotationKey            = operatorLabelPrefix + "previous-cluster-id"
+	previousCredentialsNamespaceAnnotationKey = operatorLabelPrefix + "previous-credentials-namespace"
+
+	managedByLabelKey = "app.kubernetes.io/managed-by"
+	instanceLabelKey  = "app.kubernetes.io/instance"
+)
+
+type Detector interface {
+	InitializeFromSecret(s *corev1.Secret)
+	CredentialsNamespaceFromManager() string
+	CredentialsNamespaceFromOperator() string
+	ClusterIdFromManager() string
+	ClusterIdFromOperatorConfigMap() string
+	ClusterIdFromOperatorClusterIdSecret() string
+	PreviousCredentialsNamespace() string
+	CheckCredentialsNamespaceDrift(ctx context.Context, requiredSecret *corev1.Secret) *conditions.ErrorWithReason
+	CheckClusterIdConfigMapDrift(ctx context.Context, requiredSecret *corev1.Secret) *conditions.ErrorWithReason
+	CheckClusterIdSecretDrift(ctx context.Context, requiredSecret *corev1.Secret) *conditions.ErrorWithReason
+	GetDefaultCredentialsSecret(ctx context.Context) (*corev1.Secret, error)
+	GetSapBtpServiceOperatorConfigMap(ctx context.Context) (*corev1.ConfigMap, error)
+	DeleteClusterIdSecret(ctx context.Context) error
+	// DeleteChangedResources must be called after InitializeFromSecret and the Check* methods;
+	// it operates on state accumulated by those calls.
+	DeleteChangedResources(ctx context.Context) error
+}
+
+type DriftDetector struct {
+	client          client.Client
+	apiServerClient client.Client
+
+	previousCredentialsNamespace                        string
+	clusterIdFromSapBtpManagerSecret                    string
+	clusterIdFromSapBtpServiceOperatorConfigMap         string
+	clusterIdFromSapBtpServiceOperatorClusterIdSecret   string
+	credentialsNamespaceFromSapBtpManagerSecret         string
+	credentialsNamespaceFromSapBtpServiceOperatorSecret string
+}
+
+func NewDetector(k8sClient client.Client, apiServerClient client.Client) *DriftDetector {
+	return &DriftDetector{
+		client:          k8sClient,
+		apiServerClient: apiServerClient,
+	}
+}
+
+var _ Detector = (*DriftDetector)(nil)
+
+func (d *DriftDetector) InitializeFromSecret(s *corev1.Secret) {
+	credentialsNamespace := config.ChartNamespace
+	if s != nil {
+		if v, ok := s.Data[credentialsNamespaceSecretKey]; ok && len(v) > 0 {
+			credentialsNamespace = string(v)
+		}
+		d.clusterIdFromSapBtpManagerSecret = string(s.Data[clusterIdSecretKey])
+		d.previousCredentialsNamespace = s.Annotations[previousCredentialsNamespaceAnnotationKey]
+	}
+	d.credentialsNamespaceFromSapBtpManagerSecret = credentialsNamespace
+	d.credentialsNamespaceFromSapBtpServiceOperatorSecret = credentialsNamespace
+}
+
+func (d *DriftDetector) CredentialsNamespaceFromManager() string {
+	return d.credentialsNamespaceFromSapBtpManagerSecret
+}
+
+func (d *DriftDetector) CredentialsNamespaceFromOperator() string {
+	return d.credentialsNamespaceFromSapBtpServiceOperatorSecret
+}
+
+func (d *DriftDetector) ClusterIdFromManager() string {
+	return d.clusterIdFromSapBtpManagerSecret
+}
+
+func (d *DriftDetector) ClusterIdFromOperatorConfigMap() string {
+	return d.clusterIdFromSapBtpServiceOperatorConfigMap
+}
+
+func (d *DriftDetector) ClusterIdFromOperatorClusterIdSecret() string {
+	return d.clusterIdFromSapBtpServiceOperatorClusterIdSecret
+}
+
+func (d *DriftDetector) PreviousCredentialsNamespace() string {
+	return d.previousCredentialsNamespace
+}
+
+func (d *DriftDetector) SetCredentialsNamespaceFromOperator(ns string) {
+	d.credentialsNamespaceFromSapBtpServiceOperatorSecret = ns
+}
+
+func (d *DriftDetector) SetClusterIdFromOperatorConfigMap(id string) {
+	d.clusterIdFromSapBtpServiceOperatorConfigMap = id
+}
+
+func (d *DriftDetector) CheckCredentialsNamespaceDrift(ctx context.Context, requiredSecret *corev1.Secret) *conditions.ErrorWithReason {
+	logger := log.FromContext(ctx)
+
+	defaultCredentialsSecret, err := d.GetDefaultCredentialsSecret(ctx)
+	if err != nil {
+		logger.Error(err, fmt.Sprintf("while getting %s secret", sapBtpServiceOperatorSecretName))
+		return conditions.NewErrorWithReason(conditions.GettingDefaultCredentialsSecretFailed, err.Error())
+	}
+
+	if defaultCredentialsSecret != nil {
+		d.credentialsNamespaceFromSapBtpServiceOperatorSecret = defaultCredentialsSecret.Namespace
+		if d.credentialsNamespaceFromSapBtpManagerSecret != d.credentialsNamespaceFromSapBtpServiceOperatorSecret {
+			logger.Info(fmt.Sprintf("credentials namespaces between %s secret and %s secret don't match", config.SecretName, sapBtpServiceOperatorSecretName))
+			if err := d.annotateSecret(ctx, requiredSecret, previousCredentialsNamespaceAnnotationKey, d.credentialsNamespaceFromSapBtpServiceOperatorSecret); err != nil {
+				return conditions.NewErrorWithReason(conditions.AnnotatingSecretFailed, err.Error())
+			}
+		}
+	}
+
+	return nil
+}
+
+func (d *DriftDetector) CheckClusterIdConfigMapDrift(ctx context.Context, requiredSecret *corev1.Secret) *conditions.ErrorWithReason {
+	logger := log.FromContext(ctx)
+
+	sapBtpOperatorConfigMap, err := d.GetSapBtpServiceOperatorConfigMap(ctx)
+	if err != nil {
+		logger.Error(err, fmt.Sprintf("while getting %s ConfigMap", sapBtpServiceOperatorConfigMapName))
+		return conditions.NewErrorWithReason(conditions.GettingSapBtpServiceOperatorConfigMapFailed, err.Error())
+	}
+
+	if sapBtpOperatorConfigMap != nil {
+		d.clusterIdFromSapBtpServiceOperatorConfigMap = sapBtpOperatorConfigMap.Data[strings.ToUpper(clusterIdSecretKey)]
+		d.clusterIdFromSapBtpServiceOperatorClusterIdSecret = d.clusterIdFromSapBtpServiceOperatorConfigMap
+		if d.clusterIdFromSapBtpManagerSecret != d.clusterIdFromSapBtpServiceOperatorConfigMap {
+			logger.Info(fmt.Sprintf("cluster IDs between %s secret and %s configmap don't match", config.SecretName, sapBtpServiceOperatorConfigMapName))
+			if err := d.annotateSecret(ctx, requiredSecret, previousClusterIdAnnotationKey, d.clusterIdFromSapBtpServiceOperatorConfigMap); err != nil {
+				return conditions.NewErrorWithReason(conditions.AnnotatingSecretFailed, err.Error())
+			}
+		}
+	}
+
+	return nil
+}
+
+func (d *DriftDetector) CheckClusterIdSecretDrift(ctx context.Context, requiredSecret *corev1.Secret) *conditions.ErrorWithReason {
+	logger := log.FromContext(ctx)
+
+	clusterIdSecret, err := d.getSecretByNameAndNamespace(ctx, sapBtpServiceOperatorClusterIdSecretName, d.credentialsNamespaceFromSapBtpServiceOperatorSecret)
+	if err != nil {
+		logger.Error(err, fmt.Sprintf("while getting %s secret", sapBtpServiceOperatorClusterIdSecretName))
+		return conditions.NewErrorWithReason(conditions.GettingSapBtpServiceOperatorClusterIdSecretFailed, err.Error())
+	}
+
+	if clusterIdSecret != nil {
+		if clusterIdFromSecret, ok := clusterIdSecret.Data[initialClusterIdSecretKey]; ok && len(clusterIdFromSecret) > 0 {
+			d.clusterIdFromSapBtpServiceOperatorClusterIdSecret = string(clusterIdFromSecret)
+		}
+		if d.clusterIdFromSapBtpServiceOperatorConfigMap != d.clusterIdFromSapBtpServiceOperatorClusterIdSecret {
+			logger.Info(fmt.Sprintf("cluster IDs between %s configmap and %s secret don't match", sapBtpServiceOperatorConfigMapName, sapBtpServiceOperatorClusterIdSecretName))
+			if err = d.annotateSecret(ctx, requiredSecret, previousClusterIdAnnotationKey, d.clusterIdFromSapBtpServiceOperatorClusterIdSecret); err != nil {
+				logger.Error(err, fmt.Sprintf("while annotating %s secret", requiredSecret.Name))
+				return conditions.NewErrorWithReason(conditions.AnnotatingSecretFailed, err.Error())
+			}
+			logger.Info(fmt.Sprintf("deleting %s secret from %s namespace due to invalid cluster ID", clusterIdSecret.Name, clusterIdSecret.Namespace))
+			if err = d.deleteObject(ctx, clusterIdSecret); err != nil {
+				logger.Error(err, fmt.Sprintf("while deleting %s secret", clusterIdSecret.Name))
+				return conditions.NewErrorWithReason(conditions.DeletionOfOrphanedResourcesFailed, err.Error())
+			}
+			if err = d.restartSapBtpServiceOperatorPodIfNotReady(ctx, logger); err != nil {
+				return conditions.NewErrorWithReason(conditions.ResourceRemovalFailed, fmt.Sprintf("while restarting SAP BTP service operator pod: %s", err))
+			}
+		}
+	}
+
+	return nil
+}
+
+func (d *DriftDetector) DeleteChangedResources(ctx context.Context) error {
+	clusterIdSecret, err := d.getSecretByNameAndNamespace(ctx, sapBtpServiceOperatorClusterIdSecretName, d.credentialsNamespaceFromSapBtpServiceOperatorSecret)
+	if err != nil {
+		return err
+	}
+	pod, err := d.getSapBtpServiceOperatorPod(ctx)
+	if err != nil {
+		return err
+	}
+	credentialsSecret, err := d.getSecretByNameAndNamespace(ctx, sapBtpServiceOperatorSecretName, d.credentialsNamespaceFromSapBtpServiceOperatorSecret)
+	if err != nil {
+		return err
+	}
+
+	isCredentialsNamespaceChanged := d.credentialsNamespaceFromSapBtpServiceOperatorSecret != "" &&
+		d.credentialsNamespaceFromSapBtpManagerSecret != d.credentialsNamespaceFromSapBtpServiceOperatorSecret
+
+	isClusterIdChanged := d.clusterIdFromSapBtpServiceOperatorConfigMap != "" &&
+		(d.clusterIdFromSapBtpManagerSecret != d.clusterIdFromSapBtpServiceOperatorConfigMap ||
+			d.clusterIdFromSapBtpServiceOperatorConfigMap != d.clusterIdFromSapBtpServiceOperatorClusterIdSecret)
+
+	if isCredentialsNamespaceChanged || isClusterIdChanged {
+		if clusterIdSecret != nil {
+			if err = d.deleteObject(ctx, clusterIdSecret); err != nil {
+				return err
+			}
+		}
+		if pod != nil {
+			if err = d.deleteObject(ctx, pod); err != nil {
+				return err
+			}
+		}
+	}
+
+	if isCredentialsNamespaceChanged && credentialsSecret != nil {
+		if err = d.deleteObject(ctx, credentialsSecret); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (d *DriftDetector) DeleteClusterIdSecret(ctx context.Context) error {
+	clusterIdSecret, err := d.getSecretByNameAndNamespace(ctx, sapBtpServiceOperatorClusterIdSecretName, d.credentialsNamespaceFromSapBtpManagerSecret)
+	if err != nil {
+		return fmt.Errorf("failed to get cluster ID secret: %w", err)
+	}
+	if clusterIdSecret != nil {
+		if err := d.deleteObject(ctx, clusterIdSecret); err != nil {
+			return fmt.Errorf("failed to delete cluster ID secret: %w", err)
+		}
+	}
+	return nil
+}
+
+func (d *DriftDetector) GetDefaultCredentialsSecret(ctx context.Context) (*corev1.Secret, error) {
+	var defaultCredentialsSecret *corev1.Secret
+	secrets := &corev1.SecretList{}
+	if err := d.client.List(ctx, secrets, client.MatchingLabels{managedByLabelKey: operatorName}); err != nil {
+		return nil, fmt.Errorf("unable to list managed secrets: %w", err)
+	}
+	if len(secrets.Items) == 0 {
+		return nil, nil
+	}
+	for i, s := range secrets.Items {
+		if s.Name == sapBtpServiceOperatorSecretName && s.Namespace == d.previousCredentialsNamespace {
+			defaultCredentialsSecret = &secrets.Items[i]
+			break
+		} else if s.Name == sapBtpServiceOperatorSecretName {
+			defaultCredentialsSecret = &secrets.Items[i]
+		}
+	}
+	return defaultCredentialsSecret, nil
+}
+
+func (d *DriftDetector) GetSapBtpServiceOperatorConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {
+	cm := &corev1.ConfigMap{}
+	if err := d.client.Get(ctx, client.ObjectKey{Namespace: config.ChartNamespace, Name: sapBtpServiceOperatorConfigMapName}, cm); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return cm, nil
+}
+
+func (d *DriftDetector) annotateSecret(ctx context.Context, s *corev1.Secret, key, value string) error {
+	annotations := s.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	if annotations[key] == value {
+		return nil
+	}
+	annotations[key] = value
+	s.SetAnnotations(annotations)
+	return d.client.Update(ctx, s, client.FieldOwner(operatorName))
+}
+
+func (d *DriftDetector) getSecretByNameAndNamespace(ctx context.Context, name, namespace string) (*corev1.Secret, error) {
+	secret := &corev1.Secret{}
+	if err := d.apiServerClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, secret); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("while getting %s secret from %s namespace: %w", name, namespace, err)
+	}
+	return secret, nil
+}
+
+func (d *DriftDetector) getSapBtpServiceOperatorPod(ctx context.Context) (*corev1.Pod, error) {
+	var pod *corev1.Pod
+	pods := &corev1.PodList{}
+	if err := d.apiServerClient.List(ctx, pods, client.MatchingLabels{instanceLabelKey: operandName}); err != nil {
+		return nil, fmt.Errorf("unable to list SAP BTP service operator pods: %w", err)
+	}
+	if len(pods.Items) == 0 {
+		return nil, nil
+	}
+	for i, p := range pods.Items {
+		if strings.HasPrefix(p.Name, operandName) && p.Namespace == config.ChartNamespace {
+			pod = &pods.Items[i]
+			break
+		}
+	}
+	return pod, nil
+}
+
+func (d *DriftDetector) deleteObject(ctx context.Context, obj client.Object) error {
+	if err := d.apiServerClient.Delete(ctx, obj); err != nil {
+		return fmt.Errorf("while deleting %s %s from %s namespace: %w", obj.GetName(), obj.GetObjectKind().GroupVersionKind().Kind, obj.GetNamespace(), err)
+	}
+	return nil
+}
+
+func (d *DriftDetector) restartSapBtpServiceOperatorPodIfNotReady(ctx context.Context, logger logr.Logger) error {
+	pod, err := d.getSapBtpServiceOperatorPod(ctx)
+	if err != nil {
+		logger.Error(err, "while getting SAP BTP service operator pod")
+		return err
+	}
+	if pod != nil {
+		for _, condition := range pod.Status.Conditions {
+			if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionFalse {
+				if err := d.deleteObject(ctx, pod); err != nil {
+					logger.Error(err, fmt.Sprintf("while deleting not ready %s pod", pod.Name))
+					return err
+				}
+				break
+			}
+		}
+	}
+	return nil
+}

--- a/internal/credentials/drift/detector_test.go
+++ b/internal/credentials/drift/detector_test.go
@@ -1,0 +1,707 @@
+package drift_test
+
+import (
+	"context"
+
+	"github.com/kyma-project/btp-manager/controllers/config"
+	"github.com/kyma-project/btp-manager/internal/conditions"
+	"github.com/kyma-project/btp-manager/internal/credentials/drift"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Drift Detector", func() {
+	var (
+		detector  *drift.DriftDetector
+		k8sClient client.Client
+		ctx       context.Context
+	)
+
+	BeforeEach(func() {
+		config.ChartNamespace = kymaNamespace
+		ctx = context.Background()
+	})
+
+	Describe("InitializeFromSecret", func() {
+		BeforeEach(func() {
+			k8sClient = newFakeClient()
+			detector = drift.NewDetector(k8sClient, k8sClient)
+		})
+
+		It("should extract cluster ID from the secret", func() {
+			secret := btpManagerSecret("test-cluster-id", "", nil)
+
+			detector.InitializeFromSecret(secret)
+
+			Expect(detector.ClusterIdFromManager()).To(Equal("test-cluster-id"))
+		})
+
+		It("should extract credentials namespace from the secret", func() {
+			secret := btpManagerSecret("", "custom-ns", nil)
+
+			detector.InitializeFromSecret(secret)
+
+			Expect(detector.CredentialsNamespaceFromManager()).To(Equal("custom-ns"))
+			Expect(detector.CredentialsNamespaceFromOperator()).To(Equal("custom-ns"))
+		})
+
+		It("should default credentials namespace to ChartNamespace when not set in the secret", func() {
+			secret := btpManagerSecret("", "", nil)
+
+			detector.InitializeFromSecret(secret)
+
+			Expect(detector.CredentialsNamespaceFromManager()).To(Equal(kymaNamespace))
+		})
+
+		It("should extract previous credentials namespace from annotation", func() {
+			secret := btpManagerSecret("", "", map[string]string{
+				previousCredentialsNamespaceAnnotationKey: "old-ns",
+			})
+
+			detector.InitializeFromSecret(secret)
+
+			Expect(detector.PreviousCredentialsNamespace()).To(Equal("old-ns"))
+		})
+
+		It("should default credentials namespace to ChartNamespace when secret is nil", func() {
+			detector.InitializeFromSecret(nil)
+
+			Expect(detector.CredentialsNamespaceFromManager()).To(Equal(kymaNamespace))
+			Expect(detector.CredentialsNamespaceFromOperator()).To(Equal(kymaNamespace))
+			Expect(detector.ClusterIdFromManager()).To(BeEmpty())
+			Expect(detector.PreviousCredentialsNamespace()).To(BeEmpty())
+		})
+	})
+
+	Describe("GetDefaultCredentialsSecret", func() {
+		It("should return nil when no managed secrets exist", func() {
+			k8sClient = newFakeClient()
+			detector = drift.NewDetector(k8sClient, k8sClient)
+
+			secret, err := detector.GetDefaultCredentialsSecret(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secret).To(BeNil())
+		})
+
+		It("should return the operator secret matching the previous credentials namespace", func() {
+			secretInDefault := operatorSecret(kymaNamespace)
+			secretInPrevious := operatorSecret("previous-ns")
+			k8sClient = newFakeClient(secretInDefault, secretInPrevious)
+			detector = drift.NewDetector(k8sClient, k8sClient)
+
+			managerSecret := btpManagerSecret("", "", map[string]string{
+				previousCredentialsNamespaceAnnotationKey: "previous-ns",
+			})
+			detector.InitializeFromSecret(managerSecret)
+
+			secret, err := detector.GetDefaultCredentialsSecret(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secret).NotTo(BeNil())
+			Expect(secret.Namespace).To(Equal("previous-ns"))
+		})
+
+		It("should fall back to any matching secret when previous namespace does not match", func() {
+			secretInOther := operatorSecret("other-ns")
+			k8sClient = newFakeClient(secretInOther)
+			detector = drift.NewDetector(k8sClient, k8sClient)
+
+			detector.InitializeFromSecret(nil)
+
+			secret, err := detector.GetDefaultCredentialsSecret(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secret).NotTo(BeNil())
+			Expect(secret.Namespace).To(Equal("other-ns"))
+		})
+
+		It("should ignore secrets with a different name", func() {
+			unrelatedSecret := &corev1.Secret{}
+			unrelatedSecret.Name = "some-other-secret"
+			unrelatedSecret.Namespace = kymaNamespace
+			unrelatedSecret.Labels = map[string]string{managedByLabelKey: operatorName}
+
+			k8sClient = newFakeClient(unrelatedSecret)
+			detector = drift.NewDetector(k8sClient, k8sClient)
+
+			secret, err := detector.GetDefaultCredentialsSecret(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secret).To(BeNil())
+		})
+	})
+
+	Describe("GetSapBtpServiceOperatorConfigMap", func() {
+		It("should return the ConfigMap when it exists", func() {
+			cm := operatorConfigMap("cluster-123")
+			k8sClient = newFakeClient(cm)
+			detector = drift.NewDetector(k8sClient, k8sClient)
+
+			result, err := detector.GetSapBtpServiceOperatorConfigMap(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Data[clusterIdConfigMapKey]).To(Equal("cluster-123"))
+		})
+
+		It("should return nil when the ConfigMap does not exist", func() {
+			k8sClient = newFakeClient()
+			detector = drift.NewDetector(k8sClient, k8sClient)
+
+			result, err := detector.GetSapBtpServiceOperatorConfigMap(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeNil())
+		})
+	})
+
+	Describe("CheckCredentialsNamespaceDrift", func() {
+		var requiredSecret *corev1.Secret
+
+		BeforeEach(func() {
+			requiredSecret = btpManagerSecret("cluster-1", kymaNamespace, nil)
+		})
+
+		Context("when no operator secret exists", func() {
+			BeforeEach(func() {
+				k8sClient = newFakeClient()
+				detector = drift.NewDetector(k8sClient, k8sClient)
+				detector.InitializeFromSecret(requiredSecret)
+			})
+
+			It("should return nil (no drift)", func() {
+				result := detector.CheckCredentialsNamespaceDrift(ctx, requiredSecret)
+
+				Expect(result).To(BeNil())
+			})
+		})
+
+		Context("when the operator secret is in the same namespace as the manager secret", func() {
+			BeforeEach(func() {
+				opSecret := operatorSecret(kymaNamespace)
+				k8sClient = newFakeClient(opSecret)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+				detector.InitializeFromSecret(requiredSecret)
+			})
+
+			It("should return nil (no drift)", func() {
+				result := detector.CheckCredentialsNamespaceDrift(ctx, requiredSecret)
+
+				Expect(result).To(BeNil())
+			})
+
+			It("should track the operator's namespace", func() {
+				Expect(detector.CheckCredentialsNamespaceDrift(ctx, requiredSecret)).To(Succeed())
+
+				Expect(detector.CredentialsNamespaceFromOperator()).To(Equal(kymaNamespace))
+			})
+		})
+
+		Context("when the operator secret is in a different namespace", func() {
+			BeforeEach(func() {
+				opSecret := operatorSecret("old-ns")
+				k8sClient = newFakeClient(opSecret, requiredSecret)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+				detector.InitializeFromSecret(requiredSecret)
+			})
+
+			It("should return nil but annotate the required secret with the previous namespace", func() {
+				result := detector.CheckCredentialsNamespaceDrift(ctx, requiredSecret)
+
+				Expect(result).To(BeNil())
+				Expect(requiredSecret.Annotations).To(HaveKeyWithValue(
+					previousCredentialsNamespaceAnnotationKey, "old-ns",
+				))
+			})
+
+			It("should track the operator's namespace", func() {
+				Expect(detector.CheckCredentialsNamespaceDrift(ctx, requiredSecret)).To(Succeed())
+
+				Expect(detector.CredentialsNamespaceFromOperator()).To(Equal("old-ns"))
+			})
+		})
+
+		Context("error paths", func() {
+			It("should return GettingDefaultCredentialsSecretFailed when listing secrets fails", func() {
+				k8sClient = newErrorOnListClient(newFakeClient())
+				detector = drift.NewDetector(k8sClient, newFakeClient())
+				detector.InitializeFromSecret(requiredSecret)
+
+				result := detector.CheckCredentialsNamespaceDrift(ctx, requiredSecret)
+
+				Expect(result).NotTo(BeNil())
+				Expect(result.Reason).To(Equal(conditions.GettingDefaultCredentialsSecretFailed))
+			})
+
+			It("should return AnnotatingSecretFailed when annotating the secret fails", func() {
+				opSecret := operatorSecret("old-ns")
+				// List must succeed (to detect drift); Update must fail (to trigger annotation error).
+				k8sClient = newErrorOnUpdateClient(newFakeClient(opSecret, requiredSecret))
+				detector = drift.NewDetector(k8sClient, newFakeClient())
+				detector.InitializeFromSecret(requiredSecret)
+
+				result := detector.CheckCredentialsNamespaceDrift(ctx, requiredSecret)
+
+				Expect(result).NotTo(BeNil())
+				Expect(result.Reason).To(Equal(conditions.AnnotatingSecretFailed))
+			})
+		})
+	})
+
+	Describe("CheckClusterIdConfigMapDrift", func() {
+		var requiredSecret *corev1.Secret
+
+		BeforeEach(func() {
+			requiredSecret = btpManagerSecret("cluster-1", kymaNamespace, nil)
+		})
+
+		Context("when no operator ConfigMap exists", func() {
+			BeforeEach(func() {
+				k8sClient = newFakeClient()
+				detector = drift.NewDetector(k8sClient, k8sClient)
+				detector.InitializeFromSecret(requiredSecret)
+			})
+
+			It("should return nil (no drift)", func() {
+				result := detector.CheckClusterIdConfigMapDrift(ctx, requiredSecret)
+
+				Expect(result).To(BeNil())
+			})
+		})
+
+		Context("when the ConfigMap cluster ID matches the manager secret", func() {
+			BeforeEach(func() {
+				cm := operatorConfigMap("cluster-1")
+				k8sClient = newFakeClient(cm)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+				detector.InitializeFromSecret(requiredSecret)
+			})
+
+			It("should return nil (no drift)", func() {
+				result := detector.CheckClusterIdConfigMapDrift(ctx, requiredSecret)
+
+				Expect(result).To(BeNil())
+			})
+
+			It("should track the ConfigMap's cluster ID", func() {
+				Expect(detector.CheckClusterIdConfigMapDrift(ctx, requiredSecret)).To(Succeed())
+
+				Expect(detector.ClusterIdFromOperatorConfigMap()).To(Equal("cluster-1"))
+			})
+		})
+
+		Context("when the ConfigMap cluster ID differs from the manager secret", func() {
+			BeforeEach(func() {
+				cm := operatorConfigMap("old-cluster-id")
+				k8sClient = newFakeClient(cm, requiredSecret)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+				detector.InitializeFromSecret(requiredSecret)
+			})
+
+			It("should return nil but annotate the required secret with the old cluster ID", func() {
+				result := detector.CheckClusterIdConfigMapDrift(ctx, requiredSecret)
+
+				Expect(result).To(BeNil())
+				Expect(requiredSecret.Annotations).To(HaveKeyWithValue(
+					previousClusterIdAnnotationKey, "old-cluster-id",
+				))
+			})
+
+			It("should track the ConfigMap's cluster ID", func() {
+				Expect(detector.CheckClusterIdConfigMapDrift(ctx, requiredSecret)).To(Succeed())
+
+				Expect(detector.ClusterIdFromOperatorConfigMap()).To(Equal("old-cluster-id"))
+			})
+		})
+
+		Context("error paths", func() {
+			It("should return GettingSapBtpServiceOperatorConfigMapFailed when the ConfigMap fetch fails", func() {
+				badClient := newErrorOnGetClient(newFakeClient())
+				detector = drift.NewDetector(badClient, badClient)
+				detector.InitializeFromSecret(requiredSecret)
+
+				result := detector.CheckClusterIdConfigMapDrift(ctx, requiredSecret)
+
+				Expect(result).NotTo(BeNil())
+				Expect(result.Reason).To(Equal(conditions.GettingSapBtpServiceOperatorConfigMapFailed))
+			})
+
+			It("should return AnnotatingSecretFailed when annotating the secret fails", func() {
+				cm := operatorConfigMap("old-cluster-id")
+				// Get must succeed (to return ConfigMap); Update must fail (to trigger annotation error).
+				k8sClient = newErrorOnUpdateClient(newFakeClient(cm, requiredSecret))
+				detector = drift.NewDetector(k8sClient, newFakeClient())
+				detector.InitializeFromSecret(requiredSecret)
+
+				result := detector.CheckClusterIdConfigMapDrift(ctx, requiredSecret)
+
+				Expect(result).NotTo(BeNil())
+				Expect(result.Reason).To(Equal(conditions.AnnotatingSecretFailed))
+			})
+		})
+	})
+
+	Describe("CheckClusterIdSecretDrift", func() {
+		var requiredSecret *corev1.Secret
+
+		BeforeEach(func() {
+			requiredSecret = btpManagerSecret("cluster-1", kymaNamespace, nil)
+		})
+
+		Context("when no cluster ID secret exists", func() {
+			BeforeEach(func() {
+				k8sClient = newFakeClient()
+				detector = drift.NewDetector(k8sClient, k8sClient)
+				detector.InitializeFromSecret(requiredSecret)
+			})
+
+			It("should return nil (no drift)", func() {
+				result := detector.CheckClusterIdSecretDrift(ctx, requiredSecret)
+
+				Expect(result).To(BeNil())
+			})
+		})
+
+		Context("when the cluster ID secret matches the ConfigMap value", func() {
+			BeforeEach(func() {
+				cidSecret := clusterIdSecret(kymaNamespace, "cluster-1")
+				k8sClient = newFakeClient(cidSecret)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+				detector.InitializeFromSecret(requiredSecret)
+				detector.SetClusterIdFromOperatorConfigMap("cluster-1")
+			})
+
+			It("should return nil (no drift)", func() {
+				result := detector.CheckClusterIdSecretDrift(ctx, requiredSecret)
+
+				Expect(result).To(BeNil())
+			})
+
+			It("should track the cluster ID secret's value", func() {
+				Expect(detector.CheckClusterIdSecretDrift(ctx, requiredSecret)).To(Succeed())
+
+				Expect(detector.ClusterIdFromOperatorClusterIdSecret()).To(Equal("cluster-1"))
+			})
+		})
+
+		Context("when the cluster ID secret differs from the ConfigMap value", func() {
+			var cidSecret *corev1.Secret
+
+			BeforeEach(func() {
+				cidSecret = clusterIdSecret(kymaNamespace, "stale-cluster-id")
+				pod := operatorPod(operandName+"-controller-manager-abc", kymaNamespace, corev1.ConditionFalse)
+				k8sClient = newFakeClient(cidSecret, pod, requiredSecret)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+				detector.InitializeFromSecret(requiredSecret)
+				detector.SetClusterIdFromOperatorConfigMap("cluster-1")
+			})
+
+			It("should annotate the required secret with the stale cluster ID", func() {
+				Expect(detector.CheckClusterIdSecretDrift(ctx, requiredSecret)).To(Succeed())
+
+				Expect(requiredSecret.Annotations).To(HaveKeyWithValue(
+					previousClusterIdAnnotationKey, "stale-cluster-id",
+				))
+			})
+
+			It("should delete the stale cluster ID secret", func() {
+				result := detector.CheckClusterIdSecretDrift(ctx, requiredSecret)
+
+				Expect(result).To(BeNil())
+
+				secret := &corev1.Secret{}
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(cidSecret), secret)
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should restart the not-ready operator pod", func() {
+				result := detector.CheckClusterIdSecretDrift(ctx, requiredSecret)
+
+				Expect(result).To(BeNil())
+
+				pods := &corev1.PodList{}
+				Expect(k8sClient.List(ctx, pods, client.MatchingLabels{instanceLabelKey: operandName})).To(Succeed())
+				Expect(pods.Items).To(BeEmpty())
+			})
+		})
+
+		Context("when the cluster ID secret differs but the operator pod is ready", func() {
+			BeforeEach(func() {
+				cidSecret := clusterIdSecret(kymaNamespace, "stale-cluster-id")
+				pod := operatorPod(operandName+"-controller-manager-abc", kymaNamespace, corev1.ConditionTrue)
+				k8sClient = newFakeClient(cidSecret, pod, requiredSecret)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+				detector.InitializeFromSecret(requiredSecret)
+				detector.SetClusterIdFromOperatorConfigMap("cluster-1")
+			})
+
+			It("should not delete the ready pod", func() {
+				Expect(detector.CheckClusterIdSecretDrift(ctx, requiredSecret)).To(Succeed())
+
+				pods := &corev1.PodList{}
+				Expect(k8sClient.List(ctx, pods, client.MatchingLabels{instanceLabelKey: operandName})).To(Succeed())
+				Expect(pods.Items).To(HaveLen(1))
+			})
+		})
+
+		Context("when the cluster ID secret differs but the labelled pod is in a different namespace", func() {
+			BeforeEach(func() {
+				cidSecret := clusterIdSecret(kymaNamespace, "stale-cluster-id")
+				podInWrongNs := operatorPod(operandName+"-abc", "other-namespace", corev1.ConditionFalse)
+				k8sClient = newFakeClient(cidSecret, podInWrongNs, requiredSecret)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+				detector.InitializeFromSecret(requiredSecret)
+				detector.SetClusterIdFromOperatorConfigMap("cluster-1")
+			})
+
+			It("should not restart a pod outside ChartNamespace", func() {
+				Expect(detector.CheckClusterIdSecretDrift(ctx, requiredSecret)).To(Succeed())
+
+				pods := &corev1.PodList{}
+				Expect(k8sClient.List(ctx, pods, client.MatchingLabels{instanceLabelKey: operandName})).To(Succeed())
+				Expect(pods.Items).To(HaveLen(1))
+			})
+		})
+
+		Context("error paths", func() {
+			It("should return GettingSapBtpServiceOperatorClusterIdSecretFailed when the cluster ID secret fetch fails", func() {
+				badApiClient := newErrorOnGetClient(newFakeClient())
+				detector = drift.NewDetector(k8sClient, badApiClient)
+				detector.InitializeFromSecret(requiredSecret)
+
+				result := detector.CheckClusterIdSecretDrift(ctx, requiredSecret)
+
+				Expect(result).NotTo(BeNil())
+				Expect(result.Reason).To(Equal(conditions.GettingSapBtpServiceOperatorClusterIdSecretFailed))
+			})
+
+			It("should return AnnotatingSecretFailed when annotating the required secret fails", func() {
+				cidSecret := clusterIdSecret(kymaNamespace, "stale-cluster-id")
+				// Get must succeed (apiServerClient); Update must fail (cached client).
+				apiServerClient := newFakeClient(cidSecret)
+				cachedClient := newErrorOnUpdateClient(newFakeClient(requiredSecret))
+				detector = drift.NewDetector(cachedClient, apiServerClient)
+				detector.InitializeFromSecret(requiredSecret)
+				detector.SetClusterIdFromOperatorConfigMap("cluster-1")
+
+				result := detector.CheckClusterIdSecretDrift(ctx, requiredSecret)
+
+				Expect(result).NotTo(BeNil())
+				Expect(result.Reason).To(Equal(conditions.AnnotatingSecretFailed))
+			})
+
+			It("should return DeletionOfOrphanedResourcesFailed when deleting the cluster ID secret fails", func() {
+				cidSecret := clusterIdSecret(kymaNamespace, "stale-cluster-id")
+				// Get must succeed; Update must succeed; Delete must fail.
+				apiServerClient := newErrorOnDeleteClient(newFakeClient(cidSecret))
+				cachedClient := newFakeClient(requiredSecret)
+				detector = drift.NewDetector(cachedClient, apiServerClient)
+				detector.InitializeFromSecret(requiredSecret)
+				detector.SetClusterIdFromOperatorConfigMap("cluster-1")
+
+				result := detector.CheckClusterIdSecretDrift(ctx, requiredSecret)
+
+				Expect(result).NotTo(BeNil())
+				Expect(result.Reason).To(Equal(conditions.DeletionOfOrphanedResourcesFailed))
+			})
+
+			It("should return ResourceRemovalFailed when restarting the operator pod fails", func() {
+				cidSecret := clusterIdSecret(kymaNamespace, "stale-cluster-id")
+				notReadyPod := operatorPod(operandName+"-abc", kymaNamespace, corev1.ConditionFalse)
+				// Get/Delete must succeed; List must fail to simulate pod listing failure during restart.
+				apiServerClient := newErrorOnListClient(newFakeClient(cidSecret, notReadyPod))
+				cachedClient := newFakeClient(requiredSecret)
+				detector = drift.NewDetector(cachedClient, apiServerClient)
+				detector.InitializeFromSecret(requiredSecret)
+				detector.SetClusterIdFromOperatorConfigMap("cluster-1")
+
+				result := detector.CheckClusterIdSecretDrift(ctx, requiredSecret)
+
+				Expect(result).NotTo(BeNil())
+				Expect(result.Reason).To(Equal(conditions.ResourceRemovalFailed))
+			})
+		})
+	})
+
+	Describe("DeleteChangedResources", func() {
+		// DeleteChangedResources relies on internal state populated by the
+		// Check* methods. These tests simulate the real reconciler workflow:
+		// InitializeFromSecret → Check* → DeleteChangedResources.
+
+		Context("when nothing changed", func() {
+			BeforeEach(func() {
+				cidSecret := clusterIdSecret(kymaNamespace, "cluster-1")
+				cm := operatorConfigMap("cluster-1")
+				opSecret := operatorSecret(kymaNamespace)
+				pod := operatorPod(operandName+"-abc", kymaNamespace, corev1.ConditionTrue)
+				requiredSecret := btpManagerSecret("cluster-1", kymaNamespace, nil)
+				k8sClient = newFakeClient(cidSecret, cm, opSecret, pod, requiredSecret)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+
+				detector.InitializeFromSecret(requiredSecret)
+				Expect(detector.CheckCredentialsNamespaceDrift(ctx, requiredSecret)).To(Succeed())
+				Expect(detector.CheckClusterIdConfigMapDrift(ctx, requiredSecret)).To(Succeed())
+				Expect(detector.CheckClusterIdSecretDrift(ctx, requiredSecret)).To(Succeed())
+			})
+
+			It("should not delete any resources", func() {
+				err := detector.DeleteChangedResources(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				secrets := &corev1.SecretList{}
+				Expect(k8sClient.List(ctx, secrets)).To(Succeed())
+				secretNames := extractSecretNames(secrets.Items)
+				Expect(secretNames).To(ContainElements(
+					sapBtpServiceOperatorSecretName,
+					sapBtpServiceOperatorClusterIdSecretName,
+				))
+
+				pods := &corev1.PodList{}
+				Expect(k8sClient.List(ctx, pods)).To(Succeed())
+				Expect(pods.Items).To(HaveLen(1))
+			})
+		})
+
+		Context("when cluster ID changed (manager secret differs from ConfigMap)", func() {
+			BeforeEach(func() {
+				cidSecret := clusterIdSecret(kymaNamespace, "old-cluster")
+				cm := operatorConfigMap("old-cluster")
+				opSecret := operatorSecret(kymaNamespace)
+				pod := operatorPod(operandName+"-abc", kymaNamespace, corev1.ConditionTrue)
+				requiredSecret := btpManagerSecret("new-cluster", kymaNamespace, nil)
+				k8sClient = newFakeClient(cidSecret, cm, opSecret, pod, requiredSecret)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+
+				detector.InitializeFromSecret(requiredSecret)
+				Expect(detector.CheckCredentialsNamespaceDrift(ctx, requiredSecret)).To(Succeed())
+				Expect(detector.CheckClusterIdConfigMapDrift(ctx, requiredSecret)).To(Succeed())
+				Expect(detector.CheckClusterIdSecretDrift(ctx, requiredSecret)).To(Succeed())
+			})
+
+			It("should delete the cluster ID secret and the operator pod", func() {
+				err := detector.DeleteChangedResources(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				pods := &corev1.PodList{}
+				Expect(k8sClient.List(ctx, pods)).To(Succeed())
+				Expect(pods.Items).To(BeEmpty())
+
+				secrets := &corev1.SecretList{}
+				Expect(k8sClient.List(ctx, secrets)).To(Succeed())
+				secretNames := extractSecretNames(secrets.Items)
+				Expect(secretNames).NotTo(ContainElement(sapBtpServiceOperatorClusterIdSecretName))
+			})
+
+			It("should not delete the operator credentials secret", func() {
+				err := detector.DeleteChangedResources(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				secrets := &corev1.SecretList{}
+				Expect(k8sClient.List(ctx, secrets)).To(Succeed())
+				secretNames := extractSecretNames(secrets.Items)
+				Expect(secretNames).To(ContainElement(sapBtpServiceOperatorSecretName))
+			})
+		})
+
+		Context("when credentials namespace changed", func() {
+			BeforeEach(func() {
+				cidSecret := clusterIdSecret("old-ns", "cluster-1")
+				opSecret := operatorSecret("old-ns")
+				pod := operatorPod(operandName+"-abc", kymaNamespace, corev1.ConditionTrue)
+				requiredSecret := btpManagerSecret("cluster-1", "new-ns", nil)
+				k8sClient = newFakeClient(cidSecret, opSecret, pod, requiredSecret)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+
+				detector.InitializeFromSecret(requiredSecret)
+				Expect(detector.CheckCredentialsNamespaceDrift(ctx, requiredSecret)).To(Succeed())
+			})
+
+			It("should delete the cluster ID secret, the operator pod, and the credentials secret", func() {
+				err := detector.DeleteChangedResources(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				pods := &corev1.PodList{}
+				Expect(k8sClient.List(ctx, pods)).To(Succeed())
+				Expect(pods.Items).To(BeEmpty())
+
+				secrets := &corev1.SecretList{}
+				Expect(k8sClient.List(ctx, secrets)).To(Succeed())
+				secretNames := extractSecretNames(secrets.Items)
+				Expect(secretNames).NotTo(ContainElement(sapBtpServiceOperatorClusterIdSecretName))
+				Expect(secretNames).NotTo(ContainElement(sapBtpServiceOperatorSecretName))
+			})
+		})
+
+		Context("when resources targeted for deletion are already absent", func() {
+			BeforeEach(func() {
+				cm := operatorConfigMap("old-cluster")
+				requiredSecret := btpManagerSecret("new-cluster", kymaNamespace, nil)
+				k8sClient = newFakeClient(cm, requiredSecret)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+
+				detector.InitializeFromSecret(requiredSecret)
+				Expect(detector.CheckClusterIdConfigMapDrift(ctx, requiredSecret)).To(Succeed())
+			})
+
+			It("should succeed without errors", func() {
+				err := detector.DeleteChangedResources(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("DeleteClusterIdSecret", func() {
+		Context("when the cluster ID secret exists", func() {
+			BeforeEach(func() {
+				cidSecret := clusterIdSecret(kymaNamespace, "cluster-1")
+				k8sClient = newFakeClient(cidSecret)
+				detector = drift.NewDetector(k8sClient, k8sClient)
+
+				managerSecret := btpManagerSecret("cluster-1", kymaNamespace, nil)
+				detector.InitializeFromSecret(managerSecret)
+			})
+
+			It("should delete it", func() {
+				err := detector.DeleteClusterIdSecret(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+
+				secrets := &corev1.SecretList{}
+				Expect(k8sClient.List(ctx, secrets)).To(Succeed())
+				Expect(secrets.Items).To(BeEmpty())
+			})
+		})
+
+		Context("when the cluster ID secret does not exist", func() {
+			BeforeEach(func() {
+				k8sClient = newFakeClient()
+				detector = drift.NewDetector(k8sClient, k8sClient)
+
+				managerSecret := btpManagerSecret("cluster-1", kymaNamespace, nil)
+				detector.InitializeFromSecret(managerSecret)
+			})
+
+			It("should succeed without errors", func() {
+				err := detector.DeleteClusterIdSecret(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+})
+
+func extractSecretNames(secrets []corev1.Secret) []string {
+	names := make([]string, 0, len(secrets))
+	for _, s := range secrets {
+		names = append(names, s.Name)
+	}
+	return names
+}

--- a/internal/credentials/drift/detector_test.go
+++ b/internal/credentials/drift/detector_test.go
@@ -118,6 +118,22 @@ var _ = Describe("Drift Detector", func() {
 			Expect(secret.Namespace).To(Equal("other-ns"))
 		})
 
+		It("should deterministically pick the lowest namespace when multiple secrets match and none is the previous namespace", func() {
+			secretInB := operatorSecret("ns-b")
+			secretInA := operatorSecret("ns-a")
+			secretInC := operatorSecret("ns-c")
+			k8sClient = newFakeClient(secretInB, secretInA, secretInC)
+			detector = drift.NewDetector(k8sClient, k8sClient)
+
+			detector.InitializeFromSecret(nil)
+
+			secret, err := detector.GetDefaultCredentialsSecret(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(secret).NotTo(BeNil())
+			Expect(secret.Namespace).To(Equal("ns-a"))
+		})
+
 		It("should ignore secrets with a different name", func() {
 			unrelatedSecret := &corev1.Secret{}
 			unrelatedSecret.Name = "some-other-secret"
@@ -344,7 +360,7 @@ var _ = Describe("Drift Detector", func() {
 		})
 	})
 
-	Describe("CheckClusterIdSecretDrift", func() {
+	Describe("ResolveClusterIdSecretDrift", func() {
 		var requiredSecret *corev1.Secret
 
 		BeforeEach(func() {
@@ -359,7 +375,7 @@ var _ = Describe("Drift Detector", func() {
 			})
 
 			It("should return nil (no drift)", func() {
-				result := detector.CheckClusterIdSecretDrift(ctx, requiredSecret)
+				result := detector.ResolveClusterIdSecretDrift(ctx, requiredSecret)
 
 				Expect(result).To(BeNil())
 			})
@@ -375,13 +391,13 @@ var _ = Describe("Drift Detector", func() {
 			})
 
 			It("should return nil (no drift)", func() {
-				result := detector.CheckClusterIdSecretDrift(ctx, requiredSecret)
+				result := detector.ResolveClusterIdSecretDrift(ctx, requiredSecret)
 
 				Expect(result).To(BeNil())
 			})
 
 			It("should track the cluster ID secret's value", func() {
-				Expect(detector.CheckClusterIdSecretDrift(ctx, requiredSecret)).To(Succeed())
+				Expect(detector.ResolveClusterIdSecretDrift(ctx, requiredSecret)).To(Succeed())
 
 				Expect(detector.ClusterIdFromOperatorClusterIdSecret()).To(Equal("cluster-1"))
 			})
@@ -400,7 +416,7 @@ var _ = Describe("Drift Detector", func() {
 			})
 
 			It("should annotate the required secret with the stale cluster ID", func() {
-				Expect(detector.CheckClusterIdSecretDrift(ctx, requiredSecret)).To(Succeed())
+				Expect(detector.ResolveClusterIdSecretDrift(ctx, requiredSecret)).To(Succeed())
 
 				Expect(requiredSecret.Annotations).To(HaveKeyWithValue(
 					previousClusterIdAnnotationKey, "stale-cluster-id",
@@ -408,7 +424,7 @@ var _ = Describe("Drift Detector", func() {
 			})
 
 			It("should delete the stale cluster ID secret", func() {
-				result := detector.CheckClusterIdSecretDrift(ctx, requiredSecret)
+				result := detector.ResolveClusterIdSecretDrift(ctx, requiredSecret)
 
 				Expect(result).To(BeNil())
 
@@ -418,7 +434,7 @@ var _ = Describe("Drift Detector", func() {
 			})
 
 			It("should restart the not-ready operator pod", func() {
-				result := detector.CheckClusterIdSecretDrift(ctx, requiredSecret)
+				result := detector.ResolveClusterIdSecretDrift(ctx, requiredSecret)
 
 				Expect(result).To(BeNil())
 
@@ -439,7 +455,7 @@ var _ = Describe("Drift Detector", func() {
 			})
 
 			It("should not delete the ready pod", func() {
-				Expect(detector.CheckClusterIdSecretDrift(ctx, requiredSecret)).To(Succeed())
+				Expect(detector.ResolveClusterIdSecretDrift(ctx, requiredSecret)).To(Succeed())
 
 				pods := &corev1.PodList{}
 				Expect(k8sClient.List(ctx, pods, client.MatchingLabels{instanceLabelKey: operandName})).To(Succeed())
@@ -458,7 +474,7 @@ var _ = Describe("Drift Detector", func() {
 			})
 
 			It("should not restart a pod outside ChartNamespace", func() {
-				Expect(detector.CheckClusterIdSecretDrift(ctx, requiredSecret)).To(Succeed())
+				Expect(detector.ResolveClusterIdSecretDrift(ctx, requiredSecret)).To(Succeed())
 
 				pods := &corev1.PodList{}
 				Expect(k8sClient.List(ctx, pods, client.MatchingLabels{instanceLabelKey: operandName})).To(Succeed())
@@ -472,7 +488,7 @@ var _ = Describe("Drift Detector", func() {
 				detector = drift.NewDetector(k8sClient, badApiClient)
 				detector.InitializeFromSecret(requiredSecret)
 
-				result := detector.CheckClusterIdSecretDrift(ctx, requiredSecret)
+				result := detector.ResolveClusterIdSecretDrift(ctx, requiredSecret)
 
 				Expect(result).NotTo(BeNil())
 				Expect(result.Reason).To(Equal(conditions.GettingSapBtpServiceOperatorClusterIdSecretFailed))
@@ -487,7 +503,7 @@ var _ = Describe("Drift Detector", func() {
 				detector.InitializeFromSecret(requiredSecret)
 				detector.SetClusterIdFromOperatorConfigMap("cluster-1")
 
-				result := detector.CheckClusterIdSecretDrift(ctx, requiredSecret)
+				result := detector.ResolveClusterIdSecretDrift(ctx, requiredSecret)
 
 				Expect(result).NotTo(BeNil())
 				Expect(result.Reason).To(Equal(conditions.AnnotatingSecretFailed))
@@ -502,7 +518,7 @@ var _ = Describe("Drift Detector", func() {
 				detector.InitializeFromSecret(requiredSecret)
 				detector.SetClusterIdFromOperatorConfigMap("cluster-1")
 
-				result := detector.CheckClusterIdSecretDrift(ctx, requiredSecret)
+				result := detector.ResolveClusterIdSecretDrift(ctx, requiredSecret)
 
 				Expect(result).NotTo(BeNil())
 				Expect(result.Reason).To(Equal(conditions.DeletionOfOrphanedResourcesFailed))
@@ -518,7 +534,7 @@ var _ = Describe("Drift Detector", func() {
 				detector.InitializeFromSecret(requiredSecret)
 				detector.SetClusterIdFromOperatorConfigMap("cluster-1")
 
-				result := detector.CheckClusterIdSecretDrift(ctx, requiredSecret)
+				result := detector.ResolveClusterIdSecretDrift(ctx, requiredSecret)
 
 				Expect(result).NotTo(BeNil())
 				Expect(result.Reason).To(Equal(conditions.ResourceRemovalFailed))
@@ -544,7 +560,7 @@ var _ = Describe("Drift Detector", func() {
 				detector.InitializeFromSecret(requiredSecret)
 				Expect(detector.CheckCredentialsNamespaceDrift(ctx, requiredSecret)).To(Succeed())
 				Expect(detector.CheckClusterIdConfigMapDrift(ctx, requiredSecret)).To(Succeed())
-				Expect(detector.CheckClusterIdSecretDrift(ctx, requiredSecret)).To(Succeed())
+				Expect(detector.ResolveClusterIdSecretDrift(ctx, requiredSecret)).To(Succeed())
 			})
 
 			It("should not delete any resources", func() {
@@ -579,7 +595,7 @@ var _ = Describe("Drift Detector", func() {
 				detector.InitializeFromSecret(requiredSecret)
 				Expect(detector.CheckCredentialsNamespaceDrift(ctx, requiredSecret)).To(Succeed())
 				Expect(detector.CheckClusterIdConfigMapDrift(ctx, requiredSecret)).To(Succeed())
-				Expect(detector.CheckClusterIdSecretDrift(ctx, requiredSecret)).To(Succeed())
+				Expect(detector.ResolveClusterIdSecretDrift(ctx, requiredSecret)).To(Succeed())
 			})
 
 			It("should delete the cluster ID secret and the operator pod", func() {

--- a/internal/credentials/drift/suite_test.go
+++ b/internal/credentials/drift/suite_test.go
@@ -1,0 +1,176 @@
+package drift_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	kymaNamespace = "kyma-system"
+
+	sapBtpManagerSecretName                  = "sap-btp-manager"
+	sapBtpServiceOperatorSecretName          = "sap-btp-service-operator"
+	sapBtpServiceOperatorClusterIdSecretName = "sap-btp-operator-clusterid"
+	sapBtpServiceOperatorConfigMapName       = "sap-btp-operator-config"
+	operandName                              = "sap-btp-operator"
+
+	managedByLabelKey = "app.kubernetes.io/managed-by"
+	instanceLabelKey  = "app.kubernetes.io/instance"
+	operatorName      = "btp-manager"
+
+	clusterIdSecretKey            = "cluster_id"
+	credentialsNamespaceSecretKey = "credentials_namespace"
+	initialClusterIdSecretKey     = "INITIAL_CLUSTER_ID"
+	clusterIdConfigMapKey         = "CLUSTER_ID"
+
+	previousClusterIdAnnotationKey            = "operator.kyma-project.io/previous-cluster-id"
+	previousCredentialsNamespaceAnnotationKey = "operator.kyma-project.io/previous-credentials-namespace"
+)
+
+var scheme *runtime.Scheme
+
+func TestDriftDetector(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Drift Detector Suite")
+}
+
+var _ = BeforeSuite(func() {
+	scheme = runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+})
+
+func newFakeClient(objects ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objects...).
+		Build()
+}
+
+func btpManagerSecret(clusterID, credentialsNamespace string, annotations map[string]string) *corev1.Secret {
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        sapBtpManagerSecretName,
+			Namespace:   kymaNamespace,
+			Annotations: annotations,
+		},
+		Data: map[string][]byte{
+			clusterIdSecretKey: []byte(clusterID),
+		},
+	}
+	if credentialsNamespace != "" {
+		s.Data[credentialsNamespaceSecretKey] = []byte(credentialsNamespace)
+	}
+	return s
+}
+
+func operatorSecret(namespace string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sapBtpServiceOperatorSecretName,
+			Namespace: namespace,
+			Labels:    map[string]string{managedByLabelKey: operatorName},
+		},
+	}
+}
+
+func clusterIdSecret(namespace, initialClusterID string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sapBtpServiceOperatorClusterIdSecretName,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			initialClusterIdSecretKey: []byte(initialClusterID),
+		},
+	}
+}
+
+func operatorConfigMap(clusterID string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sapBtpServiceOperatorConfigMapName,
+			Namespace: kymaNamespace,
+		},
+		Data: map[string]string{
+			clusterIdConfigMapKey: clusterID,
+		},
+	}
+}
+
+func operatorPod(name, namespace string, ready corev1.ConditionStatus) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    map[string]string{instanceLabelKey: operandName},
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{Type: corev1.PodReady, Status: ready},
+			},
+		},
+	}
+}
+
+// errorOnGetClient wraps a real client and forces Get calls to fail.
+type errorOnGetClient struct {
+	client.Client
+}
+
+func newErrorOnGetClient(inner client.Client) client.Client {
+	return &errorOnGetClient{Client: inner}
+}
+
+func (c *errorOnGetClient) Get(_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+	return fmt.Errorf("simulated Get error")
+}
+
+// errorOnListClient wraps a real client and forces List calls to fail.
+type errorOnListClient struct {
+	client.Client
+}
+
+func newErrorOnListClient(inner client.Client) client.Client {
+	return &errorOnListClient{Client: inner}
+}
+
+func (c *errorOnListClient) List(_ context.Context, _ client.ObjectList, _ ...client.ListOption) error {
+	return fmt.Errorf("simulated List error")
+}
+
+// errorOnUpdateClient wraps a real client and forces Update calls to fail.
+type errorOnUpdateClient struct {
+	client.Client
+}
+
+func newErrorOnUpdateClient(inner client.Client) client.Client {
+	return &errorOnUpdateClient{Client: inner}
+}
+
+func (c *errorOnUpdateClient) Update(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+	return fmt.Errorf("simulated Update error")
+}
+
+// errorOnDeleteClient wraps a real client and forces Delete calls to fail.
+type errorOnDeleteClient struct {
+	client.Client
+}
+
+func newErrorOnDeleteClient(inner client.Client) client.Client {
+	return &errorOnDeleteClient{Client: inner}
+}
+
+func (c *errorOnDeleteClient) Delete(_ context.Context, _ client.Object, _ ...client.DeleteOption) error {
+	return fmt.Errorf("simulated Delete error")
+}

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ import (
 	"github.com/kyma-project/btp-manager/api/v1alpha1"
 	"github.com/kyma-project/btp-manager/controllers"
 	"github.com/kyma-project/btp-manager/controllers/config"
+	"github.com/kyma-project/btp-manager/internal/credentials/drift"
 	"github.com/kyma-project/btp-manager/internal/k8s/networkpolicy"
 	"github.com/kyma-project/btp-manager/internal/manifest"
 	btpmanagermetrics "github.com/kyma-project/btp-manager/internal/metrics"
@@ -131,6 +132,7 @@ func main() {
 	configHandler := config.NewHandler(mgr.GetClient(), scheme, configMetrics)
 	manifestHandler := &manifest.Handler{Scheme: scheme}
 	networkPolicyManager := networkpolicy.NewManager(mgr.GetClient(), manifestHandler)
+	driftDetector := drift.NewDetector(mgr.GetClient(), apiServerClient)
 	reconciler := controllers.NewBtpOperatorReconciler(
 		mgr.GetClient(),
 		apiServerClient,
@@ -141,6 +143,7 @@ func main() {
 			configHandler,
 		},
 		networkPolicyManager,
+		driftDetector,
 	)
 
 	if err = reconciler.SetupWithManager(mgr); err != nil {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `internal/credentials/drift` package with `Detector` interface and `DriftDetector` implementation for credentials-namespace and cluster-ID drift detection
- Delegate credential drift operations from the controller to `DriftDetector` (`InitializeFromSecret`, `CheckCredentialsNamespaceDrift`, `CheckClusterIdConfigMapDrift`, `CheckClusterIdSecretDrift`, `DeleteChangedResources`, `DeleteClusterIdSecret`, and the credential/cluster-ID getters)
- Wire `DriftDetector` into `NewBtpOperatorReconciler`, `main.go`, and test suite setup
- Remove 6 credential-tracking fields from the reconciler struct and delete 9 now-unused controller methods (`setCredentialsNamespacesAndClusterId`, `checkDefaultCredentialsSecretNamespace`, `checkSapBtpServiceOperatorClusterIdConfigMap`, `checkSapBtpServiceOperatorClusterIdSecret`, `deleteResourcesIfBtpManagerSecretChanged`, `getDefaultCredentialsSecret`, `getSapBtpServiceOperatorConfigMap`, `restartSapBtpServiceOperatorPodIfNotReady`, `annotateSecret`)

**Related issue(s)**
See also #1313

---

> **Note:** This is PR 3/5 in a split of [#1526](https://github.com/kyma-project/btp-manager/pull/1526). Each PR leaves the codebase fully functional with all tests passing.
>
> Merge order: [#1561](https://github.com/kyma-project/btp-manager/pull/1561) (merged) → [#1562](https://github.com/kyma-project/btp-manager/pull/1562) (merged) → **this PR** → PR 4 (ModuleResourceManager) → PR 5 (ObjectManager + SecretManager + WebhookCertificateManager)