### PR TITLE
Bump Go to 1.26.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine3.22 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.24 AS builder
 
 WORKDIR /btp-manager-workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/btp-manager
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/tests/fake-server/Dockerfile
+++ b/tests/fake-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine3.22 AS builder
+FROM golang:1.26.5-alpine3.24 AS builder
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/tests/probe/Dockerfile
+++ b/tests/probe/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine3.22 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.24 AS builder
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/tests/webhook/Dockerfile
+++ b/tests/webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-alpine3.22 AS builder
+FROM golang:1.26.5-alpine3.24 AS builder
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Bump Go from `1.26.4` to `1.26.5` in `go.mod`
- Update base image from `golang:1.26.4-alpine3.22` to `golang:1.26.5-alpine3.24` in all Dockerfiles