### PR TITLE
Add ModuleResourceManager and Wire Into Controller

### DIFF
--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -19,11 +19,8 @@ package controllers
 import (
 	"context"
 	"crypto/x509"
-	"encoding/base64"
 	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"time"
@@ -35,9 +32,8 @@ import (
 	"github.com/kyma-project/btp-manager/internal/conditions"
 	"github.com/kyma-project/btp-manager/internal/credentials/drift"
 	"github.com/kyma-project/btp-manager/internal/k8s/networkpolicy"
-	"github.com/kyma-project/btp-manager/internal/manifest"
+	"github.com/kyma-project/btp-manager/internal/manager/moduleresource"
 	"github.com/kyma-project/btp-manager/internal/metrics"
-	"github.com/kyma-project/btp-manager/internal/ymlutils"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -156,33 +152,26 @@ type BtpOperatorReconciler struct {
 	*rest.Config
 	apiServerClient        client.Client
 	Scheme                 *runtime.Scheme
-	manifestHandler        *manifest.Handler
 	webhookMetrics         *metrics.WebhookMetrics
 	instanceBindingService InstanceBindingSerivce
 	workqueueSize          int
 	networkPolicyManager   networkpolicy.NetworkPolicyManager
 	driftDetector          drift.Detector
+	moduleResourceManager  moduleresource.ResourceManager
 	watchHandlers          []config.WatchHandler
 }
 
-type ResourceReadiness struct {
-	Name      string
-	Namespace string
-	Kind      string
-	Ready     bool
-}
-
-func NewBtpOperatorReconciler(client client.Client, apiServerClient client.Client, scheme *runtime.Scheme, instanceBindingSerivice InstanceBindingSerivce, metrics *metrics.WebhookMetrics, watchHandlers []config.WatchHandler, networkPolicyManager networkpolicy.NetworkPolicyManager, driftDetector drift.Detector) *BtpOperatorReconciler {
+func NewBtpOperatorReconciler(client client.Client, apiServerClient client.Client, scheme *runtime.Scheme, instanceBindingSerivice InstanceBindingSerivce, metrics *metrics.WebhookMetrics, watchHandlers []config.WatchHandler, networkPolicyManager networkpolicy.NetworkPolicyManager, driftDetector drift.Detector, moduleResourceManager moduleresource.ResourceManager) *BtpOperatorReconciler {
 	return &BtpOperatorReconciler{
 		Client:                 client,
 		apiServerClient:        apiServerClient,
 		Scheme:                 scheme,
-		manifestHandler:        &manifest.Handler{Scheme: scheme},
 		instanceBindingService: instanceBindingSerivice,
 		webhookMetrics:         metrics,
 		watchHandlers:          watchHandlers,
 		networkPolicyManager:   networkPolicyManager,
 		driftDetector:          driftDetector,
+		moduleResourceManager:  moduleResourceManager,
 	}
 }
 
@@ -342,7 +331,7 @@ func (r *BtpOperatorReconciler) HandleProcessingState(ctx context.Context, cr *v
 		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.Reason, errWithReason.Message)
 	}
 
-	if err := r.deleteOutdatedResources(ctx); err != nil {
+	if err := r.moduleResourceManager.DeleteOutdatedResources(ctx); err != nil {
 		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, conditions.ProvisioningFailed, err.Error())
 	}
 
@@ -426,41 +415,12 @@ func (r *BtpOperatorReconciler) verifySecret(secret *corev1.Secret) error {
 	return nil
 }
 
-func (r *BtpOperatorReconciler) deleteOutdatedResources(ctx context.Context) error {
-	logger := log.FromContext(ctx)
-
-	logger.Info("getting outdated module resources to delete")
-	resourcesToDelete, err := r.createUnstructuredObjectsFromManifestsDir(r.getResourcesToDeletePath())
-	if err != nil {
-		logger.Error(err, "while getting objects to delete from manifests")
-		return fmt.Errorf("Failed to create deletable objects from manifests: %w", err)
-	}
-	logger.Info(fmt.Sprintf("got %d outdated module resources to delete", len(resourcesToDelete)))
-
-	err = r.deleteResources(ctx, resourcesToDelete)
-	if err != nil {
-		logger.Error(err, "while deleting outdated resources")
-		return fmt.Errorf("Failed to delete outdated resources: %w", err)
-	}
-
-	return nil
-}
-
 func (r *BtpOperatorReconciler) createUnstructuredObjectsFromManifestsDir(manifestsDir string) ([]*unstructured.Unstructured, error) {
-	objs, err := r.manifestHandler.CollectObjectsFromDir(manifestsDir)
-	if err != nil {
-		return nil, err
-	}
-	us, err := r.manifestHandler.ObjectsToUnstructured(objs)
-	if err != nil {
-		return nil, err
-	}
-
-	return us, nil
+	return r.moduleResourceManager.CreateUnstructuredObjectsFromManifestsDir(manifestsDir)
 }
 
 func (r *BtpOperatorReconciler) getResourcesToDeletePath() string {
-	return fmt.Sprintf("%s%cdelete", config.ResourcesPath, os.PathSeparator)
+	return r.moduleResourceManager.GetResourcesToDeletePath()
 }
 
 func (r *BtpOperatorReconciler) addNetworkPoliciesToResources(ctx context.Context, resourcesToApply *[]*unstructured.Unstructured) error {
@@ -475,28 +435,6 @@ func (r *BtpOperatorReconciler) addNetworkPoliciesToResources(ctx context.Contex
 	}
 	*resourcesToApply = append(*resourcesToApply, networkPolicies...)
 	logger.Info(fmt.Sprintf("added %d network policies to resources to apply", len(networkPolicies)))
-
-	return nil
-}
-
-func (r *BtpOperatorReconciler) deleteResources(ctx context.Context, us []*unstructured.Unstructured) error {
-	logger := log.FromContext(ctx)
-
-	var errs []string
-	for _, u := range us {
-		if err := r.Delete(ctx, u); err != nil {
-			if k8serrors.IsNotFound(err) {
-				continue
-			} else {
-				errs = append(errs, fmt.Sprintf("failed to delete %s %s: %s", u.GetName(), u.GetKind(), err))
-			}
-		}
-		logger.Info("deleted resource", "name", u.GetName(), "kind", u.GetKind())
-	}
-
-	if errs != nil {
-		return errors.New(strings.Join(errs, ", "))
-	}
 
 	return nil
 }
@@ -529,7 +467,7 @@ func (r *BtpOperatorReconciler) reconcileResources(ctx context.Context, cr *v1al
 		return fmt.Errorf("failed to delete old webhook network policy: %w", err)
 	}
 
-	if err = r.prepareModuleResourcesFromManifests(ctx, resourcesToApply, s); err != nil {
+	if err = r.moduleResourceManager.PrepareModuleResources(ctx, resourcesToApply, s); err != nil {
 		logger.Error(err, "while preparing objects to apply")
 		return fmt.Errorf("failed to prepare objects to apply: %w", err)
 	}
@@ -539,16 +477,16 @@ func (r *BtpOperatorReconciler) reconcileResources(ctx context.Context, cr *v1al
 		return fmt.Errorf("failed to prepare admission webhooks: %w", err)
 	}
 
-	r.deleteCreationTimestamp(resourcesToApply...)
+	r.moduleResourceManager.DeleteCreationTimestamp(resourcesToApply...)
 
 	logger.Info(fmt.Sprintf("applying module resources for %d resources", len(resourcesToApply)))
-	if err = r.createOrUpdateResources(ctx, resourcesToApply); err != nil {
+	if err = r.moduleResourceManager.ApplyOrUpdateResources(ctx, resourcesToApply); err != nil {
 		logger.Error(err, "while applying module resources")
 		return fmt.Errorf("failed to apply module resources: %w", err)
 	}
 
 	logger.Info("waiting for module resources readiness")
-	if err = r.waitForResourcesReadiness(ctx, resourcesToApply); err != nil {
+	if err = r.moduleResourceManager.WaitForResourcesReadiness(ctx, resourcesToApply); err != nil {
 		logger.Error(err, "while waiting for module resources readiness")
 		return fmt.Errorf("timed out while waiting for resources readiness: %w", err)
 	}
@@ -557,61 +495,7 @@ func (r *BtpOperatorReconciler) reconcileResources(ctx context.Context, cr *v1al
 }
 
 func (r *BtpOperatorReconciler) getResourcesToApplyPath() string {
-	return fmt.Sprintf("%s%capply", config.ResourcesPath, os.PathSeparator)
-}
-
-func (r *BtpOperatorReconciler) prepareModuleResourcesFromManifests(ctx context.Context, resourcesToApply []*unstructured.Unstructured, s *corev1.Secret) error {
-	logger := log.FromContext(ctx)
-	logger.Info("preparing module resources to apply")
-
-	var configMap, secret, deployment *unstructured.Unstructured
-	for _, u := range resourcesToApply {
-		switch {
-		case u.GetKind() == configMapKind && u.GetName() == sapBtpServiceOperatorConfigMapName:
-			configMap = u
-		case u.GetKind() == secretKind && u.GetName() == sapBtpServiceOperatorSecretName:
-			secret = u
-		case u.GetKind() == deploymentKind && u.GetName() == config.DeploymentName:
-			deployment = u
-		}
-	}
-
-	if configMap == nil {
-		return fmt.Errorf("configmap %q not found in resources to apply", sapBtpServiceOperatorConfigMapName)
-	}
-	if secret == nil {
-		return fmt.Errorf("secret %q not found in resources to apply", sapBtpServiceOperatorSecretName)
-	}
-	if deployment == nil {
-		return fmt.Errorf("deployment %q not found in resources to apply", config.DeploymentName)
-	}
-
-	chartVer, err := ymlutils.ExtractStringValueFromYamlForGivenKey(filepath.Join(config.ChartPath, "Chart.yaml"), "version")
-	if err != nil {
-		logger.Error(err, "while getting module chart version")
-		return fmt.Errorf("failed to get module chart version: %w", err)
-	}
-
-	if err := r.addLabels(chartVer, resourcesToApply...); err != nil {
-		logger.Error(err, "while adding labels to resources")
-		return fmt.Errorf("failed to add labels to resources: %w", err)
-	}
-	r.setNamespace(resourcesToApply...)
-
-	if err := r.setConfigMapValues(s, configMap); err != nil {
-		logger.Error(err, "while setting ConfigMap values")
-		return fmt.Errorf("failed to set ConfigMap values: %w", err)
-	}
-	if err := r.setSecretValues(s, secret); err != nil {
-		logger.Error(err, "while setting Secret values")
-		return fmt.Errorf("failed to set Secret values: %w", err)
-	}
-	if err := r.setDeploymentImages(deployment); err != nil {
-		logger.Error(err, "while setting container images in Deployment")
-		return fmt.Errorf("failed to set container images in Deployment: %w", err)
-	}
-
-	return nil
+	return r.moduleResourceManager.GetResourcesToApplyPath()
 }
 
 func (r *BtpOperatorReconciler) cleanupNetworkPolicies(ctx context.Context) error {
@@ -626,216 +510,6 @@ func (r *BtpOperatorReconciler) deleteOldWebhookNetworkPolicy(ctx context.Contex
 		return nil
 	}
 	return r.networkPolicyManager.DeleteOldWebhookNetworkPolicy(ctx)
-}
-
-func (r *BtpOperatorReconciler) addLabels(chartVer string, us ...*unstructured.Unstructured) error {
-
-	for _, u := range us {
-		labels := u.GetLabels()
-		if len(labels) == 0 {
-			labels = make(map[string]string)
-		}
-		labels[managedByLabelKey] = operatorName
-		labels[chartVersionLabelKey] = chartVer
-		labels[kymaProjectModuleLabelKey] = moduleName
-		u.SetLabels(labels)
-		if u.GetKind() == deploymentKind {
-			tplLabels, found, err := unstructured.NestedStringMap(u.Object, "spec", "template", "metadata", "labels")
-			if err == nil {
-				if !found || tplLabels == nil {
-					tplLabels = make(map[string]string)
-				}
-				tplLabels[kymaProjectModuleLabelKey] = moduleName
-				if err := unstructured.SetNestedStringMap(u.Object, tplLabels, "spec", "template", "metadata", "labels"); err != nil {
-					return fmt.Errorf("failed to set pod template labels for deployment %s: %w", u.GetName(), err)
-				}
-			} else {
-				return fmt.Errorf("failed to get pod template labels for deployment %s: %w", u.GetName(), err)
-			}
-		}
-	}
-	return nil
-}
-
-func (r *BtpOperatorReconciler) setNamespace(us ...*unstructured.Unstructured) {
-	for _, u := range us {
-		u.SetNamespace(config.ChartNamespace)
-	}
-}
-
-func (r *BtpOperatorReconciler) deleteCreationTimestamp(us ...*unstructured.Unstructured) {
-	for _, u := range us {
-		unstructured.RemoveNestedField(u.Object, "metadata", "creationTimestamp")
-	}
-}
-
-func (r *BtpOperatorReconciler) setConfigMapValues(secret *corev1.Secret, u *unstructured.Unstructured) error {
-	entries := []struct {
-		key string
-		val any
-	}{
-		{ClusterIdConfigMapKey, string(secret.Data[ClusterIdSecretKey])},
-		{ReleaseNamespaceConfigMapKey, r.driftDetector.CredentialsNamespaceFromManager()},
-		{ManagementNamespaceConfigMapKey, r.driftDetector.CredentialsNamespaceFromManager()},
-		{EnableLimitedCacheConfigMapKey, config.EnableLimitedCache},
-	}
-	for _, e := range entries {
-		if err := unstructured.SetNestedField(u.Object, e.val, "data", e.key); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (r *BtpOperatorReconciler) setSecretValues(secret *corev1.Secret, u *unstructured.Unstructured) error {
-	u.SetNamespace(r.driftDetector.CredentialsNamespaceFromManager())
-	for k := range secret.Data {
-		if k == ClusterIdSecretKey || k == CredentialsNamespaceSecretKey {
-			continue
-		}
-		if err := unstructured.SetNestedField(u.Object, base64.StdEncoding.EncodeToString(secret.Data[k]), "data", k); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (r *BtpOperatorReconciler) setDeploymentImages(u *unstructured.Unstructured) error {
-	sapBtpServiceOperatorImage := os.Getenv(SapBtpServiceOperatorEnv)
-	if err := r.setContainerImage(u, sapBtpServiceOperatorContainerName, sapBtpServiceOperatorImage); err != nil {
-		return fmt.Errorf("failed to set container image for %s: %w", SapBtpServiceOperatorName, err)
-	}
-
-	return nil
-}
-
-func (r *BtpOperatorReconciler) setContainerImage(u *unstructured.Unstructured, containerName, image string) error {
-	containers, found, err := unstructured.NestedSlice(u.Object, "spec", "template", "spec", "containers")
-	if err != nil {
-		return fmt.Errorf("failed to get containers from %s %s: %w", u.GetKind(), u.GetName(), err)
-	}
-	if !found {
-		return fmt.Errorf("containers not found in %s %s", u.GetKind(), u.GetName())
-	}
-	for i, c := range containers {
-		container, ok := c.(map[string]interface{})
-		if !ok {
-			return fmt.Errorf("cannot cast container field to map[string]interface{}: %v", c)
-		}
-		if container["name"] == containerName {
-			container["image"] = image
-			containers[i] = container
-			break
-		}
-	}
-
-	return unstructured.SetNestedSlice(u.Object, containers, "spec", "template", "spec", "containers")
-}
-
-func (r *BtpOperatorReconciler) createOrUpdateResources(ctx context.Context, us []*unstructured.Unstructured) error {
-	logger := log.FromContext(ctx)
-	for _, u := range us {
-		preExistingResource := &unstructured.Unstructured{}
-		preExistingResource.SetGroupVersionKind(u.GroupVersionKind())
-		if err := r.Get(ctx, client.ObjectKey{Name: u.GetName(), Namespace: u.GetNamespace()}, preExistingResource); err != nil {
-			if !k8serrors.IsNotFound(err) {
-				return fmt.Errorf("while trying to get %s %s: %w", u.GetName(), u.GetKind(), err)
-			}
-			logger.Info(fmt.Sprintf("creating %s - %s", u.GetKind(), u.GetName()))
-			if err := r.Create(ctx, u, client.FieldOwner(operatorName)); err != nil {
-				return fmt.Errorf("while creating %s %s: %w", u.GetName(), u.GetKind(), err)
-			}
-		} else {
-			logger.Info(fmt.Sprintf("updating %s - %s", u.GetKind(), u.GetName()))
-			u.SetResourceVersion(preExistingResource.GetResourceVersion())
-			if err := r.Update(ctx, u, client.FieldOwner(operatorName)); err != nil {
-				return fmt.Errorf("while updating %s %s: %w", u.GetName(), u.GetKind(), err)
-			}
-		}
-	}
-	return nil
-}
-
-func (r *BtpOperatorReconciler) waitForResourcesReadiness(ctx context.Context, us []*unstructured.Unstructured) error {
-	numOfResources := len(us)
-	resourcesReadinessInformer := make(chan ResourceReadiness, numOfResources)
-	for _, u := range us {
-		if u.GetKind() == deploymentKind {
-			go r.checkDeploymentReadiness(ctx, u, resourcesReadinessInformer)
-			continue
-		}
-		go r.checkResourceExistence(ctx, u, resourcesReadinessInformer)
-	}
-
-	for i := 0; i < numOfResources; i++ {
-		if resourceReady := <-resourcesReadinessInformer; !resourceReady.Ready {
-			return fmt.Errorf("%s %s in namespace %s readiness timeout reached", resourceReady.Kind, resourceReady.Name, resourceReady.Namespace)
-		}
-	}
-	return nil
-}
-
-func (r *BtpOperatorReconciler) checkDeploymentReadiness(ctx context.Context, u *unstructured.Unstructured, c chan<- ResourceReadiness) {
-	logger := log.FromContext(ctx)
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, config.ReadyCheckInterval)
-	defer cancel()
-
-	var err error
-	var availableConditionStatus, progressingConditionStatus string
-	got := &appsv1.Deployment{}
-	now := time.Now()
-	for {
-		if time.Since(now) >= config.ReadyTimeout {
-			logger.Error(err, fmt.Sprintf("timed out while checking %s %s readiness", u.GetName(), u.GetKind()))
-			c <- ResourceReadiness{
-				Name:      u.GetName(),
-				Namespace: u.GetNamespace(),
-				Kind:      u.GetKind(),
-				Ready:     false,
-			}
-			return
-		}
-		if err = r.Get(ctxWithTimeout, client.ObjectKey{Name: u.GetName(), Namespace: u.GetNamespace()}, got); err == nil {
-			for _, condition := range got.Status.Conditions {
-				if string(condition.Type) == deploymentProgressingConditionType {
-					progressingConditionStatus = string(condition.Status)
-				} else if string(condition.Type) == deploymentAvailableConditionType {
-					availableConditionStatus = string(condition.Status)
-				}
-			}
-			if progressingConditionStatus == "True" && availableConditionStatus == "True" {
-				c <- ResourceReadiness{Ready: true}
-				return
-			}
-		}
-	}
-}
-
-func (r *BtpOperatorReconciler) checkResourceExistence(ctx context.Context, u *unstructured.Unstructured, c chan<- ResourceReadiness) {
-	logger := log.FromContext(ctx)
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, config.ReadyCheckInterval)
-	defer cancel()
-
-	var err error
-	now := time.Now()
-	got := &unstructured.Unstructured{}
-	got.SetGroupVersionKind(u.GroupVersionKind())
-	for {
-		if time.Since(now) >= config.ReadyTimeout {
-			logger.Error(err, fmt.Sprintf("timed out while checking %s %s existence", u.GetName(), u.GetKind()))
-			c <- ResourceReadiness{
-				Name:      u.GetName(),
-				Namespace: u.GetNamespace(),
-				Kind:      u.GetKind(),
-				Ready:     false,
-			}
-			return
-		}
-		if err = r.Get(ctxWithTimeout, client.ObjectKey{Name: u.GetName(), Namespace: u.GetNamespace()}, got); err == nil {
-			c <- ResourceReadiness{Ready: true}
-			return
-		}
-	}
 }
 
 func (r *BtpOperatorReconciler) HandleWarningState(ctx context.Context, cr *v1alpha1.BtpOperator) (ctrl.Result, error) {
@@ -1382,7 +1056,7 @@ func (r *BtpOperatorReconciler) HandleReadyState(ctx context.Context, cr *v1alph
 		}
 	}
 
-	if err := r.deleteOutdatedResources(ctx); err != nil {
+	if err := r.moduleResourceManager.DeleteOutdatedResources(ctx); err != nil {
 		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, conditions.ReconcileFailed, err.Error())
 	}
 
@@ -1942,7 +1616,7 @@ func (r *BtpOperatorReconciler) reconcileResourcesWithoutChangingCrState(ctx con
 	if errWithReason != nil {
 		logger.Error(errWithReason, "secret verification failed")
 	}
-	if err := r.deleteOutdatedResources(ctx); err != nil {
+	if err := r.moduleResourceManager.DeleteOutdatedResources(ctx); err != nil {
 		logger.Error(err, "outdated resources deletion failed")
 	}
 	if err := r.reconcileResources(ctx, cr, secret); err != nil {

--- a/controllers/btpoperator_controller_test.go
+++ b/controllers/btpoperator_controller_test.go
@@ -34,7 +34,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should return error from client.Get", func(t *testing.T) {
 		// given
 		retryK8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil)
+		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil)
 		retryK8sClient.EnableErrorOnGet()
 
 		// when
@@ -57,7 +57,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should return error from client.Update", func(t *testing.T) {
 		// given
 		retryK8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil)
+		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil)
 		retryK8sClient.EnableErrorOnUpdate()
 
 		// when
@@ -80,7 +80,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should time out", func(t *testing.T) {
 		// given
 		disabledUpdatek8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(disabledUpdatek8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil)
+		btpOperatorReconciler := NewBtpOperatorReconciler(disabledUpdatek8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil)
 		disabledUpdatek8sClient.DisableUpdate()
 
 		// when
@@ -102,7 +102,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should update BtpOperator status after a few retries", func(t *testing.T) {
 		// given
 		retryK8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil)
+		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil)
 
 		// when
 		err := btpOperatorReconciler.UpdateBtpOperatorStatus(ctx, btpOperator, v1alpha1.StateProcessing, conditions.Initialized, "test")
@@ -124,7 +124,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should update BtpOperator status three times", func(t *testing.T) {
 		// given
 		retryK8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil)
+		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil)
 		conditionMsg1 := "test1"
 		conditionMsg2 := "test2"
 		conditionMsg3 := "test3"

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/kyma-project/btp-manager/internal/certs"
 	"github.com/kyma-project/btp-manager/internal/credentials/drift"
 	"github.com/kyma-project/btp-manager/internal/k8s/networkpolicy"
+	"github.com/kyma-project/btp-manager/internal/manager/moduleresource"
 	"github.com/kyma-project/btp-manager/internal/manifest"
 	btpmanagermetrics "github.com/kyma-project/btp-manager/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
@@ -185,6 +186,7 @@ var _ = SynchronizedBeforeSuite(func() {
 	manifestHandler := &manifest.Handler{Scheme: k8sManager.GetScheme()}
 	networkPolicyManager := networkpolicy.NewManager(k8sManager.GetClient(), manifestHandler)
 	driftDetector := drift.NewDetector(k8sManager.GetClient(), k8sClient)
+	moduleResourceManager := moduleresource.NewManager(k8sManager.GetClient(), k8sManager.GetScheme(), driftDetector)
 	reconciler = NewBtpOperatorReconciler(
 		k8sManager.GetClient(),
 		k8sClient,
@@ -196,6 +198,7 @@ var _ = SynchronizedBeforeSuite(func() {
 		},
 		networkPolicyManager,
 		driftDetector,
+		moduleResourceManager,
 	)
 
 	k8sClientFromManager = k8sManager.GetClient()

--- a/internal/manager/moduleresource/manager.go
+++ b/internal/manager/moduleresource/manager.go
@@ -191,7 +191,7 @@ func (m *Manager) SetConfigMapValues(u *unstructured.Unstructured) error {
 	clusterId := m.driftDetector.ClusterIdFromManager()
 
 	if err := unstructured.SetNestedField(u.Object, clusterId, "data", clusterIdConfigMapKey); err != nil {
-		return fmt.Errorf("failed to set cluster_id: %w", err)
+		return fmt.Errorf("failed to set %s: %w", clusterIdConfigMapKey, err)
 	}
 
 	if err := unstructured.SetNestedField(u.Object, credentialsNamespace, "data", releaseNamespaceConfigMapKey); err != nil {

--- a/internal/manager/moduleresource/manager.go
+++ b/internal/manager/moduleresource/manager.go
@@ -57,14 +57,8 @@ type CredentialsProvider interface {
 	ClusterIdFromManager() string
 }
 
-type Metadata struct {
-	Kind string
-	Name string
-}
-
 type ResourceManager interface {
 	CreateUnstructuredObjectsFromManifestsDir(manifestsDir string) ([]*unstructured.Unstructured, error)
-	ResourcesOfKinds(resources []*unstructured.Unstructured, kinds ...string) (matching, rest []*unstructured.Unstructured)
 	PrepareModuleResources(ctx context.Context, resourcesToApply []*unstructured.Unstructured, s *corev1.Secret) error
 	ApplyOrUpdateResources(ctx context.Context, us []*unstructured.Unstructured) error
 	WaitForResourcesReadiness(ctx context.Context, us []*unstructured.Unstructured) error
@@ -79,7 +73,6 @@ type Manager struct {
 	client          client.Client
 	scheme          *runtime.Scheme
 	manifestHandler *manifest.Handler
-	resourceIndices map[Metadata]int
 	driftDetector   CredentialsProvider
 }
 
@@ -88,7 +81,6 @@ func NewManager(client client.Client, scheme *runtime.Scheme, driftDetector Cred
 		client:          client,
 		scheme:          scheme,
 		manifestHandler: &manifest.Handler{Scheme: scheme},
-		resourceIndices: make(map[Metadata]int),
 		driftDetector:   driftDetector,
 	}
 }
@@ -106,47 +98,7 @@ func (m *Manager) CreateUnstructuredObjectsFromManifestsDir(manifestsDir string)
 		return nil, fmt.Errorf("while converting to unstructured: %w", err)
 	}
 
-	m.indexModuleResources(unstructuredObjects)
-
 	return unstructuredObjects, nil
-}
-
-func (m *Manager) indexModuleResources(unstructuredObjects []*unstructured.Unstructured) {
-	m.resourceIndices = make(map[Metadata]int, len(unstructuredObjects))
-	for i, u := range unstructuredObjects {
-		resource := Metadata{
-			Kind: u.GetKind(),
-			Name: u.GetName(),
-		}
-		m.resourceIndices[resource] = i
-	}
-}
-
-// ResourcesOfKinds partitions resources into two slices: those whose kind is
-// listed in kinds (matching) and everything else (rest). The partition is based
-// on the index built during manifest loading, so resources appended after
-// loading (e.g. network policies) are always placed in rest regardless of kind.
-func (m *Manager) ResourcesOfKinds(resources []*unstructured.Unstructured, kinds ...string) (matching, rest []*unstructured.Unstructured) {
-	kindSet := make(map[string]struct{}, len(kinds))
-	for _, k := range kinds {
-		kindSet[k] = struct{}{}
-	}
-
-	matchingIndices := make(map[int]struct{})
-	for meta, idx := range m.resourceIndices {
-		if _, ok := kindSet[meta.Kind]; ok {
-			matchingIndices[idx] = struct{}{}
-		}
-	}
-
-	for i, r := range resources {
-		if _, ok := matchingIndices[i]; ok {
-			matching = append(matching, r)
-		} else {
-			rest = append(rest, r)
-		}
-	}
-	return
 }
 
 func (m *Manager) PrepareModuleResources(ctx context.Context, resourcesToApply []*unstructured.Unstructured, s *corev1.Secret) error {

--- a/internal/manager/moduleresource/manager.go
+++ b/internal/manager/moduleresource/manager.go
@@ -102,19 +102,19 @@ func (m *Manager) CreateUnstructuredObjectsFromManifestsDir(manifestsDir string)
 }
 
 func (m *Manager) PrepareModuleResources(ctx context.Context, resourcesToApply []*unstructured.Unstructured, s *corev1.Secret) error {
-	configMapIndex, secretIndex, deploymentIndex := -1, -1, -1
-	for i, u := range resourcesToApply {
+	var configMap, secret, deployment *unstructured.Unstructured
+	for _, u := range resourcesToApply {
 		switch {
 		case u.GetName() == "sap-btp-operator-config" && u.GetKind() == "ConfigMap":
-			configMapIndex = i
+			configMap = u
 		case u.GetName() == SapBtpServiceOperatorName && u.GetKind() == "Secret":
-			secretIndex = i
+			secret = u
 		case u.GetName() == config.DeploymentName && u.GetKind() == DeploymentKind:
-			deploymentIndex = i
+			deployment = u
 		}
 	}
-	if configMapIndex < 0 || secretIndex < 0 || deploymentIndex < 0 {
-		return fmt.Errorf("required module resources not found in manifests (configMapIndex=%d, secretIndex=%d, deploymentIndex=%d)", configMapIndex, secretIndex, deploymentIndex)
+	if configMap == nil || secret == nil || deployment == nil {
+		return fmt.Errorf("required module resources not found in manifests (configMap=%t, secret=%t, deployment=%t)", configMap != nil, secret != nil, deployment != nil)
 	}
 	chartVer, err := ymlutils.ExtractStringValueFromYamlForGivenKey(fmt.Sprintf("%s%cChart.yaml", config.ChartPath, os.PathSeparator), "version")
 	if err != nil {
@@ -126,13 +126,13 @@ func (m *Manager) PrepareModuleResources(ctx context.Context, resourcesToApply [
 	}
 	m.SetNamespace(resourcesToApply)
 
-	if err := m.SetConfigMapValues(resourcesToApply[configMapIndex]); err != nil {
+	if err := m.SetConfigMapValues(configMap); err != nil {
 		return fmt.Errorf("failed to set ConfigMap values: %w", err)
 	}
-	if err := m.SetSecretValues(s, resourcesToApply[secretIndex]); err != nil {
+	if err := m.SetSecretValues(s, secret); err != nil {
 		return fmt.Errorf("failed to set Secret values: %w", err)
 	}
-	if err := m.SetDeploymentImages(resourcesToApply[deploymentIndex]); err != nil {
+	if err := m.SetDeploymentImages(deployment); err != nil {
 		return fmt.Errorf("failed to set container images in Deployment: %w", err)
 	}
 

--- a/internal/manager/moduleresource/manager.go
+++ b/internal/manager/moduleresource/manager.go
@@ -1,0 +1,460 @@
+package moduleresource
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/kyma-project/btp-manager/controllers/config"
+	"github.com/kyma-project/btp-manager/internal/manifest"
+	"github.com/kyma-project/btp-manager/internal/ymlutils"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	OperatorName = "btp-manager"
+	ModuleName   = "btp-operator"
+
+	ManagedByLabelKey         = "app.kubernetes.io/managed-by"
+	ChartVersionLabelKey      = "chart-version"
+	KymaProjectModuleLabelKey = "kyma-project.io/module"
+
+	ClientIdSecretKey             = "clientid"
+	ClientSecretKey               = "clientsecret"
+	SmUrlSecretKey                = "sm_url"
+	TokenUrlSecretKey             = "tokenurl"
+	ClusterIdSecretKey            = "cluster_id"
+	CredentialsNamespaceSecretKey = "credentials_namespace"
+
+	SapBtpServiceOperatorName = "sap-btp-service-operator"
+	SapBtpServiceOperatorEnv  = "SAP_BTP_SERVICE_OPERATOR"
+
+	DeploymentKind = "Deployment"
+)
+
+const (
+	clusterIdConfigMapKey           = "CLUSTER_ID"
+	releaseNamespaceConfigMapKey    = "RELEASE_NAMESPACE"
+	managementNamespaceConfigMapKey = "MANAGEMENT_NAMESPACE"
+	enableLimitedCacheConfigMapKey  = "ENABLE_LIMITED_CACHE"
+
+	sapBtpServiceOperatorContainerName = "manager"
+)
+
+// CredentialsProvider gives the module resource manager the authoritative credential
+// values it needs to configure the operand's ConfigMap and Secret.
+// drift.DriftDetector satisfies this interface via Go's structural typing.
+type CredentialsProvider interface {
+	CredentialsNamespaceFromManager() string
+	ClusterIdFromManager() string
+}
+
+type Metadata struct {
+	Kind string
+	Name string
+}
+
+type ResourceManager interface {
+	CreateUnstructuredObjectsFromManifestsDir(manifestsDir string) ([]*unstructured.Unstructured, error)
+	ResourcesOfKinds(resources []*unstructured.Unstructured, kinds ...string) (matching, rest []*unstructured.Unstructured)
+	PrepareModuleResources(ctx context.Context, resourcesToApply []*unstructured.Unstructured, s *corev1.Secret) error
+	ApplyOrUpdateResources(ctx context.Context, us []*unstructured.Unstructured) error
+	WaitForResourcesReadiness(ctx context.Context, us []*unstructured.Unstructured) error
+	DeleteOutdatedResources(ctx context.Context) error
+	DeleteResources(ctx context.Context, us []*unstructured.Unstructured) error
+	DeleteCreationTimestamp(us ...*unstructured.Unstructured)
+	GetResourcesToApplyPath() string
+	GetResourcesToDeletePath() string
+}
+
+type Manager struct {
+	client          client.Client
+	scheme          *runtime.Scheme
+	manifestHandler *manifest.Handler
+	resourceIndices map[Metadata]int
+	driftDetector   CredentialsProvider
+}
+
+func NewManager(client client.Client, scheme *runtime.Scheme, driftDetector CredentialsProvider) *Manager {
+	return &Manager{
+		client:          client,
+		scheme:          scheme,
+		manifestHandler: &manifest.Handler{Scheme: scheme},
+		resourceIndices: make(map[Metadata]int),
+		driftDetector:   driftDetector,
+	}
+}
+
+var _ ResourceManager = (*Manager)(nil)
+
+func (m *Manager) CreateUnstructuredObjectsFromManifestsDir(manifestsDir string) ([]*unstructured.Unstructured, error) {
+	objects, err := m.manifestHandler.CollectObjectsFromDir(manifestsDir)
+	if err != nil {
+		return nil, fmt.Errorf("while collecting objects from directory %s: %w", manifestsDir, err)
+	}
+
+	unstructuredObjects, err := m.manifestHandler.ObjectsToUnstructured(objects)
+	if err != nil {
+		return nil, fmt.Errorf("while converting to unstructured: %w", err)
+	}
+
+	m.indexModuleResources(unstructuredObjects)
+
+	return unstructuredObjects, nil
+}
+
+func (m *Manager) indexModuleResources(unstructuredObjects []*unstructured.Unstructured) {
+	m.resourceIndices = make(map[Metadata]int, len(unstructuredObjects))
+	for i, u := range unstructuredObjects {
+		resource := Metadata{
+			Kind: u.GetKind(),
+			Name: u.GetName(),
+		}
+		m.resourceIndices[resource] = i
+	}
+}
+
+// ResourcesOfKinds partitions resources into two slices: those whose kind is
+// listed in kinds (matching) and everything else (rest). The partition is based
+// on the index built during manifest loading, so resources appended after
+// loading (e.g. network policies) are always placed in rest regardless of kind.
+func (m *Manager) ResourcesOfKinds(resources []*unstructured.Unstructured, kinds ...string) (matching, rest []*unstructured.Unstructured) {
+	kindSet := make(map[string]struct{}, len(kinds))
+	for _, k := range kinds {
+		kindSet[k] = struct{}{}
+	}
+
+	matchingIndices := make(map[int]struct{})
+	for meta, idx := range m.resourceIndices {
+		if _, ok := kindSet[meta.Kind]; ok {
+			matchingIndices[idx] = struct{}{}
+		}
+	}
+
+	for i, r := range resources {
+		if _, ok := matchingIndices[i]; ok {
+			matching = append(matching, r)
+		} else {
+			rest = append(rest, r)
+		}
+	}
+	return
+}
+
+func (m *Manager) PrepareModuleResources(ctx context.Context, resourcesToApply []*unstructured.Unstructured, s *corev1.Secret) error {
+	configMapIndex, secretIndex, deploymentIndex := -1, -1, -1
+	for i, u := range resourcesToApply {
+		switch {
+		case u.GetName() == "sap-btp-operator-config" && u.GetKind() == "ConfigMap":
+			configMapIndex = i
+		case u.GetName() == SapBtpServiceOperatorName && u.GetKind() == "Secret":
+			secretIndex = i
+		case u.GetName() == config.DeploymentName && u.GetKind() == DeploymentKind:
+			deploymentIndex = i
+		}
+	}
+	if configMapIndex < 0 || secretIndex < 0 || deploymentIndex < 0 {
+		return fmt.Errorf("required module resources not found in manifests (configMapIndex=%d, secretIndex=%d, deploymentIndex=%d)", configMapIndex, secretIndex, deploymentIndex)
+	}
+	chartVer, err := ymlutils.ExtractStringValueFromYamlForGivenKey(fmt.Sprintf("%s%cChart.yaml", config.ChartPath, os.PathSeparator), "version")
+	if err != nil {
+		return fmt.Errorf("failed to get module chart version: %w", err)
+	}
+
+	if err := m.AddLabels(chartVer, resourcesToApply...); err != nil {
+		return fmt.Errorf("failed to add labels to resources: %w", err)
+	}
+	m.SetNamespace(resourcesToApply)
+
+	if err := m.SetConfigMapValues(resourcesToApply[configMapIndex]); err != nil {
+		return fmt.Errorf("failed to set ConfigMap values: %w", err)
+	}
+	if err := m.SetSecretValues(s, resourcesToApply[secretIndex]); err != nil {
+		return fmt.Errorf("failed to set Secret values: %w", err)
+	}
+	if err := m.SetDeploymentImages(resourcesToApply[deploymentIndex]); err != nil {
+		return fmt.Errorf("failed to set container images in Deployment: %w", err)
+	}
+
+	return nil
+}
+
+func (m *Manager) DeleteCreationTimestamp(us ...*unstructured.Unstructured) {
+	for _, u := range us {
+		unstructured.RemoveNestedField(u.Object, "metadata", "creationTimestamp")
+	}
+}
+
+func (m *Manager) AddLabels(chartVersion string, us ...*unstructured.Unstructured) error {
+	for _, u := range us {
+		labels := u.GetLabels()
+		if len(labels) == 0 {
+			labels = make(map[string]string)
+		}
+		labels[ManagedByLabelKey] = OperatorName
+		labels[ChartVersionLabelKey] = chartVersion
+		labels[KymaProjectModuleLabelKey] = ModuleName
+		u.SetLabels(labels)
+
+		if u.GetKind() == DeploymentKind {
+			if err := m.addLabelsInPodTemplate(u); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (m *Manager) addLabelsInPodTemplate(u *unstructured.Unstructured) error {
+	tplLabels, found, err := unstructured.NestedStringMap(u.Object, "spec", "template", "metadata", "labels")
+	if err != nil {
+		return fmt.Errorf("failed to get pod template labels for deployment %s: %w", u.GetName(), err)
+	}
+	if !found || tplLabels == nil {
+		tplLabels = make(map[string]string)
+	}
+	tplLabels[KymaProjectModuleLabelKey] = ModuleName
+	if err := unstructured.SetNestedStringMap(u.Object, tplLabels, "spec", "template", "metadata", "labels"); err != nil {
+		return fmt.Errorf("failed to set pod template labels for deployment %s: %w", u.GetName(), err)
+	}
+	return nil
+}
+
+func (m *Manager) SetNamespace(us []*unstructured.Unstructured) {
+	for _, u := range us {
+		u.SetNamespace(config.ChartNamespace)
+	}
+}
+
+func (m *Manager) SetConfigMapValues(u *unstructured.Unstructured) error {
+	credentialsNamespace := m.driftDetector.CredentialsNamespaceFromManager()
+	clusterId := m.driftDetector.ClusterIdFromManager()
+
+	if err := unstructured.SetNestedField(u.Object, clusterId, "data", clusterIdConfigMapKey); err != nil {
+		return fmt.Errorf("failed to set cluster_id: %w", err)
+	}
+
+	if err := unstructured.SetNestedField(u.Object, credentialsNamespace, "data", releaseNamespaceConfigMapKey); err != nil {
+		return fmt.Errorf("failed to set release namespace: %w", err)
+	}
+
+	if err := unstructured.SetNestedField(u.Object, credentialsNamespace, "data", managementNamespaceConfigMapKey); err != nil {
+		return fmt.Errorf("failed to set management namespace: %w", err)
+	}
+
+	if err := unstructured.SetNestedField(u.Object, config.EnableLimitedCache, "data", enableLimitedCacheConfigMapKey); err != nil {
+		return fmt.Errorf("failed to set enable limited cache: %w", err)
+	}
+
+	return nil
+}
+
+func (m *Manager) SetSecretValues(secret *corev1.Secret, u *unstructured.Unstructured) error {
+	u.SetNamespace(m.driftDetector.CredentialsNamespaceFromManager())
+
+	for k := range secret.Data {
+		if k == ClusterIdSecretKey || k == CredentialsNamespaceSecretKey {
+			continue
+		}
+		if err := unstructured.SetNestedField(u.Object, base64.StdEncoding.EncodeToString(secret.Data[k]), "data", k); err != nil {
+			return fmt.Errorf("failed to set secret field %s: %w", k, err)
+		}
+	}
+
+	return nil
+}
+
+func (m *Manager) SetDeploymentImages(u *unstructured.Unstructured) error {
+	sapBtpServiceOperatorImage := os.Getenv(SapBtpServiceOperatorEnv)
+	if err := m.setContainerImage(u, sapBtpServiceOperatorContainerName, sapBtpServiceOperatorImage); err != nil {
+		return fmt.Errorf("failed to set container image for %s: %w", SapBtpServiceOperatorName, err)
+	}
+	return nil
+}
+
+func (m *Manager) setContainerImage(u *unstructured.Unstructured, containerName, image string) error {
+	containers, found, err := unstructured.NestedSlice(u.Object, "spec", "template", "spec", "containers")
+	if err != nil {
+		return fmt.Errorf("failed to get containers from %s %s: %w", u.GetKind(), u.GetName(), err)
+	}
+	if !found {
+		return fmt.Errorf("containers not found in %s %s", u.GetKind(), u.GetName())
+	}
+
+	containerFound := false
+	for i, c := range containers {
+		container, ok := c.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("cannot cast container field to map[string]interface{}: %v", c)
+		}
+		if container["name"] == containerName {
+			container["image"] = image
+			containers[i] = container
+			containerFound = true
+			break
+		}
+	}
+
+	if !containerFound {
+		return fmt.Errorf("container %s not found in %s %s", containerName, u.GetKind(), u.GetName())
+	}
+
+	return unstructured.SetNestedSlice(u.Object, containers, "spec", "template", "spec", "containers")
+}
+
+func (m *Manager) GetResourcesToApplyPath() string {
+	return fmt.Sprintf("%s%capply", config.ResourcesPath, os.PathSeparator)
+}
+
+func (m *Manager) GetResourcesToDeletePath() string {
+	return fmt.Sprintf("%s%cdelete", config.ResourcesPath, os.PathSeparator)
+}
+
+func (m *Manager) ApplyOrUpdateResources(ctx context.Context, us []*unstructured.Unstructured) error {
+	for _, u := range us {
+		if err := m.applyOrUpdateResource(ctx, u); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *Manager) applyOrUpdateResource(ctx context.Context, u *unstructured.Unstructured) error {
+	preExistingResource := &unstructured.Unstructured{}
+	preExistingResource.SetGroupVersionKind(u.GroupVersionKind())
+	if err := m.client.Get(ctx, client.ObjectKey{Name: u.GetName(), Namespace: u.GetNamespace()}, preExistingResource); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return m.applyResource(ctx, u)
+		}
+		return fmt.Errorf("while trying to get %s %s: %w", u.GetName(), u.GetKind(), err)
+	}
+	u.SetResourceVersion(preExistingResource.GetResourceVersion())
+	return m.updateResource(ctx, u)
+}
+
+func (m *Manager) applyResource(ctx context.Context, u *unstructured.Unstructured) error {
+	if err := m.client.Create(ctx, u, client.FieldOwner(OperatorName)); err != nil {
+		return fmt.Errorf("while creating %s %s: %w", u.GetName(), u.GetKind(), err)
+	}
+	return nil
+}
+
+func (m *Manager) updateResource(ctx context.Context, u *unstructured.Unstructured) error {
+	if err := m.client.Update(ctx, u, client.FieldOwner(OperatorName)); err != nil {
+		return fmt.Errorf("while updating %s %s: %w", u.GetName(), u.GetKind(), err)
+	}
+	return nil
+}
+
+func (m *Manager) DeleteOutdatedResources(ctx context.Context) error {
+	objects, err := m.CreateUnstructuredObjectsFromManifestsDir(m.GetResourcesToDeletePath())
+	if err != nil {
+		return fmt.Errorf("failed to create deletable objects from manifests: %w", err)
+	}
+
+	return m.DeleteResources(ctx, objects)
+}
+
+func (m *Manager) DeleteResources(ctx context.Context, us []*unstructured.Unstructured) error {
+	var errs []string
+	for _, u := range us {
+		if err := m.client.Delete(ctx, u); err != nil {
+			if !k8serrors.IsNotFound(err) {
+				errs = append(errs, fmt.Sprintf("failed to delete %s %s: %s", u.GetName(), u.GetKind(), err))
+			}
+		}
+	}
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, ", "))
+	}
+	return nil
+}
+
+func (m *Manager) WaitForResourcesReadiness(ctx context.Context, us []*unstructured.Unstructured) error {
+	errChan := make(chan error, len(us))
+
+	for _, u := range us {
+		go func(resource *unstructured.Unstructured) {
+			errChan <- m.waitForResource(ctx, resource)
+		}(u)
+	}
+
+	var firstErr error
+	for range us {
+		if err := <-errChan; err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	return firstErr
+}
+
+func (m *Manager) waitForResource(ctx context.Context, u *unstructured.Unstructured) error {
+	now := time.Now()
+	for {
+		if time.Since(now) >= config.ReadyTimeout {
+			return fmt.Errorf("timeout waiting for %s %s to be ready", u.GetName(), u.GetKind())
+		}
+
+		ctxWithTimeout, cancel := context.WithTimeout(ctx, config.ReadyCheckInterval)
+		current := &unstructured.Unstructured{}
+		current.SetGroupVersionKind(u.GroupVersionKind())
+		err := m.client.Get(ctxWithTimeout, client.ObjectKey{Name: u.GetName(), Namespace: u.GetNamespace()}, current)
+		timedOut := ctxWithTimeout.Err() != nil
+		cancel()
+		if err == nil && m.isResourceReady(current) {
+			return nil
+		}
+		if err != nil && !k8serrors.IsNotFound(err) && !timedOut && ctx.Err() == nil {
+			return fmt.Errorf("while checking readiness of %s %s: %w", u.GetName(), u.GetKind(), err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timeout waiting for %s %s to be ready", u.GetName(), u.GetKind())
+		case <-time.After(config.ReadyCheckInterval):
+		}
+	}
+}
+
+func (m *Manager) isResourceReady(u *unstructured.Unstructured) bool {
+	kind := u.GetKind()
+
+	switch kind {
+	case "Deployment":
+		return m.isDeploymentReady(u)
+	default:
+		return true
+	}
+}
+
+func (m *Manager) isDeploymentReady(u *unstructured.Unstructured) bool {
+	conditions, found, err := unstructured.NestedSlice(u.Object, "status", "conditions")
+	if err != nil || !found {
+		return false
+	}
+	var available, progressing bool
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		condType, _ := cond["type"].(string)
+		condStatus, _ := cond["status"].(string)
+		switch condType {
+		case "Available":
+			available = condStatus == "True"
+		case "Progressing":
+			progressing = condStatus == "True"
+		}
+	}
+	return available && progressing
+}

--- a/internal/manager/moduleresource/manager_test.go
+++ b/internal/manager/moduleresource/manager_test.go
@@ -527,10 +527,6 @@ var _ = Describe("Module Resource Manager", func() {
 	})
 })
 
-func createRequiredSecret(k8sClient client.Client) error {
-	return k8sClient.Create(context.Background(), requiredSecret())
-}
-
 func requiredSecret() *corev1.Secret {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/manager/moduleresource/manager_test.go
+++ b/internal/manager/moduleresource/manager_test.go
@@ -2,6 +2,7 @@ package moduleresource
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"testing"
@@ -203,9 +204,10 @@ var _ = Describe("Module Resource Manager", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(found).To(BeTrue())
 
-			Expect(data).To(HaveKey(ClientIdSecretKey))
-			Expect(data).To(HaveKey(ClientSecretKey))
-			Expect(data).To(HaveKey(SmUrlSecretKey))
+			Expect(data).To(HaveKeyWithValue(ClientIdSecretKey, base64.StdEncoding.EncodeToString(secret.Data[ClientIdSecretKey])))
+			Expect(data).To(HaveKeyWithValue(ClientSecretKey, base64.StdEncoding.EncodeToString(secret.Data[ClientSecretKey])))
+			Expect(data).To(HaveKeyWithValue(SmUrlSecretKey, base64.StdEncoding.EncodeToString(secret.Data[SmUrlSecretKey])))
+			Expect(data).To(HaveKeyWithValue(TokenUrlSecretKey, base64.StdEncoding.EncodeToString(secret.Data[TokenUrlSecretKey])))
 			Expect(data).NotTo(HaveKey(ClusterIdSecretKey))
 			Expect(data).NotTo(HaveKey(CredentialsNamespaceSecretKey))
 		})
@@ -483,11 +485,11 @@ func requiredSecret() *corev1.Secret {
 			Namespace: requiredSecretNamespace,
 		},
 		Data: map[string][]byte{
-			ClientIdSecretKey:  []byte("dGVzdF9jbGllbnRpZA=="),
-			ClientSecretKey:    []byte("dGVzdF9jbGllbnRzZWNyZXQ="),
-			SmUrlSecretKey:     []byte("dGVzdF9zbV91cmw="),
-			TokenUrlSecretKey:  []byte("dGVzdF90b2tlbnVybA=="),
-			ClusterIdSecretKey: []byte("dGVzdF9jbHVzdGVyX2lk"),
+			ClientIdSecretKey:  []byte("test_clientid"),
+			ClientSecretKey:    []byte("test_clientsecret"),
+			SmUrlSecretKey:     []byte("test_sm_url"),
+			TokenUrlSecretKey:  []byte("test_tokenurl"),
+			ClusterIdSecretKey: []byte("test_cluster_id"),
 		},
 	}
 	return secret

--- a/internal/manager/moduleresource/manager_test.go
+++ b/internal/manager/moduleresource/manager_test.go
@@ -1,0 +1,608 @@
+package moduleresource
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/kyma-project/btp-manager/controllers/config"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kyma-project/btp-manager/api/v1alpha1"
+)
+
+const (
+	testNamespace = "test-namespace"
+	kymaNamespace = "kyma-system"
+
+	configmapKind = "ConfigMap"
+	secretKind    = "Secret"
+
+	configmapName  = "test-configmap"
+	secretName     = "test-secret"
+	deploymentName = "test-deployment"
+
+	moduleResourcesPath         = "./testdata"
+	moduleResourcesPathToApply  = moduleResourcesPath + "/apply"
+	moduleResourcesPathToDelete = moduleResourcesPath + "/delete"
+
+	requiredSecretName      = "sap-btp-manager"
+	requiredSecretNamespace = "kyma-system"
+)
+
+var (
+	fakeClient          client.Client
+	scheme              *runtime.Scheme
+	defaultStubDetector *stubCredentialsProvider
+)
+
+func TestModuleResource(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Module Resource Suite")
+}
+
+var _ = BeforeSuite(func() {
+	scheme = runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+
+	fakeClient = fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	defaultStubDetector = &stubCredentialsProvider{
+		credentialsNamespace: kymaNamespace,
+		clusterId:            "",
+	}
+})
+
+var _ = Describe("Module Resource Manager", func() {
+	var manager *Manager
+
+	BeforeEach(func() {
+		fakeClient = fake.NewClientBuilder().
+			WithScheme(scheme).
+			Build()
+
+		manager = NewManager(fakeClient, scheme, defaultStubDetector)
+	})
+
+	Describe("partition resources by kind", func() {
+		It("should return resources of the requested kind in matching and the rest in rest", func() {
+			objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
+			Expect(err).NotTo(HaveOccurred())
+
+			matching, rest := manager.ResourcesOfKinds(objects, configmapKind)
+
+			Expect(matching).To(HaveLen(1))
+			Expect(matching[0].GetKind()).To(Equal(configmapKind))
+			Expect(rest).To(HaveLen(2))
+			for _, r := range rest {
+				Expect(r.GetKind()).NotTo(Equal(configmapKind))
+			}
+		})
+
+		It("should place resources appended after loading into rest regardless of kind", func() {
+			objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
+			Expect(err).NotTo(HaveOccurred())
+
+			extra := &unstructured.Unstructured{}
+			extra.SetKind(configmapKind)
+			extra.SetName("extra-configmap")
+			objects = append(objects, extra)
+
+			matching, rest := manager.ResourcesOfKinds(objects, configmapKind)
+
+			Expect(matching).To(HaveLen(1))
+			Expect(matching[0].GetName()).To(Equal(configmapName))
+			Expect(rest).To(HaveLen(3))
+		})
+
+		It("should return all resources in rest when no kind matches", func() {
+			objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
+			Expect(err).NotTo(HaveOccurred())
+
+			matching, rest := manager.ResourcesOfKinds(objects, "NetworkPolicy")
+
+			Expect(matching).To(BeEmpty())
+			Expect(rest).To(HaveLen(len(objects)))
+		})
+
+		It("should return all resources in rest when no kinds are specified", func() {
+			objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
+			Expect(err).NotTo(HaveOccurred())
+
+			matching, rest := manager.ResourcesOfKinds(objects)
+
+			Expect(matching).To(BeEmpty())
+			Expect(rest).To(HaveLen(len(objects)))
+		})
+	})
+
+	Describe("create unstructured objects from manifests directory", func() {
+		It("should load and convert manifests to unstructured objects", func() {
+			objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(objects).To(HaveLen(3))
+			Expect(manager.resourceIndices).To(HaveLen(3))
+
+			configmapIndex := manager.resourceIndices[Metadata{Kind: configmapKind, Name: configmapName}]
+			configmap := objects[configmapIndex]
+			Expect(configmap.GetKind()).To(Equal(configmapKind))
+			Expect(configmap.GetName()).To(Equal(configmapName))
+			Expect(configmap.GetNamespace()).To(Equal(testNamespace))
+
+			deploymentIndex := manager.resourceIndices[Metadata{Kind: DeploymentKind, Name: deploymentName}]
+			deployment := objects[deploymentIndex]
+			Expect(deployment.GetKind()).To(Equal(DeploymentKind))
+			Expect(deployment.GetName()).To(Equal(deploymentName))
+			Expect(deployment.GetNamespace()).To(Equal(testNamespace))
+
+			secretIndex := manager.resourceIndices[Metadata{Kind: secretKind, Name: secretName}]
+			secret := objects[secretIndex]
+			Expect(secret.GetKind()).To(Equal(secretKind))
+			Expect(secret.GetName()).To(Equal(secretName))
+			Expect(secret.GetNamespace()).To(Equal(testNamespace))
+		})
+
+		It("should return error for non-existent directory", func() {
+			_, err := manager.CreateUnstructuredObjectsFromManifestsDir("./non-existent")
+
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("add labels", func() {
+		It("should add managed-by, chart version, and module labels to all resources", func() {
+			objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
+			Expect(err).NotTo(HaveOccurred())
+
+			chartVersion := "0.0.1"
+			Expect(manager.AddLabels(chartVersion, objects...)).NotTo(HaveOccurred())
+
+			for _, obj := range objects {
+				labels := obj.GetLabels()
+				Expect(labels).To(HaveKey(ManagedByLabelKey))
+				Expect(labels[ManagedByLabelKey]).To(Equal(OperatorName))
+				Expect(labels[KymaProjectModuleLabelKey]).To(Equal(ModuleName))
+				Expect(labels[ChartVersionLabelKey]).To(Equal(chartVersion))
+			}
+
+			deploymentIndex := manager.resourceIndices[Metadata{Kind: DeploymentKind, Name: deploymentName}]
+			spec, found, err := unstructured.NestedMap(objects[deploymentIndex].Object, "spec", "template", "metadata", "labels")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+			Expect(spec[KymaProjectModuleLabelKey]).To(Equal(ModuleName))
+		})
+	})
+
+	Describe("set namespace", func() {
+		It("should set namespace in all resources", func() {
+			objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
+			Expect(err).NotTo(HaveOccurred())
+
+			manager.SetNamespace(objects)
+
+			for _, obj := range objects {
+				Expect(obj.GetNamespace()).To(Equal(kymaNamespace))
+			}
+		})
+	})
+
+	Describe("set ConfigMap values", func() {
+		It("should set ConfigMap values from the credentials provider", func() {
+			const (
+				expectedClusterId               = "test-cluster-123"
+				expectedCredentialsNamespace    = "test-creds-ns"
+				expectedEnableLimitedCacheValue = "true"
+			)
+
+			stub := &stubCredentialsProvider{
+				credentialsNamespace: expectedCredentialsNamespace,
+				clusterId:            expectedClusterId,
+			}
+			manager = NewManager(fakeClient, scheme, stub)
+
+			restoreEnableLimitedCache := config.EnableLimitedCache
+			config.EnableLimitedCache = expectedEnableLimitedCacheValue
+			defer func() {
+				config.EnableLimitedCache = restoreEnableLimitedCache
+			}()
+
+			objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
+			Expect(err).NotTo(HaveOccurred())
+
+			configmapIndex, found := manager.resourceIndices[Metadata{Kind: configmapKind, Name: configmapName}]
+			Expect(found).To(BeTrue())
+			configmap := objects[configmapIndex]
+
+			err = manager.SetConfigMapValues(configmap)
+			Expect(err).NotTo(HaveOccurred())
+
+			data, found, err := unstructured.NestedStringMap(configmap.Object, "data")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+			Expect(data[clusterIdConfigMapKey]).To(Equal(expectedClusterId))
+			Expect(data[releaseNamespaceConfigMapKey]).To(Equal(expectedCredentialsNamespace))
+			Expect(data[managementNamespaceConfigMapKey]).To(Equal(expectedCredentialsNamespace))
+			Expect(data[enableLimitedCacheConfigMapKey]).To(Equal(expectedEnableLimitedCacheValue))
+		})
+	})
+
+	Describe("set default credentials secret values", func() {
+		It("should copy data with base64 encoding excluding cluster_id and credentials_namespace", func() {
+			const expectedCredentialsNamespace = "credentials-namespace"
+			secret := requiredSecret()
+
+			stub := &stubCredentialsProvider{credentialsNamespace: expectedCredentialsNamespace}
+			manager = NewManager(fakeClient, scheme, stub)
+
+			secretObj := &unstructured.Unstructured{}
+			secretObj.SetKind(secretKind)
+			secretObj.SetName(SapBtpServiceOperatorName)
+			secretObj.SetNamespace(kymaNamespace)
+
+			Expect(manager.SetSecretValues(secret, secretObj)).NotTo(HaveOccurred())
+			Expect(secretObj.GetNamespace()).To(Equal(expectedCredentialsNamespace))
+
+			data, found, err := unstructured.NestedStringMap(secretObj.Object, "data")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+
+			Expect(data).To(HaveKey(ClientIdSecretKey))
+			Expect(data).To(HaveKey(ClientSecretKey))
+			Expect(data).To(HaveKey(SmUrlSecretKey))
+			Expect(data).NotTo(HaveKey(ClusterIdSecretKey))
+			Expect(data).NotTo(HaveKey(CredentialsNamespaceSecretKey))
+		})
+	})
+
+	Describe("set Deployment images", func() {
+		const (
+			sapBtpOperatorImage = "local.test/kyma-project/sap-btp-operator:v0.0.1"
+		)
+
+		BeforeEach(func() {
+			Expect(os.Setenv(SapBtpServiceOperatorEnv, sapBtpOperatorImage)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			Expect(os.Unsetenv(SapBtpServiceOperatorEnv)).To(Succeed())
+		})
+
+		It("should set container image for sap-btp-service-operator", func() {
+			objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
+			Expect(err).NotTo(HaveOccurred())
+
+			deploymentIndex, found := manager.resourceIndices[Metadata{Kind: DeploymentKind, Name: deploymentName}]
+			Expect(found).To(BeTrue())
+			deployment := objects[deploymentIndex]
+
+			err = manager.SetDeploymentImages(deployment)
+			Expect(err).NotTo(HaveOccurred())
+
+			containers, found, err := unstructured.NestedSlice(deployment.Object, "spec", "template", "spec", "containers")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(found).To(BeTrue())
+
+			managerContainer, ok := containers[0].(map[string]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(managerContainer["name"]).To(Equal("manager"))
+			Expect(managerContainer["image"]).To(Equal(sapBtpOperatorImage))
+		})
+
+		It("should return error if container not found", func() {
+			deployment := unstructuredDeployment(false, false)
+			deployment.Object["spec"] = map[string]interface{}{
+				"template": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name": "wrong-container-name",
+							},
+						},
+					},
+				},
+			}
+
+			err := manager.SetDeploymentImages(deployment)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("container manager not found"))
+		})
+	})
+
+	Describe("module resources management", func() {
+		var ctx context.Context
+		var savedModuleResourcesPath string
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			savedModuleResourcesPath = config.ResourcesPath
+			config.ResourcesPath = moduleResourcesPath
+		})
+
+		AfterEach(func() {
+			config.ResourcesPath = savedModuleResourcesPath
+		})
+
+		Describe("apply or update resources", func() {
+
+			It("should create new resources", func() {
+				objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(manager.GetResourcesToApplyPath())
+				Expect(err).NotTo(HaveOccurred())
+				err = manager.ApplyOrUpdateResources(ctx, objects)
+				Expect(err).NotTo(HaveOccurred())
+
+				configmap := &corev1.ConfigMap{}
+				err = fakeClient.Get(ctx, client.ObjectKey{
+					Name:      configmapName,
+					Namespace: testNamespace,
+				}, configmap)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(configmap.GetName()).To(Equal(configmapName))
+			})
+
+			It("should update existing resources", func() {
+				const (
+					expectedKey = "key"
+					expectedVal = "value"
+				)
+				configmap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      configmapName,
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{
+						"old-key": "old-value",
+					},
+				}
+
+				err := fakeClient.Create(ctx, configmap)
+				Expect(err).NotTo(HaveOccurred())
+
+				objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(manager.GetResourcesToApplyPath())
+				Expect(err).NotTo(HaveOccurred())
+				err = manager.ApplyOrUpdateResources(ctx, objects)
+				Expect(err).NotTo(HaveOccurred())
+
+				updated := &corev1.ConfigMap{}
+				err = fakeClient.Get(ctx, client.ObjectKey{
+					Name:      configmapName,
+					Namespace: testNamespace,
+				}, updated)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updated.Data[expectedKey]).To(Equal(expectedVal))
+			})
+		})
+
+		Describe("delete resources", func() {
+			var ctx context.Context
+
+			BeforeEach(func() {
+				ctx = context.Background()
+			})
+
+			It("should delete existing resources", func() {
+				configmap := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      configmapName,
+						Namespace: testNamespace,
+					},
+					Data: map[string]string{
+						"foo": "bar",
+					},
+				}
+
+				err := fakeClient.Create(ctx, configmap)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = fakeClient.Get(ctx, client.ObjectKey{
+					Name:      configmapName,
+					Namespace: testNamespace,
+				}, configmap)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(manager.DeleteOutdatedResources(context.Background())).Should(Succeed())
+
+				err = fakeClient.Get(ctx, client.ObjectKey{
+					Name:      configmapName,
+					Namespace: testNamespace,
+				}, configmap)
+				Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+			})
+
+			It("should not error when deleting non-existent resources", func() {
+				Expect(manager.DeleteOutdatedResources(context.Background())).Should(Succeed())
+			})
+
+			It("should return error when unable to delete resources", func() {
+				const (
+					expectedName1 = "configmap1"
+					expectedName2 = "configmap2"
+				)
+				client := &errorOnDeleteClient{fakeClient}
+				manager = NewManager(client, scheme, defaultStubDetector)
+
+				us1 := &unstructured.Unstructured{}
+				us1.SetKind(configmapKind)
+				us1.SetName(expectedName1)
+				us1.SetNamespace(testNamespace)
+
+				us2 := &unstructured.Unstructured{}
+				us2.SetKind(configmapKind)
+				us2.SetName(expectedName2)
+				us2.SetNamespace(testNamespace)
+
+				objects := []*unstructured.Unstructured{us1, us2}
+
+				err := manager.DeleteResources(ctx, objects)
+				Expect(err).To(HaveOccurred())
+
+				const errorFormat = "failed to delete %s %s"
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(errorFormat, expectedName1, configmapKind)))
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf(errorFormat, expectedName2, configmapKind)))
+			})
+		})
+	})
+
+	Describe("wait for resources readiness", func() {
+		var savedReadyTimeout, savedReadyCheckInterval time.Duration
+
+		BeforeEach(func() {
+			savedReadyTimeout, savedReadyCheckInterval = config.ReadyTimeout, config.ReadyCheckInterval
+			config.ReadyTimeout = 1 * time.Second
+			config.ReadyCheckInterval = 100 * time.Millisecond
+		})
+
+		AfterEach(func() {
+			config.ReadyTimeout = savedReadyTimeout
+			config.ReadyCheckInterval = savedReadyCheckInterval
+		})
+
+		It("should successfully wait for Deployment readiness", func() {
+			ctx := context.Background()
+			deployment := unstructuredDeployment(true, true)
+
+			err := fakeClient.Create(ctx, deployment)
+			Expect(err).NotTo(HaveOccurred())
+
+			objects := []*unstructured.Unstructured{deployment}
+			err = manager.WaitForResourcesReadiness(ctx, objects)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should timeout when Deployment is not ready", func() {
+			ctx := context.Background()
+			deployment := unstructuredDeployment(false, false)
+
+			err := fakeClient.Create(ctx, deployment)
+			Expect(err).NotTo(HaveOccurred())
+
+			objects := []*unstructured.Unstructured{deployment}
+			err = manager.WaitForResourcesReadiness(ctx, objects)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("timeout"))
+		})
+
+		It("should consider ConfigMap as immediately ready", func() {
+			ctx := context.Background()
+			configmap := unstructuredConfigmap()
+
+			err := fakeClient.Create(ctx, configmap)
+			Expect(err).NotTo(HaveOccurred())
+
+			objects := []*unstructured.Unstructured{configmap}
+			err = manager.WaitForResourcesReadiness(ctx, objects)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should handle multiple resources concurrently", func() {
+			ctx := context.Background()
+			deployment := unstructuredDeployment(true, true)
+			configmap := unstructuredConfigmap()
+
+			err := fakeClient.Create(ctx, deployment)
+			Expect(err).NotTo(HaveOccurred())
+			err = fakeClient.Create(ctx, configmap)
+			Expect(err).NotTo(HaveOccurred())
+
+			objects := []*unstructured.Unstructured{deployment, configmap}
+			err = manager.WaitForResourcesReadiness(ctx, objects)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})
+
+func createRequiredSecret(k8sClient client.Client) error {
+	return k8sClient.Create(context.Background(), requiredSecret())
+}
+
+func requiredSecret() *corev1.Secret {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      requiredSecretName,
+			Namespace: requiredSecretNamespace,
+		},
+		Data: map[string][]byte{
+			ClientIdSecretKey:  []byte("dGVzdF9jbGllbnRpZA=="),
+			ClientSecretKey:    []byte("dGVzdF9jbGllbnRzZWNyZXQ="),
+			SmUrlSecretKey:     []byte("dGVzdF9zbV91cmw="),
+			TokenUrlSecretKey:  []byte("dGVzdF90b2tlbnVybA=="),
+			ClusterIdSecretKey: []byte("dGVzdF9jbHVzdGVyX2lk"),
+		},
+	}
+	return secret
+}
+
+type stubCredentialsProvider struct {
+	credentialsNamespace string
+	clusterId            string
+}
+
+func (s *stubCredentialsProvider) CredentialsNamespaceFromManager() string {
+	return s.credentialsNamespace
+}
+func (s *stubCredentialsProvider) ClusterIdFromManager() string { return s.clusterId }
+
+type errorOnDeleteClient struct {
+	client.Client
+}
+
+func (e *errorOnDeleteClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	return fmt.Errorf("expected delete error")
+}
+
+func unstructuredDeployment(available, progressing bool) *unstructured.Unstructured {
+	condStatus := func(v bool) string {
+		if v {
+			return "True"
+		}
+		return "False"
+	}
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       DeploymentKind,
+			"metadata": map[string]interface{}{
+				"name":      deploymentName,
+				"namespace": testNamespace,
+			},
+			"spec": map[string]interface{}{
+				"replicas": int64(1),
+			},
+			"status": map[string]interface{}{
+				"conditions": []interface{}{
+					map[string]interface{}{"type": "Available", "status": condStatus(available)},
+					map[string]interface{}{"type": "Progressing", "status": condStatus(progressing)},
+				},
+			},
+		},
+	}
+}
+
+func unstructuredConfigmap() *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       configmapKind,
+			"metadata": map[string]interface{}{
+				"name":      configmapName,
+				"namespace": testNamespace,
+			},
+		},
+	}
+}

