### PR TITLE
Add CA Bundle Probe Documentation

### DIFF
--- a/docs/contributor/08-10-metrics.md
+++ b/docs/contributor/08-10-metrics.md
@@ -7,5 +7,6 @@ BTP Manager provides metrics on the endpoint `:8080/metrics`. You find Kubebuild
 
 | Metric                                   | Description                                                                                       |
 |:-----------------------------------------|:--------------------------------------------------------------------------------------------------|
-| **btpmanager_certs_regenerations_total** | The total number of [certificate](06-10-certs.md) regenerations.                                  |
-| **btpmanager_custom_config_applied**     | Gauge indicating if the custom configuration ConfigMap is applied (1 = applied, 0 = not applied). |
+| **btpmanager_certs_regenerations_total**   | The total number of [certificate](06-10-certs.md) regenerations.                                                                            |
+| **btpmanager_custom_config_applied**       | Gauge indicating if the custom configuration ConfigMap is applied (1 = applied, 0 = not applied).                                           |
+| **btpmanager_credential_probe_status**     | Gauge indicating the [CA bundle probe](09-10-ca-bundle-probe.md) status: 1 = alert (CA mounted but token URL cert not trusted), 0 = ok.     |

--- a/docs/contributor/08-10-metrics.md
+++ b/docs/contributor/08-10-metrics.md
@@ -9,4 +9,4 @@ BTP Manager provides metrics on the endpoint `:8080/metrics`. You find Kubebuild
 |:-----------------------------------------|:--------------------------------------------------------------------------------------------------|
 | **btpmanager_certs_regenerations_total**   | The total number of [certificate](06-10-certs.md) regenerations.                                                                            |
 | **btpmanager_custom_config_applied**       | Gauge indicating if the custom configuration ConfigMap is applied (1 = applied, 0 = not applied).                                           |
-| **btpmanager_credential_probe_status**     | Gauge indicating the [CA bundle probe](09-10-ca-bundle-probe.md) status: 1 = alert (CA mounted but token URL cert not trusted), 0 = ok.     |
+| **btpmanager_credential_probe_status**     | Gauge indicating the [CA bundle probe](09-10-ca-bundle-probe.md) status: 1 = alert (CA mounted but token URL cert not trusted), 0 = non-alert result written by probe. Not updated on silent-exit cycles (no mount + TLS ok). |

--- a/docs/contributor/09-10-ca-bundle-probe.md
+++ b/docs/contributor/09-10-ca-bundle-probe.md
@@ -65,7 +65,10 @@ Mount detection is based solely on the presence of the `rt-bootstrapper-certs` v
 | `ProbeInterval` | ConfigMap `sap-btp-manager` / CLI flag `--probe-interval` | `0s` (disabled) | How often to run the probe. Set to `0` to disable. |
 | `PROBE_IMAGE` | Environment variable | — | Container image for the probe Job. Required to enable the probe. |
 | `PROBE_TOKENURL_OVERRIDE` | Environment variable | — | Override the token URL used by the probe (for testing). |
-| `PROBE_FORCE_HASH` | Environment variable | — | Force a specific hash value (for testing). |
+| **ProbeInterval** | ConfigMap `sap-btp-manager` / CLI flag `--probe-interval` | `0s` (disabled) | How often to run the probe. Set to `0` to disable. |
+| **PROBE_IMAGE** | Environment variable | None | Container image for the probe Job. Required to enable the probe. |
+| **PROBE_TOKENURL_OVERRIDE** | Environment variable | None | Override the token URL used by the probe (for testing). |
+| **PROBE_FORCE_HASH** | Environment variable | None | Force a specific hash value (for testing). |
 
 ## Metric
 

--- a/docs/contributor/09-10-ca-bundle-probe.md
+++ b/docs/contributor/09-10-ca-bundle-probe.md
@@ -10,7 +10,7 @@ The probe is disabled by default (`ProbeInterval: 0s`). It requires a probe imag
 
 ## How It Works
 
-BTP Manager runs a `ProbeRunner` as a controller-runtime `Runnable`. On each interval tick, it:
+BTP Manager runs a `ProbeRunner` as a controller-runtime `Runnable`. On each interval tick, it performs the following steps:
 
 1. Deletes any leftover probe Job from a previous cycle.
 2. Creates a new Kubernetes Job (`btp-manager-ca-bundle-probe`) in `kyma-system`.

