### PR TITLE
Add Not Found Status Badge for Missing Custom Secrets

### DIFF
--- a/busola-tests/ext-test-btp-operator.spec.js
+++ b/busola-tests/ext-test-btp-operator.spec.js
@@ -134,18 +134,18 @@ data:
       cy.contains('Managed').should('be.visible');
       cy.contains('Credentials Namespace').should('be.visible');
       cy.contains('kyma-system').should('be.visible');
-
-      // SAP BTP Service Operator Secret sub-panel
-      cy.contains('SAP BTP Service Operator Secret').should('be.visible');
-      cy.contains('Inherited').should('be.visible');
     });
+
+    // SAP BTP Service Operator Secret sub-panel
+    cy.contains('SAP BTP Service Operator Secret').should('exist');
+    cy.contains('Inherited').should('exist');
 
     // --- Test Edit ResourceLink → navigates to sap-btp-manager secret ---
     cy.getMidColumn().within(() => {
       cy.contains('ui5-link', 'Edit').click();
     });
     cy.wait(500);
-    cy.contains('sap-btp-manager').should('be.visible');
+    cy.contains('sap-btp-manager').should('exist');
     cy.go('back');
     cy.wait(500);
 
@@ -172,7 +172,7 @@ data:
         .click();
     });
     cy.wait(500);
-    cy.contains('servicebindings.services.cloud.sap.com').should('be.visible');
+    cy.contains('servicebindings.services.cloud.sap.com').should('exist');
     cy.contains('Resource Details').should('be.visible');
     cy.go('back');
     cy.wait(500);
@@ -263,14 +263,13 @@ data:
       cy.contains('test').should('be.visible');
 
       // BTP Manager Secret shows Unmanaged badge
-      cy.contains('Unmanaged').should('be.visible');
-
-      // Namespace-Based Secrets shows test secret as "In Use"
-      cy.contains('Namespace-Based Secrets').scrollIntoView();
-      cy.wait(500);
-      cy.contains('test-sap-btp-service-operator').scrollIntoView();
-      cy.contains('In Use').should('exist');
+      cy.contains('Unmanaged').should('exist');
     });
+
+    // Namespace-Based Secrets shows test secret as "In Use"
+    cy.getMidColumn().contains('Namespace-Based Secrets').scrollIntoView();
+    cy.getMidColumn().contains('test-sap-btp-service-operator').scrollIntoView();
+    cy.getMidColumn().contains('In use').should('exist');
 
     // 5. Create Service Instance and Service Binding
     cy.getLeftNav().contains('Cluster Overview').click();
@@ -371,8 +370,11 @@ spec:
       cy.contains('test-custom-secret').scrollIntoView();
       cy.contains('test-custom-secret').should('exist');
 
-      // Not in Use: kyma-system ≠ managedNamespace "test" (set in previous test)
-      cy.contains('Not in Use').should('exist');
+      // Secret does not exist in the cluster → Not Found
+      cy.contains('test-custom-secret')
+        .closest('ui5-table-row')
+        .contains('Not found')
+        .should('exist');
 
       // Service Instances count shows "1" in the same row
       cy.contains('test-custom-secret')