--- a/internal/manager/moduleresource/manager_test.go
+++ b/internal/manager/moduleresource/manager_test.go
@@ -79,82 +79,23 @@ var _ = Describe("Module Resource Manager", func() {
 		manager = NewManager(fakeClient, scheme, defaultStubDetector)
 	})
 
-	Describe("partition resources by kind", func() {
-		It("should return resources of the requested kind in matching and the rest in rest", func() {
-			objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
-			Expect(err).NotTo(HaveOccurred())
-
-			matching, rest := manager.ResourcesOfKinds(objects, configmapKind)
-
-			Expect(matching).To(HaveLen(1))
-			Expect(matching[0].GetKind()).To(Equal(configmapKind))
-			Expect(rest).To(HaveLen(2))
-			for _, r := range rest {
-				Expect(r.GetKind()).NotTo(Equal(configmapKind))
-			}
-		})
-
-		It("should place resources appended after loading into rest regardless of kind", func() {
-			objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
-			Expect(err).NotTo(HaveOccurred())
-
-			extra := &unstructured.Unstructured{}
-			extra.SetKind(configmapKind)
-			extra.SetName("extra-configmap")
-			objects = append(objects, extra)
-
-			matching, rest := manager.ResourcesOfKinds(objects, configmapKind)
-
-			Expect(matching).To(HaveLen(1))
-			Expect(matching[0].GetName()).To(Equal(configmapName))
-			Expect(rest).To(HaveLen(3))
-		})
-
-		It("should return all resources in rest when no kind matches", func() {
-			objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
-			Expect(err).NotTo(HaveOccurred())
-
-			matching, rest := manager.ResourcesOfKinds(objects, "NetworkPolicy")
-
-			Expect(matching).To(BeEmpty())
-			Expect(rest).To(HaveLen(len(objects)))
-		})
-
-		It("should return all resources in rest when no kinds are specified", func() {
-			objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
-			Expect(err).NotTo(HaveOccurred())
-
-			matching, rest := manager.ResourcesOfKinds(objects)
-
-			Expect(matching).To(BeEmpty())
-			Expect(rest).To(HaveLen(len(objects)))
-		})
-	})
-
 	Describe("create unstructured objects from manifests directory", func() {
 		It("should load and convert manifests to unstructured objects", func() {
 			objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(objects).To(HaveLen(3))
-			Expect(manager.resourceIndices).To(HaveLen(3))
 
-			configmapIndex := manager.resourceIndices[Metadata{Kind: configmapKind, Name: configmapName}]
-			configmap := objects[configmapIndex]
-			Expect(configmap.GetKind()).To(Equal(configmapKind))
-			Expect(configmap.GetName()).To(Equal(configmapName))
+			configmap := findByKindAndName(objects, configmapKind, configmapName)
+			Expect(configmap).NotTo(BeNil())
 			Expect(configmap.GetNamespace()).To(Equal(testNamespace))
 
-			deploymentIndex := manager.resourceIndices[Metadata{Kind: DeploymentKind, Name: deploymentName}]
-			deployment := objects[deploymentIndex]
-			Expect(deployment.GetKind()).To(Equal(DeploymentKind))
-			Expect(deployment.GetName()).To(Equal(deploymentName))
+			deployment := findByKindAndName(objects, DeploymentKind, deploymentName)
+			Expect(deployment).NotTo(BeNil())
 			Expect(deployment.GetNamespace()).To(Equal(testNamespace))
 
-			secretIndex := manager.resourceIndices[Metadata{Kind: secretKind, Name: secretName}]
-			secret := objects[secretIndex]
-			Expect(secret.GetKind()).To(Equal(secretKind))
-			Expect(secret.GetName()).To(Equal(secretName))
+			secret := findByKindAndName(objects, secretKind, secretName)
+			Expect(secret).NotTo(BeNil())
 			Expect(secret.GetNamespace()).To(Equal(testNamespace))
 		})
 
@@ -181,8 +122,9 @@ var _ = Describe("Module Resource Manager", func() {
 				Expect(labels[ChartVersionLabelKey]).To(Equal(chartVersion))
 			}
 
-			deploymentIndex := manager.resourceIndices[Metadata{Kind: DeploymentKind, Name: deploymentName}]
-			spec, found, err := unstructured.NestedMap(objects[deploymentIndex].Object, "spec", "template", "metadata", "labels")
+			deployment := findByKindAndName(objects, DeploymentKind, deploymentName)
+			Expect(deployment).NotTo(BeNil())
+			spec, found, err := unstructured.NestedMap(deployment.Object, "spec", "template", "metadata", "labels")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(found).To(BeTrue())
 			Expect(spec[KymaProjectModuleLabelKey]).To(Equal(ModuleName))
@@ -225,9 +167,8 @@ var _ = Describe("Module Resource Manager", func() {
 			objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
 			Expect(err).NotTo(HaveOccurred())
 
-			configmapIndex, found := manager.resourceIndices[Metadata{Kind: configmapKind, Name: configmapName}]
-			Expect(found).To(BeTrue())
-			configmap := objects[configmapIndex]
+			configmap := findByKindAndName(objects, configmapKind, configmapName)
+			Expect(configmap).NotTo(BeNil())
 
 			err = manager.SetConfigMapValues(configmap)
 			Expect(err).NotTo(HaveOccurred())
@@ -287,9 +228,8 @@ var _ = Describe("Module Resource Manager", func() {
 			objects, err := manager.CreateUnstructuredObjectsFromManifestsDir(moduleResourcesPathToApply)
 			Expect(err).NotTo(HaveOccurred())
 
-			deploymentIndex, found := manager.resourceIndices[Metadata{Kind: DeploymentKind, Name: deploymentName}]
-			Expect(found).To(BeTrue())
-			deployment := objects[deploymentIndex]
+			deployment := findByKindAndName(objects, DeploymentKind, deploymentName)
+			Expect(deployment).NotTo(BeNil())
 
 			err = manager.SetDeploymentImages(deployment)
 			Expect(err).NotTo(HaveOccurred())
@@ -526,6 +466,15 @@ var _ = Describe("Module Resource Manager", func() {
 		})
 	})
 })
+
+func findByKindAndName(objects []*unstructured.Unstructured, kind, name string) *unstructured.Unstructured {
+	for _, o := range objects {
+		if o.GetKind() == kind && o.GetName() == name {
+			return o
+		}
+	}
+	return nil
+}
 
 func requiredSecret() *corev1.Secret {
 	secret := &corev1.Secret{

--- a/internal/manager/moduleresource/testdata/apply/test-resources.yaml
+++ b/internal/manager/moduleresource/testdata/apply/test-resources.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap
+  namespace: test-namespace
+data:
+  key: "value"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-deployment
+  namespace: test-namespace
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: test
+  template:
+    metadata:
+      labels:
+        app: test
+    spec:
+      containers:
+      - name: manager
+        image: old-image:latest
+      - name: kube-rbac-proxy
+        image: old-proxy:latest
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-secret
+  namespace: test-namespace
+type: Opaque
+data:
+  clientid: ""
+  clientsecret: ""
+  sm_url: ""
+  tokenurl: ""
+  tokenurlsuffix: "L29hdXRoL3Rva2Vu"

--- a/internal/manager/moduleresource/testdata/delete/test-resources.yaml
+++ b/internal/manager/moduleresource/testdata/delete/test-resources.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-configmap
+  namespace: test-namespace
+data:
+  key: "value"

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ import (
 	"github.com/kyma-project/btp-manager/controllers/config"
 	"github.com/kyma-project/btp-manager/internal/credentials/drift"
 	"github.com/kyma-project/btp-manager/internal/k8s/networkpolicy"
+	"github.com/kyma-project/btp-manager/internal/manager/moduleresource"
 	"github.com/kyma-project/btp-manager/internal/manifest"
 	btpmanagermetrics "github.com/kyma-project/btp-manager/internal/metrics"
 	//+kubebuilder:scaffold:imports
@@ -133,6 +134,7 @@ func main() {
 	manifestHandler := &manifest.Handler{Scheme: scheme}
 	networkPolicyManager := networkpolicy.NewManager(mgr.GetClient(), manifestHandler)
 	driftDetector := drift.NewDetector(mgr.GetClient(), apiServerClient)
+	moduleResourceManager := moduleresource.NewManager(mgr.GetClient(), scheme, driftDetector)
 	reconciler := controllers.NewBtpOperatorReconciler(
 		mgr.GetClient(),
 		apiServerClient,
@@ -144,6 +146,7 @@ func main() {
 		},
 		networkPolicyManager,
 		driftDetector,
+		moduleResourceManager,
 	)
 
 	if err = reconciler.SetupWithManager(mgr); err != nil {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `internal/manager/moduleresource` package with `ResourceManager` interface and `Manager` implementation for module resource preparation, application, readiness, and cleanup
- Delegate module resource operations from the controller to `ModuleResourceManager` (`DeleteOutdatedResources`, `PrepareModuleResources`, `DeleteCreationTimestamp`, `ApplyOrUpdateResources`, `WaitForResourcesReadiness`, and the manifest-dir/path helpers)
- Wire `ModuleResourceManager` into `NewBtpOperatorReconciler`, `main.go`, and test suite setup
- Remove the `manifestHandler` field from the reconciler struct and delete the now-unused controller methods and the `ResourceReadiness` type

**Related issue(s)**
See also #1313

---

> **Note:** This is PR 4/5 in a split of [#1526](https://github.com/kyma-project/btp-manager/pull/1526). Each PR leaves the codebase fully functional with all tests passing.
>
> Merge order: [#1561](https://github.com/kyma-project/btp-manager/pull/1561) (merged) → [#1562](https://github.com/kyma-project/btp-manager/pull/1562) (merged) → [#1563](https://github.com/kyma-project/btp-manager/pull/1563) (merged) → **this PR** → PR 5 (ObjectManager + SecretManager + WebhookCertificateManager)