--- a/docs/contributor/09-10-ca-bundle-probe.md
+++ b/docs/contributor/09-10-ca-bundle-probe.md
@@ -52,7 +52,7 @@ After each Job completes, BTP Manager reads the probe annotations and acts as fo
 | No | ok | n/a | No action (public landscape, all good) |
 | No | failed (x509) | n/a | No action (probe logs internally; no annotation written) |
 | Yes | ok | No | No action (TLS healthy, no rotation) |
-| Yes | ok | Yes | Restart `sap-btp-operator` pods |
+| Yes | ok | Yes | Restart `sap-btp-operator` Pods |
 | Yes | failed (x509) | Any | Alert metric set to 1 |
 | Any | failed (other) | Any | No action (probe logs internally; no annotation written) |
 

--- a/docs/contributor/09-10-ca-bundle-probe.md
+++ b/docs/contributor/09-10-ca-bundle-probe.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The CA bundle probe is a periodic background job that checks whether the TLS certificate of the SAP Service Manager token URL is trusted by the CA bundle currently mounted on the BTP Manager pod.
+The CA bundle probe is a periodic background job that checks whether the TLS certificate of the SAP Service Manager token URL is trusted by the CA bundle currently mounted on the BTP Manager Pod.
 
 It is designed for Kyma clusters where the `rt-bootstrapper` module is active. In such clusters, a custom CA bundle is injected into pods via a volume mount named `rt-bootstrapper-certs`. The probe detects this mount and uses the custom bundle as the certificate pool for TLS verification.
 