--- a/config/busola-extension/sap-btp-operator-extension.yaml
+++ b/config/busola-extension/sap-btp-operator-extension.yaml
@@ -329,9 +329,13 @@ data:
               (
                 $instances := $referencedSecrets().items;
                 $uniqueSecrets := $distinct($instances.spec.btpAccessCredentialsSecret);
+                $allSecretsItems := $allSecrets().items;
+                $managedNamespace := ($exists($btpSecret().data.credentials_namespace) ? $base64decode($btpSecret().data.credentials_namespace) : 'kyma-system');
                 $map($uniqueSecrets, function($secretName) {
                   {
                     "secretName": $secretName,
+                    "secretExists": $exists($filter($allSecretsItems, function($s) { $s.metadata.name = $secretName })[0]),
+                    "managedNamespace": $managedNamespace,
                     "instanceCount": $count($filter($instances, function($i) { $i.spec.btpAccessCredentialsSecret = $secretName })),
                     "instances": $filter($instances, function($i) { $i.spec.btpAccessCredentialsSecret = $secretName }).{
                       "name": metadata.name,
@@ -355,10 +359,8 @@ data:
                 name: Service Instances
               - source: >-
                   (
-                    $secretExists := $exists($allSecrets().items[metadata.name = $item.secretName][0]);
-                    $managedNamespace := ($exists($btpSecret().data.credentials_namespace) ? $base64decode($btpSecret().data.credentials_namespace) : 'kyma-system');
-                    $secretExists
-                      ? ($item.instances[0].namespace = $managedNamespace ? 'In Use' : 'Not in Use')
+                    $item.secretExists
+                      ? ($item.instances[0].namespace = $item.managedNamespace ? 'In Use' : 'Not in Use')
                       : 'Not Found';
                   )
                 name: Status
@@ -372,12 +374,10 @@ data:
                     - Not Found
                 description: >-
                   (
-                    $secretExists := $exists($allSecrets().items[metadata.name = $item.secretName][0]);
-                    $managedNamespace := ($exists($btpSecret().data.credentials_namespace) ? $base64decode($btpSecret().data.credentials_namespace) : 'kyma-system');
-                    $secretExists
-                      ? ($item.instances[0].namespace = $managedNamespace
+                    $item.secretExists
+                      ? ($item.instances[0].namespace = $item.managedNamespace
                           ? 'Ok'
-                          : 'This secret is not in the credentials namespace "' & $managedNamespace & '". Service instances referencing it will fail to provision. To resolve this, either move the secret to the credentials namespace or update the credentials namespace in the BTP Manager secret.')
+                          : 'This secret is not in the credentials namespace "' & $item.managedNamespace & '". Service instances referencing it will fail to provision. To resolve this, either move the secret to the credentials namespace or update the credentials namespace in the BTP Manager secret.')
                       : 'Secret "' & $item.secretName & '" does not exist. Create it or correct the btpAccessCredentialsSecret field on the referencing Service Instance.';
                   )
               - source: >-

--- a/config/busola-extension/sap-btp-operator-extension.yaml
+++ b/config/busola-extension/sap-btp-operator-extension.yaml
@@ -355,8 +355,11 @@ data:
                 name: Service Instances
               - source: >-
                   (
+                    $secretExists := $exists($allSecrets().items[metadata.name = $item.secretName][0]);
                     $managedNamespace := ($exists($btpSecret().data.credentials_namespace) ? $base64decode($btpSecret().data.credentials_namespace) : 'kyma-system');
-                    $item.instances[0].namespace = $managedNamespace ? 'In Use' : 'Not in Use';
+                    $secretExists
+                      ? ($item.instances[0].namespace = $managedNamespace ? 'In Use' : 'Not in Use')
+                      : 'Not Found';
                   )
                 name: Status
                 widget: Badge
@@ -365,12 +368,17 @@ data:
                     - In Use
                   warning:
                     - Not in Use
+                  critical:
+                    - Not Found
                 description: >-
                   (
+                    $secretExists := $exists($allSecrets().items[metadata.name = $item.secretName][0]);
                     $managedNamespace := ($exists($btpSecret().data.credentials_namespace) ? $base64decode($btpSecret().data.credentials_namespace) : 'kyma-system');
-                    $item.instances[0].namespace = $managedNamespace
-                    ? 'Ok'
-                    : 'This secret is not in the credentials namespace "' & $managedNamespace & '". Service instances referencing it will fail to provision. To resolve this, either move the secret to the credentials namespace or update the credentials namespace in the BTP Manager secret.'
+                    $secretExists
+                      ? ($item.instances[0].namespace = $managedNamespace
+                          ? 'Ok'
+                          : 'This secret is not in the credentials namespace "' & $managedNamespace & '". Service instances referencing it will fail to provision. To resolve this, either move the secret to the credentials namespace or update the credentials namespace in the BTP Manager secret.')
+                      : 'Secret "' & $item.secretName & '" does not exist. Create it or correct the btpAccessCredentialsSecret field on the referencing Service Instance.';
                   )
               - source: >-
                   (


### PR DESCRIPTION
Description

Changes proposed in this pull request:

Add Not Found status badge (red/negative) to the Custom Secrets table in the Busola extension — shown when a secret referenced by spec.btpAccessCredentialsSecret does not exist in the cluster
Extend the Status badge tooltip with an actionable message for the missing secret case: "Secret '...' does not exist. Create it or correct the btpAccessCredentialsSecret field on the referencing Service Instance."
Update the Busola extension E2E test to cover the Not Found case and fix test reliability issues (badge text casing, scroll behavior, single save on secret edit)

Related issue(s):
https://github.com/orgs/kyma-project/projects/38/views/1?pane=issue&itemId=184372588&issue=kyma-project%7Cbtp-manager%7C1469