--- a/docs/contributor/09-10-ca-bundle-probe.md
+++ b/docs/contributor/09-10-ca-bundle-probe.md
@@ -1,0 +1,83 @@
+# CA Bundle Probe
+
+## Overview
+
+The CA bundle probe is a periodic background job that checks whether the TLS certificate of the SAP Service Manager token URL is trusted by the CA bundle currently mounted on the BTP Manager pod.
+
+It is designed for Kyma clusters where the `rt-bootstrapper` module is active. In such clusters, a custom CA bundle is injected into pods via a volume mount named `rt-bootstrapper-certs`. The probe detects this mount and uses the custom bundle as the certificate pool for TLS verification.
+
+The probe is **disabled by default** (`ProbeInterval: 0s`). It requires a probe image to be configured via the `PROBE_IMAGE` environment variable.
+
+## How It Works
+
+BTP Manager runs a `ProbeRunner` as a controller-runtime `Runnable`. On each interval tick, it:
+
+1. Deletes any leftover probe Job from a previous cycle.
+2. Creates a new Kubernetes Job (`btp-manager-ca-bundle-probe`) in `kyma-system`.
+3. Waits for the Job to complete (up to 5 minutes).
+4. Reads the results from annotations on the `BtpOperator` CR.
+5. Updates the `btpmanager_credential_probe_status` Prometheus metric.
+6. If the CA bundle hash changed and TLS is healthy, restarts the `sap-btp-operator` pods.
+7. Updates the `tls-probe-last-hash` annotation on the `BtpOperator` CR.
+
+## Probe Job
+
+The probe Job runs a single container using the image configured via `PROBE_IMAGE`. The Job:
+
+- Runs with `RestartPolicy: Never` and `BackoffLimit: 0`.
+- Runs with Istio sidecar injection disabled (`sidecar.istio.io/inject: "false"`).
+- Uses the `btp-manager-ca-bundle-probe` ServiceAccount.
+- Writes results as annotations on the `BtpOperator` CR, then exits.
+
+### Annotations Written by the Probe
+
+| Annotation | Values | Description |
+|---|---|---|
+| `tls-probe-status` | `ok`, `alert`, or empty | TLS verification result |
+| `tls-probe-hash` | SHA256 hex string | Hash of the CA bundle file |
+| `tls-probe-updated-at` | RFC3339 timestamp | Time the probe wrote its results |
+
+### Annotation Managed by BTP Manager
+
+| Annotation | Description |
+|---|---|
+| `tls-probe-last-hash` | Hash from the previous cycle, used to detect CA bundle rotation |
+
+## Decision Logic
+
+BTP Manager reads the probe annotations after each Job completes and takes the following actions:
+
+| Mount present | TLS result | Hash changed | Action |
+|---|---|---|---|
+| No | ok | n/a | No action (public landscape, all good) |
+| No | failed (x509) | n/a | Warning log (system CA doesn't trust tokenurl) |
+| Yes | ok | No | No action (TLS healthy, no rotation) |
+| Yes | ok | Yes | Restart `sap-btp-operator` pods |
+| Yes | failed (x509) | Any | Alert metric set to 1 |
+| Any | failed (other) | Any | Warning log (connectivity/DNS issue) |
+
+Mount detection is based solely on the presence of the `rt-bootstrapper-certs` volume mount on the BTP Manager pod (via `POD_NAME` env var).
+
+## Configuration
+
+| Parameter | Source | Default | Description |
+|---|---|---|---|
+| `ProbeInterval` | ConfigMap `sap-btp-manager` / CLI flag `--probe-interval` | `0s` (disabled) | How often to run the probe. Set to `0` to disable. |
+| `PROBE_IMAGE` | Environment variable | — | Container image for the probe Job. Required to enable the probe. |
+| `PROBE_TOKENURL_OVERRIDE` | Environment variable | — | Override the token URL used by the probe (for testing). |
+| `PROBE_FORCE_HASH` | Environment variable | — | Force a specific hash value (for testing). |
+
+## Metric
+
+| Metric | Type | Description |
+|---|---|---|
+| `btpmanager_credential_probe_status` | Gauge | `1` when alert (CA mounted but cert not trusted), `0` otherwise |
+
+## RBAC
+
+The probe Job pod uses the `btp-manager-ca-bundle-probe` ServiceAccount, which has:
+- `get` and `patch` on `btpoperators.operator.kyma-project.io` (to write result annotations)
+- `get` on `secrets` in `kyma-system` (to read the CA bundle)
+
+BTP Manager itself requires additional RBAC to manage the probe Jobs:
+- `get`, `list`, `watch`, `create`, `delete` on `batch/jobs`

--- a/docs/contributor/09-10-ca-bundle-probe.md
+++ b/docs/contributor/09-10-ca-bundle-probe.md
@@ -45,16 +45,16 @@ The probe Job runs a single container using the image configured via `PROBE_IMAG
 
 ## Decision Logic
 
-BTP Manager reads the probe annotations after each Job completes and takes the following actions:
+After each Job completes, BTP Manager reads the probe annotations and acts as follows. "No action" means BTP Manager takes no action; the probe Job itself may log internally.
 
-| Mount present | TLS result | Hash changed | Action |
+| Mount present | TLS result | Hash changed | BTP Manager action |
 |---|---|---|---|
 | No | ok | n/a | No action (public landscape, all good) |
-| No | failed (x509) | n/a | Warning log (system CA doesn't trust tokenurl) |
+| No | failed (x509) | n/a | No action (probe logs internally; no annotation written) |
 | Yes | ok | No | No action (TLS healthy, no rotation) |
 | Yes | ok | Yes | Restart `sap-btp-operator` pods |
 | Yes | failed (x509) | Any | Alert metric set to 1 |
-| Any | failed (other) | Any | Warning log (connectivity/DNS issue) |
+| Any | failed (other) | Any | No action (probe logs internally; no annotation written) |
 
 Mount detection is based solely on the presence of the `rt-bootstrapper-certs` volume mount on the BTP Manager pod (via `POD_NAME` env var).
 

--- a/docs/contributor/09-10-ca-bundle-probe.md
+++ b/docs/contributor/09-10-ca-bundle-probe.md
@@ -22,7 +22,7 @@ BTP Manager runs a `ProbeRunner` as a controller-runtime `Runnable`. On each int
 
 ## Probe Job
 
-The probe Job runs a single container using the image configured via `PROBE_IMAGE`. The Job:
+The probe Job runs a single container using the image configured with **PROBE_IMAGE**. The Job performs the following steps:
 
 - Runs with `RestartPolicy: Never` and `BackoffLimit: 0`.
 - Runs with Istio sidecar injection disabled (`sidecar.istio.io/inject: "false"`).

--- a/docs/contributor/09-10-ca-bundle-probe.md
+++ b/docs/contributor/09-10-ca-bundle-probe.md
@@ -15,7 +15,7 @@ BTP Manager runs a `ProbeRunner` as a controller-runtime `Runnable`. On each int
 1. Deletes any leftover probe Job from a previous cycle.
 2. Creates a new Kubernetes Job (`btp-manager-ca-bundle-probe`) in `kyma-system`.
 3. Waits for the Job to complete (up to 5 minutes).
-4. Reads the results from annotations on the `BtpOperator` CR.
+4. Reads the results from annotations on the `BtpOperator` custom resource (CR).
 5. Updates the `btpmanager_credential_probe_status` Prometheus metric.
 6. If the CA bundle hash changed and TLS is healthy, restarts the `sap-btp-operator` Pods.
 7. Updates the `tls-probe-last-hash` annotation on the `BtpOperator` CR.

--- a/docs/contributor/09-10-ca-bundle-probe.md
+++ b/docs/contributor/09-10-ca-bundle-probe.md
@@ -17,7 +17,7 @@ BTP Manager runs a `ProbeRunner` as a controller-runtime `Runnable`. On each int
 3. Waits for the Job to complete (up to 5 minutes).
 4. Reads the results from annotations on the `BtpOperator` CR.
 5. Updates the `btpmanager_credential_probe_status` Prometheus metric.
-6. If the CA bundle hash changed and TLS is healthy, restarts the `sap-btp-operator` pods.
+6. If the CA bundle hash changed and TLS is healthy, restarts the `sap-btp-operator` Pods.
 7. Updates the `tls-probe-last-hash` annotation on the `BtpOperator` CR.
 
 ## Probe Job

--- a/docs/contributor/09-10-ca-bundle-probe.md
+++ b/docs/contributor/09-10-ca-bundle-probe.md
@@ -75,7 +75,7 @@ Mount detection is based solely on the presence of the `rt-bootstrapper-certs` v
 
 ## RBAC
 
-The probe Job pod uses the `btp-manager-ca-bundle-probe` ServiceAccount, which has:
+The probe Job Pod uses the `btp-manager-ca-bundle-probe` ServiceAccount, which has the following permissions:
 - `get` and `patch` on `btpoperators.operator.kyma-project.io` (to write result annotations)
 - `get` on `secrets` in `kyma-system` (to read the CA bundle)
 

--- a/docs/contributor/09-10-ca-bundle-probe.md
+++ b/docs/contributor/09-10-ca-bundle-probe.md
@@ -4,7 +4,7 @@
 
 The CA bundle probe is a periodic background job that checks whether the TLS certificate of the SAP Service Manager token URL is trusted by the CA bundle currently mounted on the BTP Manager Pod.
 
-It is designed for Kyma clusters where the `rt-bootstrapper` module is active. In such clusters, a custom CA bundle is injected into pods via a volume mount named `rt-bootstrapper-certs`. The probe detects this mount and uses the custom bundle as the certificate pool for TLS verification.
+It is designed for Kyma clusters where the `rt-bootstrapper` module is active. In such clusters, a custom CA bundle is injected into Pods using a volume mount named `rt-bootstrapper-certs`. The probe detects this mount and uses the custom bundle as the certificate pool for TLS verification.
 
 The probe is disabled by default (`ProbeInterval: 0s`). It requires a probe image to be configured using the **PROBE_IMAGE** environment variable.
 

--- a/docs/contributor/09-10-ca-bundle-probe.md
+++ b/docs/contributor/09-10-ca-bundle-probe.md
@@ -74,7 +74,7 @@ Mount detection is based solely on the presence of the `rt-bootstrapper-certs` v
 
 | Metric | Type | Description |
 |---|---|---|
-| `btpmanager_credential_probe_status` | Gauge | `1` when alert (CA mounted but cert not trusted). Set to `0` when the probe writes a non-alert result. **Not updated** on silent-exit cycles (no mount + TLS ok), so the gauge retains its last written value until the next cycle where the probe writes annotations. |
+| `btpmanager_credential_probe_status` | Gauge | `1` when alert (CA mounted but cert not trusted). Set to `0` when the probe writes a non-alert result. **Not updated** on silent-exit cycles (no mount + TLS ok), so the gauge retains its last written value until the next cycle, where the probe writes annotations. |
 
 ## RBAC
 

--- a/docs/contributor/09-10-ca-bundle-probe.md
+++ b/docs/contributor/09-10-ca-bundle-probe.md
@@ -6,7 +6,7 @@ The CA bundle probe is a periodic background job that checks whether the TLS cer
 
 It is designed for Kyma clusters where the `rt-bootstrapper` module is active. In such clusters, a custom CA bundle is injected into pods via a volume mount named `rt-bootstrapper-certs`. The probe detects this mount and uses the custom bundle as the certificate pool for TLS verification.
 
-The probe is **disabled by default** (`ProbeInterval: 0s`). It requires a probe image to be configured via the `PROBE_IMAGE` environment variable.
+The probe is disabled by default (`ProbeInterval: 0s`). It requires a probe image to be configured using the **PROBE_IMAGE** environment variable.
 
 ## How It Works
 

--- a/docs/contributor/09-10-ca-bundle-probe.md
+++ b/docs/contributor/09-10-ca-bundle-probe.md
@@ -62,9 +62,6 @@ Mount detection is based solely on the presence of the `rt-bootstrapper-certs` v
 
 | Parameter | Source | Default | Description |
 |---|---|---|---|
-| `ProbeInterval` | ConfigMap `sap-btp-manager` / CLI flag `--probe-interval` | `0s` (disabled) | How often to run the probe. Set to `0` to disable. |
-| `PROBE_IMAGE` | Environment variable | — | Container image for the probe Job. Required to enable the probe. |
-| `PROBE_TOKENURL_OVERRIDE` | Environment variable | — | Override the token URL used by the probe (for testing). |
 | **ProbeInterval** | ConfigMap `sap-btp-manager` / CLI flag `--probe-interval` | `0s` (disabled) | How often to run the probe. Set to `0` to disable. |
 | **PROBE_IMAGE** | Environment variable | None | Container image for the probe Job. Required to enable the probe. |
 | **PROBE_TOKENURL_OVERRIDE** | Environment variable | None | Override the token URL used by the probe (for testing). |

--- a/docs/contributor/09-10-ca-bundle-probe.md
+++ b/docs/contributor/09-10-ca-bundle-probe.md
@@ -71,7 +71,7 @@ Mount detection is based solely on the presence of the `rt-bootstrapper-certs` v
 
 | Metric | Type | Description |
 |---|---|---|
-| `btpmanager_credential_probe_status` | Gauge | `1` when alert (CA mounted but cert not trusted), `0` otherwise |
+| `btpmanager_credential_probe_status` | Gauge | `1` when alert (CA mounted but cert not trusted). Set to `0` when the probe writes a non-alert result. **Not updated** on silent-exit cycles (no mount + TLS ok), so the gauge retains its last written value until the next cycle where the probe writes annotations. |
 
 ## RBAC
 

--- a/docs/contributor/09-10-ca-bundle-probe.md
+++ b/docs/contributor/09-10-ca-bundle-probe.md
@@ -56,7 +56,7 @@ After each Job completes, BTP Manager reads the probe annotations and acts as fo
 | Yes | failed (x509) | Any | Alert metric set to 1 |
 | Any | failed (other) | Any | No action (probe logs internally; no annotation written) |
 
-Mount detection is based solely on the presence of the `rt-bootstrapper-certs` volume mount on the BTP Manager pod (via `POD_NAME` env var).
+Mount detection is based solely on the presence of the `rt-bootstrapper-certs` volume mount on the BTP Manager Pod (using **POD_NAME** environment variable).
 
 ## Configuration
 

--- a/docs/contributor/09-10-ca-bundle-probe.md
+++ b/docs/contributor/09-10-ca-bundle-probe.md
@@ -71,7 +71,7 @@ Mount detection is based solely on the presence of the `rt-bootstrapper-certs` v
 
 | Metric | Type | Description |
 |---|---|---|
-| `btpmanager_credential_probe_status` | Gauge | `1` when alert (CA mounted but cert not trusted). Set to `0` when the probe writes a non-alert result. **Not updated** on silent-exit cycles (no mount + TLS ok), so the gauge retains its last written value until the next cycle, where the probe writes annotations. |
+| `btpmanager_credential_probe_status` | Gauge | BTP Manager sets this to `1` when the probe reports an alert (CA mounted but cert not trusted), and to `0` when the probe writes a non-alert result. On silent-exit cycles (no mount + TLS ok), BTP Manager does not update the gauge, so it retains its last written value. |
 
 ## RBAC
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `docs/contributor/09-10-ca-bundle-probe.md` documenting the CA bundle probe feature: overview, how it works, probe Job details, annotations, decision logic, configuration, metric, and RBAC
- Update `docs/contributor/08-10-metrics.md` to include the `btpmanager_credential_probe_status` metric with a link to the probe documentation

**Related issue(s)**