### PR TITLE
Extract ProvisioningHandler from BtpOperatorReconciler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ make module-image   # Build and push module image
 
 **Entry point:** `main.go` initializes the controller-runtime manager with leader election, registers reconcilers, sets up health/metrics probes, and starts config watching.
 
-**Primary reconciler:** `controllers/btpoperator_controller.go` (~2600 lines) — contains the main reconciliation logic. It owns the BtpOperator state machine and drives all provisioning, updating, and deprovisioning work.
+**Primary reconciler:** `controllers/btpoperator_controller.go` (~1250 lines) — contains the main reconciliation logic. It owns the BtpOperator state machine and delegates to internal handler packages for provisioning, deprovisioning, and other concerns.
 
 **Supporting reconcilers:**
 - `controllers/serviceinstance_controller.go` — watches ServiceInstance/ServiceBinding resources to trigger BtpOperator status updates when instances or bindings change.
@@ -154,7 +154,7 @@ Each state has a dedicated handler method (`HandleInitialState`, `HandleProcessi
 |---|---|
 | `api/v1alpha1/` | BtpOperator CRD type definitions |
 | `controllers/` | All reconcilers and config handler |
-| `internal/` | Utilities: `certs/`, `conditions/`, `manifest/`, `metrics/`, `ymlutils/`, `gvksutils/` |
+| `internal/` | Internal packages: `certs/`, `conditions/`, `credentials/`, `gvksutils/`, `k8s/`, `manager/`, `manifest/`, `metrics/`, `provisioning/`, `webhook/`, `ymlutils/` |
 | `module-chart/` | Helm chart for the SAP BTP operator that BTP Manager deploys |
 | `module-resources/apply/` | K8s manifests applied during provisioning |
 | `module-resources/delete/` | K8s manifests deleted during provisioning (outdated resources) |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ make module-image   # Build and push module image
 
 **Entry point:** `main.go` initializes the controller-runtime manager with leader election, registers reconcilers, sets up health/metrics probes, and starts config watching.
 
-**Primary reconciler:** `controllers/btpoperator_controller.go` (~1250 lines) — contains the main reconciliation logic. It owns the BtpOperator state machine and delegates to internal handler packages for provisioning, deprovisioning, and other concerns.
+**Primary reconciler:** `controllers/btpoperator_controller.go` (~1250 lines) — contains the main reconciliation logic. It owns the BtpOperator state machine and delegates to internal handler packages for provisioning, deprovisioning, and other concerns. All handlers are constructed in `main.go` and injected into `NewBtpOperatorReconciler` via its constructor parameters — the same pattern used for `networkpolicy.Manager`, `drift.Detector`, `moduleresource.Manager`, `certificate.Manager`, and `provisioning.Handler`.
 
 **Supporting reconcilers:**
 - `controllers/serviceinstance_controller.go` — watches ServiceInstance/ServiceBinding resources to trigger BtpOperator status updates when instances or bindings change.

--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -385,11 +385,11 @@ func (r *BtpOperatorReconciler) handleDeleting(ctx context.Context, cr *v1alpha1
 
 	if err = r.handleDeprovisioning(ctx, cr); err != nil {
 		logger.Error(err, "deprovisioning failed. Restoring resources")
-		r.reconcileResourcesWithoutChangingCrState(ctx, cr, &logger)
+		r.provisioningHandler.ReconcileResourcesWithoutStatusChange(ctx, cr)
 		return err
 	}
 	if cr.IsReasonStringEqual(string(conditions.ServiceInstancesAndBindingsNotCleaned)) {
-		r.reconcileResourcesWithoutChangingCrState(ctx, cr, &logger)
+		r.provisioningHandler.ReconcileResourcesWithoutStatusChange(ctx, cr)
 
 		numberOfBindings, err := r.numberOfResources(ctx, bindingGvk)
 		if err != nil {
@@ -1202,10 +1202,6 @@ func (r *BtpOperatorReconciler) getSecretDataValueByKey(key string, data map[str
 		return nil, fmt.Errorf("empty value for key: %s", key)
 	}
 	return value, nil
-}
-
-func (r *BtpOperatorReconciler) reconcileResourcesWithoutChangingCrState(ctx context.Context, cr *v1alpha1.BtpOperator, logger *logr.Logger) {
-	r.provisioningHandler.ReconcileResourcesWithoutStatusChange(ctx, cr)
 }
 
 func (r *BtpOperatorReconciler) isManagedSecret(s *corev1.Secret) bool {

--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -680,9 +680,11 @@ func (r *BtpOperatorReconciler) deleteBtpOperatorResources(ctx context.Context) 
 		return fmt.Errorf("failed to delete module resources: %w", err)
 	}
 
-	if err := r.networkPolicyManager.CleanupNetworkPolicies(ctx); err != nil {
-		logger.Error(err, "while cleaning up network policies during hard delete")
-		return fmt.Errorf("failed to cleanup network policies during hard delete: %w", err)
+	if r.networkPolicyManager != nil {
+		if err := r.networkPolicyManager.CleanupNetworkPolicies(ctx); err != nil {
+			logger.Error(err, "while cleaning up network policies during hard delete")
+			return fmt.Errorf("failed to cleanup network policies during hard delete: %w", err)
+		}
 	}
 
 	if err := r.driftDetector.DeleteClusterIdSecret(ctx); err != nil {
@@ -780,8 +782,10 @@ func (r *BtpOperatorReconciler) preSoftDeleteCleanup(ctx context.Context) error 
 		}
 	}
 
-	if err := r.networkPolicyManager.CleanupNetworkPolicies(ctx); err != nil {
-		return fmt.Errorf("failed to cleanup network policies during soft delete: %w", err)
+	if r.networkPolicyManager != nil {
+		if err := r.networkPolicyManager.CleanupNetworkPolicies(ctx); err != nil {
+			return fmt.Errorf("failed to cleanup network policies during soft delete: %w", err)
+		}
 	}
 
 	return nil

--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -325,7 +325,7 @@ func (r *BtpOperatorReconciler) HandleProcessingState(ctx context.Context, cr *v
 	return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateReady, conditions.ReconcileSucceeded, "Module provisioning succeeded")
 }
 
-func (r *BtpOperatorReconciler) handleMissingSecret(ctx context.Context, cr *v1alpha1.BtpOperator, logger logr.Logger, errWithReason *ErrorWithReason) error {
+func (r *BtpOperatorReconciler) handleSecretVerificationFailure(ctx context.Context, cr *v1alpha1.BtpOperator, logger logr.Logger, errWithReason *ErrorWithReason) error {
 	logger.Info("secret verification failed: " + errWithReason.Error())
 	if errWithReason.Reason == conditions.InvalidSecret {
 		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.Reason, errWithReason.Message)
@@ -854,7 +854,7 @@ func (r *BtpOperatorReconciler) HandleReadyState(ctx context.Context, cr *v1alph
 
 	requiredSecret, errWithReason := r.getAndVerifyRequiredSecret(ctx)
 	if errWithReason != nil {
-		return r.handleMissingSecret(ctx, cr, logger, errWithReason)
+		return r.handleSecretVerificationFailure(ctx, cr, logger, errWithReason)
 	}
 
 	r.driftDetector.InitializeFromSecret(requiredSecret)

--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -327,6 +327,9 @@ func (r *BtpOperatorReconciler) HandleProcessingState(ctx context.Context, cr *v
 
 func (r *BtpOperatorReconciler) handleMissingSecret(ctx context.Context, cr *v1alpha1.BtpOperator, logger logr.Logger, errWithReason *ErrorWithReason) error {
 	logger.Info("secret verification failed: " + errWithReason.Error())
+	if errWithReason.Reason == conditions.InvalidSecret {
+		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.Reason, errWithReason.Message)
+	}
 	return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateWarning, errWithReason.Reason, errWithReason.Message)
 }
 

--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kyma-project/btp-manager/internal/k8s/networkpolicy"
 	"github.com/kyma-project/btp-manager/internal/manager/moduleresource"
 	"github.com/kyma-project/btp-manager/internal/metrics"
+	"github.com/kyma-project/btp-manager/internal/provisioning"
 	"github.com/kyma-project/btp-manager/internal/webhook/certificate"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -159,10 +160,11 @@ type BtpOperatorReconciler struct {
 	driftDetector          drift.Detector
 	moduleResourceManager  moduleresource.ResourceManager
 	certManager            certificate.CertificateManager
+	provisioningHandler    provisioning.Handler
 	watchHandlers          []config.WatchHandler
 }
 
-func NewBtpOperatorReconciler(client client.Client, apiServerClient client.Client, scheme *runtime.Scheme, instanceBindingSerivice InstanceBindingSerivce, metrics *metrics.WebhookMetrics, watchHandlers []config.WatchHandler, networkPolicyManager networkpolicy.NetworkPolicyManager, driftDetector drift.Detector, moduleResourceManager moduleresource.ResourceManager, certManager certificate.CertificateManager) *BtpOperatorReconciler {
+func NewBtpOperatorReconciler(client client.Client, apiServerClient client.Client, scheme *runtime.Scheme, instanceBindingSerivice InstanceBindingSerivce, metrics *metrics.WebhookMetrics, watchHandlers []config.WatchHandler, networkPolicyManager networkpolicy.NetworkPolicyManager, driftDetector drift.Detector, moduleResourceManager moduleresource.ResourceManager, certManager certificate.CertificateManager, provisioningHandler provisioning.Handler) *BtpOperatorReconciler {
 	return &BtpOperatorReconciler{
 		Client:                 client,
 		apiServerClient:        apiServerClient,
@@ -174,6 +176,7 @@ func NewBtpOperatorReconciler(client client.Client, apiServerClient client.Clien
 		driftDetector:          driftDetector,
 		moduleResourceManager:  moduleResourceManager,
 		certManager:            certManager,
+		provisioningHandler:    provisioningHandler,
 	}
 }
 
@@ -311,44 +314,14 @@ func (r *BtpOperatorReconciler) HandleInitialState(ctx context.Context, cr *v1al
 }
 
 func (r *BtpOperatorReconciler) HandleProcessingState(ctx context.Context, cr *v1alpha1.BtpOperator) error {
-	logger := log.FromContext(ctx)
-	logger.Info("Handling Processing state")
-
-	requiredSecret, errWithReason := r.getAndVerifyRequiredSecret(ctx)
-	if errWithReason != nil {
-		return r.handleMissingSecret(ctx, cr, logger, errWithReason)
+	log.FromContext(ctx).Info("Handling Processing state")
+	result := r.provisioningHandler.Provision(ctx, cr)
+	if result.WarningReason != nil {
+		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateWarning, result.WarningReason.Reason, result.WarningReason.Message)
 	}
-
-	r.driftDetector.InitializeFromSecret(requiredSecret)
-
-	if errWithReason := r.driftDetector.CheckCredentialsNamespaceDrift(ctx, requiredSecret); errWithReason != nil {
-		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.Reason, errWithReason.Message)
+	if result.ErrorReason != nil {
+		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, result.ErrorReason.Reason, result.ErrorReason.Message)
 	}
-
-	if errWithReason := r.driftDetector.CheckClusterIdConfigMapDrift(ctx, requiredSecret); errWithReason != nil {
-		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.Reason, errWithReason.Message)
-	}
-
-	if errWithReason := r.driftDetector.ResolveClusterIdSecretDrift(ctx, requiredSecret); errWithReason != nil {
-		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.Reason, errWithReason.Message)
-	}
-
-	if err := r.moduleResourceManager.DeleteOutdatedResources(ctx); err != nil {
-		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, conditions.ProvisioningFailed, err.Error())
-	}
-
-	if err := r.reconcileResources(ctx, cr, requiredSecret); err != nil {
-		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, conditions.ProvisioningFailed, err.Error())
-	}
-
-	if err := r.driftDetector.DeleteChangedResources(ctx); err != nil {
-		logger.Error(err, "while deleting resources")
-		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, conditions.ResourceRemovalFailed, err.Error())
-	}
-
-	r.instanceBindingService.EnableSISBController()
-
-	logger.Info("provisioning succeeded")
 	return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateReady, conditions.ReconcileSucceeded, "Module provisioning succeeded")
 }
 
@@ -358,163 +331,11 @@ func (r *BtpOperatorReconciler) handleMissingSecret(ctx context.Context, cr *v1a
 }
 
 func (r *BtpOperatorReconciler) getAndVerifyRequiredSecret(ctx context.Context) (*corev1.Secret, *ErrorWithReason) {
-	logger := log.FromContext(ctx)
-
-	logger.Info("getting the required Secret")
-	secret, err := r.getRequiredSecret(ctx)
-	if err != nil {
-		logger.Error(err, "while getting the required Secret")
-		return nil, NewErrorWithReason(conditions.MissingSecret, "Secret resource not found")
-	}
-
-	logger.Info("verifying the required Secret")
-	if err = r.verifySecret(secret); err != nil {
-		logger.Error(err, "while verifying the required Secret")
-		return nil, NewErrorWithReason(conditions.InvalidSecret, "Secret validation failed")
-	}
-	return secret, nil
-}
-
-func (r *BtpOperatorReconciler) getRequiredSecret(ctx context.Context) (*corev1.Secret, error) {
-	secret := &corev1.Secret{}
-	objKey := client.ObjectKey{Namespace: config.ChartNamespace, Name: config.SecretName}
-	if err := r.Get(ctx, objKey, secret); err != nil {
-		if k8serrors.IsNotFound(err) {
-			return nil, fmt.Errorf("%s Secret in %s namespace not found", config.SecretName, config.ChartNamespace)
-		}
-		return nil, fmt.Errorf("unable to get Secret: %w", err)
-	}
-
-	return secret, nil
-}
-
-func (r *BtpOperatorReconciler) verifySecret(secret *corev1.Secret) error {
-	missingKeys := make([]string, 0)
-	missingValues := make([]string, 0)
-	errs := make([]string, 0)
-	requiredKeys := []string{"clientid", "clientsecret", "sm_url", "tokenurl", "cluster_id"}
-	for _, key := range requiredKeys {
-		value, exists := secret.Data[key]
-		if !exists {
-			missingKeys = append(missingKeys, key)
-			continue
-		}
-		if len(value) == 0 {
-			missingValues = append(missingValues, key)
-		}
-	}
-	if len(missingKeys) > 0 {
-		missingKeysMsg := fmt.Sprintf("key(s) %s not found", strings.Join(missingKeys, ", "))
-		errs = append(errs, missingKeysMsg)
-	}
-	if len(missingValues) > 0 {
-		missingValuesMsg := fmt.Sprintf("missing value(s) for %s key(s)", strings.Join(missingValues, ", "))
-		errs = append(errs, missingValuesMsg)
-	}
-	if len(errs) > 0 {
-		return fmt.Errorf("%s", strings.Join(errs, ", "))
-	}
-	return nil
-}
-
-func (r *BtpOperatorReconciler) createUnstructuredObjectsFromManifestsDir(manifestsDir string) ([]*unstructured.Unstructured, error) {
-	return r.moduleResourceManager.CreateUnstructuredObjectsFromManifestsDir(manifestsDir)
-}
-
-func (r *BtpOperatorReconciler) getResourcesToDeletePath() string {
-	return r.moduleResourceManager.GetResourcesToDeletePath()
-}
-
-func (r *BtpOperatorReconciler) addNetworkPoliciesToResources(ctx context.Context, resourcesToApply *[]*unstructured.Unstructured) error {
-	if r.networkPolicyManager == nil {
-		return nil
-	}
-	logger := log.FromContext(ctx)
-	networkPolicies, err := r.networkPolicyManager.LoadNetworkPolicies()
-	if err != nil {
-		logger.Error(err, "while loading network policies")
-		return fmt.Errorf("failed to load network policies: %w", err)
-	}
-	*resourcesToApply = append(*resourcesToApply, networkPolicies...)
-	logger.Info(fmt.Sprintf("added %d network policies to resources to apply", len(networkPolicies)))
-
-	return nil
+	return r.provisioningHandler.GetAndVerifyRequiredSecret(ctx)
 }
 
 func (r *BtpOperatorReconciler) reconcileResources(ctx context.Context, cr *v1alpha1.BtpOperator, s *corev1.Secret) error {
-	logger := log.FromContext(ctx)
-
-	logger.Info("getting module resources to apply")
-	resourcesToApply, err := r.createUnstructuredObjectsFromManifestsDir(r.getResourcesToApplyPath())
-	if err != nil {
-		logger.Error(err, "while creating applicable objects from manifests")
-		return fmt.Errorf("failed to create applicable objects from manifests: %w", err)
-	}
-	logger.Info(fmt.Sprintf("got %d module resources to apply based on %s directory", len(resourcesToApply), r.getResourcesToApplyPath()))
-
-	if cr.IsNetworkPoliciesDisabled() {
-		logger.Info("network policies disabled, cleaning up existing ones")
-		if err := r.cleanupNetworkPolicies(ctx); err != nil {
-			logger.Error(err, "while cleaning up network policies")
-			return fmt.Errorf("failed to cleanup network policies: %w", err)
-		}
-	} else {
-		logger.Info("network policies enabled, loading and adding them to resources")
-		if err := r.addNetworkPoliciesToResources(ctx, &resourcesToApply); err != nil {
-			return err
-		}
-	}
-	if err := r.deleteOldWebhookNetworkPolicy(ctx); err != nil {
-		logger.Error(err, "while deleting old webhook network policy")
-		return fmt.Errorf("failed to delete old webhook network policy: %w", err)
-	}
-
-	if err = r.moduleResourceManager.PrepareModuleResources(ctx, resourcesToApply, s); err != nil {
-		logger.Error(err, "while preparing objects to apply")
-		return fmt.Errorf("failed to prepare objects to apply: %w", err)
-	}
-
-	webhookResources, nonWebhookResources := certificate.PartitionWebhooks(resourcesToApply)
-	preparedWebhooks, err := r.certManager.PrepareAdmissionWebhooks(ctx, webhookResources)
-	if err != nil {
-		logger.Error(err, "while preparing admission webhooks")
-		return fmt.Errorf("failed to prepare admission webhooks: %w", err)
-	}
-	resourcesToApply = append(nonWebhookResources, preparedWebhooks...)
-
-	r.moduleResourceManager.DeleteCreationTimestamp(resourcesToApply...)
-
-	logger.Info(fmt.Sprintf("applying module resources for %d resources", len(resourcesToApply)))
-	if err = r.moduleResourceManager.ApplyOrUpdateResources(ctx, resourcesToApply); err != nil {
-		logger.Error(err, "while applying module resources")
-		return fmt.Errorf("failed to apply module resources: %w", err)
-	}
-
-	logger.Info("waiting for module resources readiness")
-	if err = r.moduleResourceManager.WaitForResourcesReadiness(ctx, resourcesToApply); err != nil {
-		logger.Error(err, "while waiting for module resources readiness")
-		return fmt.Errorf("timed out while waiting for resources readiness: %w", err)
-	}
-
-	return nil
-}
-
-func (r *BtpOperatorReconciler) getResourcesToApplyPath() string {
-	return r.moduleResourceManager.GetResourcesToApplyPath()
-}
-
-func (r *BtpOperatorReconciler) cleanupNetworkPolicies(ctx context.Context) error {
-	if r.networkPolicyManager == nil {
-		return nil
-	}
-	return r.networkPolicyManager.CleanupNetworkPolicies(ctx)
-}
-
-func (r *BtpOperatorReconciler) deleteOldWebhookNetworkPolicy(ctx context.Context) error {
-	if r.networkPolicyManager == nil {
-		return nil
-	}
-	return r.networkPolicyManager.DeleteOldWebhookNetworkPolicy(ctx)
+	return r.provisioningHandler.ReconcileResources(ctx, cr, s)
 }
 
 func (r *BtpOperatorReconciler) HandleWarningState(ctx context.Context, cr *v1alpha1.BtpOperator) (ctrl.Result, error) {
@@ -836,14 +657,14 @@ func (r *BtpOperatorReconciler) deleteBtpOperatorResources(ctx context.Context) 
 	logger := log.FromContext(ctx)
 
 	logger.Info("getting module resources to delete")
-	resourcesToDeleteFromApply, err := r.createUnstructuredObjectsFromManifestsDir(r.getResourcesToApplyPath())
+	resourcesToDeleteFromApply, err := r.moduleResourceManager.CreateUnstructuredObjectsFromManifestsDir(r.moduleResourceManager.GetResourcesToApplyPath())
 	if err != nil {
 		logger.Error(err, "while getting objects to delete from manifests")
 		return fmt.Errorf("Failed to create deletable objects from manifests: %w", err)
 	}
 	logger.Info(fmt.Sprintf("got %d module resources to delete from \"apply\" dir", len(resourcesToDeleteFromApply)))
 
-	resourcesToDeleteFromDelete, err := r.createUnstructuredObjectsFromManifestsDir(r.getResourcesToDeletePath())
+	resourcesToDeleteFromDelete, err := r.moduleResourceManager.CreateUnstructuredObjectsFromManifestsDir(r.moduleResourceManager.GetResourcesToDeletePath())
 	if err != nil {
 		logger.Error(err, "while getting objects to delete from manifests")
 		return fmt.Errorf("Failed to create deletable objects from manifests: %w", err)
@@ -859,7 +680,7 @@ func (r *BtpOperatorReconciler) deleteBtpOperatorResources(ctx context.Context) 
 		return fmt.Errorf("failed to delete module resources: %w", err)
 	}
 
-	if err := r.cleanupNetworkPolicies(ctx); err != nil {
+	if err := r.networkPolicyManager.CleanupNetworkPolicies(ctx); err != nil {
 		logger.Error(err, "while cleaning up network policies during hard delete")
 		return fmt.Errorf("failed to cleanup network policies during hard delete: %w", err)
 	}
@@ -959,7 +780,7 @@ func (r *BtpOperatorReconciler) preSoftDeleteCleanup(ctx context.Context) error 
 		}
 	}
 
-	if err := r.cleanupNetworkPolicies(ctx); err != nil {
+	if err := r.networkPolicyManager.CleanupNetworkPolicies(ctx); err != nil {
 		return fmt.Errorf("failed to cleanup network policies during soft delete: %w", err)
 	}
 
@@ -1380,16 +1201,7 @@ func (r *BtpOperatorReconciler) getSecretDataValueByKey(key string, data map[str
 }
 
 func (r *BtpOperatorReconciler) reconcileResourcesWithoutChangingCrState(ctx context.Context, cr *v1alpha1.BtpOperator, logger *logr.Logger) {
-	secret, errWithReason := r.getAndVerifyRequiredSecret(ctx)
-	if errWithReason != nil {
-		logger.Error(errWithReason, "secret verification failed")
-	}
-	if err := r.moduleResourceManager.DeleteOutdatedResources(ctx); err != nil {
-		logger.Error(err, "outdated resources deletion failed")
-	}
-	if err := r.reconcileResources(ctx, cr, secret); err != nil {
-		logger.Error(err, "resources reconciliation failed")
-	}
+	r.provisioningHandler.ReconcileResourcesWithoutStatusChange(ctx, cr)
 }
 
 func (r *BtpOperatorReconciler) isManagedSecret(s *corev1.Secret) bool {

--- a/controllers/btpoperator_controller_network_policies_test.go
+++ b/controllers/btpoperator_controller_network_policies_test.go
@@ -74,7 +74,7 @@ var _ = Describe("BTP Operator Network Policies", func() {
 			btpOperator = &v1alpha1.BtpOperator{}
 			btpOperator.Name = "test-btpoperator"
 			btpOperator.Namespace = "kyma-system"
-			Expect(reconciler.cleanupNetworkPolicies(ctx)).To(Succeed())
+			Expect(reconciler.networkPolicyManager.CleanupNetworkPolicies(ctx)).To(Succeed())
 		})
 
 		It("Should load and prepare network policies", func() {
@@ -105,7 +105,7 @@ var _ = Describe("BTP Operator Network Policies", func() {
 				})
 				Expect(k8sClient.Create(ctx, policy)).To(Succeed())
 			}
-			err := reconciler.cleanupNetworkPolicies(ctx)
+			err := reconciler.networkPolicyManager.CleanupNetworkPolicies(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			for _, name := range expectedPolicyNames {
 				_, getErr := getNetworkPolicy(ctx, name, "kyma-system")
@@ -149,7 +149,7 @@ var _ = Describe("BTP Operator Network Policies", func() {
 				Client:               k8sClient,
 				networkPolicyManager: npMgr,
 			}
-			err := reconciler.cleanupNetworkPolicies(context.Background())
+			err := reconciler.networkPolicyManager.CleanupNetworkPolicies(context.Background())
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -165,7 +165,7 @@ var _ = Describe("BTP Operator Network Policies", func() {
 				kymaProjectModuleLabelKey: moduleName,
 			})
 			Expect(k8sClient.Create(context.Background(), testPolicy)).To(Succeed())
-			err := reconciler.cleanupNetworkPolicies(context.Background())
+			err := reconciler.networkPolicyManager.CleanupNetworkPolicies(context.Background())
 			Expect(err).NotTo(HaveOccurred())
 			_, getErr := getNetworkPolicy(context.Background(), "test-cleanup-policy", "kyma-system")
 			Expect(getErr).To(HaveOccurred())
@@ -179,7 +179,7 @@ var _ = Describe("BTP Operator Network Policies", func() {
 			}
 			testPolicy := createMockNetworkPolicy("test-unmanaged-policy")
 			Expect(k8sClient.Create(context.Background(), testPolicy)).To(Succeed())
-			err := reconciler.cleanupNetworkPolicies(context.Background())
+			err := reconciler.networkPolicyManager.CleanupNetworkPolicies(context.Background())
 			Expect(err).NotTo(HaveOccurred())
 			_, getErr := getNetworkPolicy(context.Background(), "test-unmanaged-policy", "kyma-system")
 			Expect(getErr).NotTo(HaveOccurred())
@@ -338,7 +338,7 @@ var _ = Describe("BTP Operator Network Policies", func() {
 			Expect(k8sClient.Create(context.Background(), oldPolicy)).To(Succeed())
 			_, err := getNetworkPolicy(context.Background(), "kyma-project.io--btp-operator-allow-to-webhook", "kyma-system")
 			Expect(err).NotTo(HaveOccurred())
-			err = reconciler.deleteOldWebhookNetworkPolicy(context.Background())
+			err = reconciler.networkPolicyManager.DeleteOldWebhookNetworkPolicy(context.Background())
 			Expect(err).NotTo(HaveOccurred())
 			_, err = getNetworkPolicy(context.Background(), "kyma-project.io--btp-operator-allow-to-webhook", "kyma-system")
 			Expect(err).To(HaveOccurred())

--- a/controllers/btpoperator_controller_provisioning_test.go
+++ b/controllers/btpoperator_controller_provisioning_test.go
@@ -55,7 +55,7 @@ var _ = Describe("BTP Operator controller - provisioning", func() {
 				secret, err := createSecretWithoutKeys()
 				Expect(err).To(BeNil())
 				Expect(k8sClient.Create(ctx, secret)).To(Succeed())
-				Eventually(updateCh).Should(Receive(matchReadyCondition(v1alpha1.StateWarning, metav1.ConditionFalse, conditions.InvalidSecret)))
+				Eventually(updateCh).Should(Receive(matchReadyCondition(v1alpha1.StateError, metav1.ConditionFalse, conditions.InvalidSecret)))
 			})
 		})
 
@@ -64,7 +64,7 @@ var _ = Describe("BTP Operator controller - provisioning", func() {
 				secret, err := createSecretWithoutValues()
 				Expect(err).To(BeNil())
 				Expect(k8sClient.Create(ctx, secret)).To(Succeed())
-				Eventually(updateCh).Should(Receive(matchReadyCondition(v1alpha1.StateWarning, metav1.ConditionFalse, conditions.InvalidSecret)))
+				Eventually(updateCh).Should(Receive(matchReadyCondition(v1alpha1.StateError, metav1.ConditionFalse, conditions.InvalidSecret)))
 			})
 		})
 

--- a/controllers/btpoperator_controller_test.go
+++ b/controllers/btpoperator_controller_test.go
@@ -34,7 +34,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should return error from client.Get", func(t *testing.T) {
 		// given
 		retryK8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil)
+		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil, nil)
 		retryK8sClient.EnableErrorOnGet()
 
 		// when
@@ -57,7 +57,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should return error from client.Update", func(t *testing.T) {
 		// given
 		retryK8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil)
+		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil, nil)
 		retryK8sClient.EnableErrorOnUpdate()
 
 		// when
@@ -80,7 +80,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should time out", func(t *testing.T) {
 		// given
 		disabledUpdatek8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(disabledUpdatek8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil)
+		btpOperatorReconciler := NewBtpOperatorReconciler(disabledUpdatek8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil, nil)
 		disabledUpdatek8sClient.DisableUpdate()
 
 		// when
@@ -102,7 +102,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should update BtpOperator status after a few retries", func(t *testing.T) {
 		// given
 		retryK8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil)
+		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil, nil)
 
 		// when
 		err := btpOperatorReconciler.UpdateBtpOperatorStatus(ctx, btpOperator, v1alpha1.StateProcessing, conditions.Initialized, "test")
@@ -124,7 +124,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should update BtpOperator status three times", func(t *testing.T) {
 		// given
 		retryK8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil)
+		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil, nil)
 		conditionMsg1 := "test1"
 		conditionMsg2 := "test2"
 		conditionMsg3 := "test3"

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/kyma-project/btp-manager/internal/manager/moduleresource"
 	"github.com/kyma-project/btp-manager/internal/manifest"
 	btpmanagermetrics "github.com/kyma-project/btp-manager/internal/metrics"
+	"github.com/kyma-project/btp-manager/internal/provisioning"
 	"github.com/kyma-project/btp-manager/internal/webhook/certificate"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -193,6 +194,7 @@ var _ = SynchronizedBeforeSuite(func() {
 	moduleResourceManager := moduleresource.NewManager(k8sManager.GetClient(), k8sManager.GetScheme(), driftDetector)
 	secretsManager := secrets.NewManager(generic.NewObjectManager[*corev1.Secret, *corev1.SecretList](k8sManager.GetClient()))
 	certManager := certificate.NewManager(secretsManager, metrics)
+	provisioningHandler := provisioning.NewHandler(k8sManager.GetClient(), driftDetector, moduleResourceManager, networkPolicyManager, certManager, cleanupReconciler)
 	reconciler = NewBtpOperatorReconciler(
 		k8sManager.GetClient(),
 		k8sClient,
@@ -206,6 +208,7 @@ var _ = SynchronizedBeforeSuite(func() {
 		driftDetector,
 		moduleResourceManager,
 		certManager,
+		provisioningHandler,
 	)
 
 	k8sClientFromManager = k8sManager.GetClient()

--- a/internal/provisioning/handler.go
+++ b/internal/provisioning/handler.go
@@ -74,6 +74,9 @@ func (h *handler) Provision(ctx context.Context, cr *v1alpha1.BtpOperator) Provi
 	requiredSecret, errWithReason := h.GetAndVerifyRequiredSecret(ctx)
 	if errWithReason != nil {
 		logger.Info("secret verification failed: " + errWithReason.Error())
+		if errWithReason.Reason == conditions.InvalidSecret {
+			return ProvisionResult{ErrorReason: errWithReason}
+		}
 		return ProvisionResult{WarningReason: errWithReason}
 	}
 

--- a/internal/provisioning/handler.go
+++ b/internal/provisioning/handler.go
@@ -1,0 +1,269 @@
+package provisioning
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kyma-project/btp-manager/api/v1alpha1"
+	"github.com/kyma-project/btp-manager/controllers/config"
+	"github.com/kyma-project/btp-manager/internal/conditions"
+	"github.com/kyma-project/btp-manager/internal/credentials/drift"
+	"github.com/kyma-project/btp-manager/internal/k8s/networkpolicy"
+	"github.com/kyma-project/btp-manager/internal/manager/moduleresource"
+	"github.com/kyma-project/btp-manager/internal/webhook/certificate"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// InstanceBindingService controls the ServiceInstance/ServiceBinding cleanup controller lifecycle.
+type InstanceBindingService interface {
+	EnableSISBController()
+}
+
+// ProvisionResult communicates the outcome of Provision to the caller.
+// Both fields nil means success.
+type ProvisionResult struct {
+	WarningReason *conditions.ErrorWithReason
+	ErrorReason   *conditions.ErrorWithReason
+}
+
+// Handler runs the provisioning flow and exposes helpers used by the Ready state path.
+type Handler interface {
+	Provision(ctx context.Context, cr *v1alpha1.BtpOperator) ProvisionResult
+	GetAndVerifyRequiredSecret(ctx context.Context) (*corev1.Secret, *conditions.ErrorWithReason)
+	ReconcileResources(ctx context.Context, cr *v1alpha1.BtpOperator, secret *corev1.Secret) error
+	ReconcileResourcesWithoutStatusChange(ctx context.Context, cr *v1alpha1.BtpOperator)
+}
+
+type handler struct {
+	client                 client.Client
+	driftDetector          drift.Detector
+	moduleResourceManager  moduleresource.ResourceManager
+	networkPolicyManager   networkpolicy.NetworkPolicyManager
+	certManager            certificate.CertificateManager
+	instanceBindingService InstanceBindingService
+}
+
+func NewHandler(
+	c client.Client,
+	driftDetector drift.Detector,
+	moduleResourceManager moduleresource.ResourceManager,
+	networkPolicyManager networkpolicy.NetworkPolicyManager,
+	certManager certificate.CertificateManager,
+	instanceBindingService InstanceBindingService,
+) Handler {
+	return &handler{
+		client:                 c,
+		driftDetector:          driftDetector,
+		moduleResourceManager:  moduleResourceManager,
+		networkPolicyManager:   networkPolicyManager,
+		certManager:            certManager,
+		instanceBindingService: instanceBindingService,
+	}
+}
+
+var _ Handler = (*handler)(nil)
+
+func (h *handler) Provision(ctx context.Context, cr *v1alpha1.BtpOperator) ProvisionResult {
+	logger := log.FromContext(ctx)
+
+	requiredSecret, errWithReason := h.GetAndVerifyRequiredSecret(ctx)
+	if errWithReason != nil {
+		logger.Info("secret verification failed: " + errWithReason.Error())
+		return ProvisionResult{WarningReason: errWithReason}
+	}
+
+	h.driftDetector.InitializeFromSecret(requiredSecret)
+
+	if errWithReason := h.driftDetector.CheckCredentialsNamespaceDrift(ctx, requiredSecret); errWithReason != nil {
+		return ProvisionResult{ErrorReason: errWithReason}
+	}
+
+	if errWithReason := h.driftDetector.CheckClusterIdConfigMapDrift(ctx, requiredSecret); errWithReason != nil {
+		return ProvisionResult{ErrorReason: errWithReason}
+	}
+
+	if errWithReason := h.driftDetector.ResolveClusterIdSecretDrift(ctx, requiredSecret); errWithReason != nil {
+		return ProvisionResult{ErrorReason: errWithReason}
+	}
+
+	if err := h.moduleResourceManager.DeleteOutdatedResources(ctx); err != nil {
+		return ProvisionResult{ErrorReason: conditions.NewErrorWithReason(conditions.ProvisioningFailed, err.Error())}
+	}
+
+	if err := h.ReconcileResources(ctx, cr, requiredSecret); err != nil {
+		return ProvisionResult{ErrorReason: conditions.NewErrorWithReason(conditions.ProvisioningFailed, err.Error())}
+	}
+
+	if err := h.driftDetector.DeleteChangedResources(ctx); err != nil {
+		logger.Error(err, "while deleting resources")
+		return ProvisionResult{ErrorReason: conditions.NewErrorWithReason(conditions.ResourceRemovalFailed, err.Error())}
+	}
+
+	h.instanceBindingService.EnableSISBController()
+	logger.Info("provisioning succeeded")
+	return ProvisionResult{}
+}
+
+func (h *handler) GetAndVerifyRequiredSecret(ctx context.Context) (*corev1.Secret, *conditions.ErrorWithReason) {
+	logger := log.FromContext(ctx)
+
+	logger.Info("getting the required Secret")
+	secret, err := h.getRequiredSecret(ctx)
+	if err != nil {
+		logger.Error(err, "while getting the required Secret")
+		return nil, conditions.NewErrorWithReason(conditions.MissingSecret, "Secret resource not found")
+	}
+
+	logger.Info("verifying the required Secret")
+	if err = verifySecret(secret); err != nil {
+		logger.Error(err, "while verifying the required Secret")
+		return nil, conditions.NewErrorWithReason(conditions.InvalidSecret, "Secret validation failed")
+	}
+	return secret, nil
+}
+
+func (h *handler) getRequiredSecret(ctx context.Context) (*corev1.Secret, error) {
+	secret := &corev1.Secret{}
+	objKey := client.ObjectKey{Namespace: config.ChartNamespace, Name: config.SecretName}
+	if err := h.client.Get(ctx, objKey, secret); err != nil {
+		if k8serrors.IsNotFound(err) {
+			return nil, fmt.Errorf("%s Secret in %s namespace not found", config.SecretName, config.ChartNamespace)
+		}
+		return nil, fmt.Errorf("unable to get Secret: %w", err)
+	}
+	return secret, nil
+}
+
+func (h *handler) ReconcileResources(ctx context.Context, cr *v1alpha1.BtpOperator, s *corev1.Secret) error {
+	logger := log.FromContext(ctx)
+
+	logger.Info("getting module resources to apply")
+	resourcesToApply, err := h.moduleResourceManager.CreateUnstructuredObjectsFromManifestsDir(h.moduleResourceManager.GetResourcesToApplyPath())
+	if err != nil {
+		logger.Error(err, "while creating applicable objects from manifests")
+		return fmt.Errorf("failed to create applicable objects from manifests: %w", err)
+	}
+	logger.Info(fmt.Sprintf("got %d module resources to apply based on %s directory", len(resourcesToApply), h.moduleResourceManager.GetResourcesToApplyPath()))
+
+	if cr.IsNetworkPoliciesDisabled() {
+		logger.Info("network policies disabled, cleaning up existing ones")
+		if err := h.cleanupNetworkPolicies(ctx); err != nil {
+			logger.Error(err, "while cleaning up network policies")
+			return fmt.Errorf("failed to cleanup network policies: %w", err)
+		}
+	} else {
+		logger.Info("network policies enabled, loading and adding them to resources")
+		if err := h.addNetworkPoliciesToResources(ctx, &resourcesToApply); err != nil {
+			return err
+		}
+	}
+
+	if err := h.deleteOldWebhookNetworkPolicy(ctx); err != nil {
+		logger.Error(err, "while deleting old webhook network policy")
+		return fmt.Errorf("failed to delete old webhook network policy: %w", err)
+	}
+
+	if err = h.moduleResourceManager.PrepareModuleResources(ctx, resourcesToApply, s); err != nil {
+		logger.Error(err, "while preparing objects to apply")
+		return fmt.Errorf("failed to prepare objects to apply: %w", err)
+	}
+
+	webhookResources, nonWebhookResources := certificate.PartitionWebhooks(resourcesToApply)
+	preparedWebhooks, err := h.certManager.PrepareAdmissionWebhooks(ctx, webhookResources)
+	if err != nil {
+		logger.Error(err, "while preparing admission webhooks")
+		return fmt.Errorf("failed to prepare admission webhooks: %w", err)
+	}
+	resourcesToApply = append(nonWebhookResources, preparedWebhooks...)
+
+	h.moduleResourceManager.DeleteCreationTimestamp(resourcesToApply...)
+
+	logger.Info(fmt.Sprintf("applying module resources for %d resources", len(resourcesToApply)))
+	if err = h.moduleResourceManager.ApplyOrUpdateResources(ctx, resourcesToApply); err != nil {
+		logger.Error(err, "while applying module resources")
+		return fmt.Errorf("failed to apply module resources: %w", err)
+	}
+
+	logger.Info("waiting for module resources readiness")
+	if err = h.moduleResourceManager.WaitForResourcesReadiness(ctx, resourcesToApply); err != nil {
+		logger.Error(err, "while waiting for module resources readiness")
+		return fmt.Errorf("timed out while waiting for resources readiness: %w", err)
+	}
+
+	return nil
+}
+
+func (h *handler) ReconcileResourcesWithoutStatusChange(ctx context.Context, cr *v1alpha1.BtpOperator) {
+	logger := log.FromContext(ctx)
+	secret, errWithReason := h.GetAndVerifyRequiredSecret(ctx)
+	if errWithReason != nil {
+		logger.Error(errWithReason, "secret verification failed")
+	}
+	if err := h.moduleResourceManager.DeleteOutdatedResources(ctx); err != nil {
+		logger.Error(err, "outdated resources deletion failed")
+	}
+	if err := h.ReconcileResources(ctx, cr, secret); err != nil {
+		logger.Error(err, "resources reconciliation failed")
+	}
+}
+
+func (h *handler) addNetworkPoliciesToResources(ctx context.Context, resourcesToApply *[]*unstructured.Unstructured) error {
+	if h.networkPolicyManager == nil {
+		return nil
+	}
+	logger := log.FromContext(ctx)
+	networkPolicies, err := h.networkPolicyManager.LoadNetworkPolicies()
+	if err != nil {
+		logger.Error(err, "while loading network policies")
+		return fmt.Errorf("failed to load network policies: %w", err)
+	}
+	*resourcesToApply = append(*resourcesToApply, networkPolicies...)
+	logger.Info(fmt.Sprintf("added %d network policies to resources to apply", len(networkPolicies)))
+	return nil
+}
+
+func (h *handler) cleanupNetworkPolicies(ctx context.Context) error {
+	if h.networkPolicyManager == nil {
+		return nil
+	}
+	return h.networkPolicyManager.CleanupNetworkPolicies(ctx)
+}
+
+func (h *handler) deleteOldWebhookNetworkPolicy(ctx context.Context) error {
+	if h.networkPolicyManager == nil {
+		return nil
+	}
+	return h.networkPolicyManager.DeleteOldWebhookNetworkPolicy(ctx)
+}
+
+func verifySecret(secret *corev1.Secret) error {
+	missingKeys := make([]string, 0)
+	missingValues := make([]string, 0)
+	errs := make([]string, 0)
+	requiredKeys := []string{"clientid", "clientsecret", "sm_url", "tokenurl", "cluster_id"}
+	for _, key := range requiredKeys {
+		value, exists := secret.Data[key]
+		if !exists {
+			missingKeys = append(missingKeys, key)
+			continue
+		}
+		if len(value) == 0 {
+			missingValues = append(missingValues, key)
+		}
+	}
+	if len(missingKeys) > 0 {
+		errs = append(errs, fmt.Sprintf("key(s) %s not found", strings.Join(missingKeys, ", ")))
+	}
+	if len(missingValues) > 0 {
+		errs = append(errs, fmt.Sprintf("missing value(s) for %s key(s)", strings.Join(missingValues, ", ")))
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("%s", strings.Join(errs, ", "))
+	}
+	return nil
+}

--- a/internal/provisioning/handler.go
+++ b/internal/provisioning/handler.go
@@ -2,6 +2,7 @@ package provisioning
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -112,6 +113,8 @@ func (h *handler) Provision(ctx context.Context, cr *v1alpha1.BtpOperator) Provi
 	return ProvisionResult{}
 }
 
+var errSecretNotFound = fmt.Errorf("%s Secret in %s namespace not found", config.SecretName, config.ChartNamespace)
+
 func (h *handler) GetAndVerifyRequiredSecret(ctx context.Context) (*corev1.Secret, *conditions.ErrorWithReason) {
 	logger := log.FromContext(ctx)
 
@@ -119,13 +122,16 @@ func (h *handler) GetAndVerifyRequiredSecret(ctx context.Context) (*corev1.Secre
 	secret, err := h.getRequiredSecret(ctx)
 	if err != nil {
 		logger.Error(err, "while getting the required Secret")
-		return nil, conditions.NewErrorWithReason(conditions.MissingSecret, "Secret resource not found")
+		if errors.Is(err, errSecretNotFound) {
+			return nil, conditions.NewErrorWithReason(conditions.MissingSecret, err.Error())
+		}
+		return nil, conditions.NewErrorWithReason(conditions.InvalidSecret, err.Error())
 	}
 
 	logger.Info("verifying the required Secret")
 	if err = verifySecret(secret); err != nil {
 		logger.Error(err, "while verifying the required Secret")
-		return nil, conditions.NewErrorWithReason(conditions.InvalidSecret, "Secret validation failed")
+		return nil, conditions.NewErrorWithReason(conditions.InvalidSecret, err.Error())
 	}
 	return secret, nil
 }
@@ -135,7 +141,7 @@ func (h *handler) getRequiredSecret(ctx context.Context) (*corev1.Secret, error)
 	objKey := client.ObjectKey{Namespace: config.ChartNamespace, Name: config.SecretName}
 	if err := h.client.Get(ctx, objKey, secret); err != nil {
 		if k8serrors.IsNotFound(err) {
-			return nil, fmt.Errorf("%s Secret in %s namespace not found", config.SecretName, config.ChartNamespace)
+			return nil, errSecretNotFound
 		}
 		return nil, fmt.Errorf("unable to get Secret: %w", err)
 	}

--- a/internal/provisioning/handler.go
+++ b/internal/provisioning/handler.go
@@ -203,6 +203,7 @@ func (h *handler) ReconcileResourcesWithoutStatusChange(ctx context.Context, cr 
 	secret, errWithReason := h.GetAndVerifyRequiredSecret(ctx)
 	if errWithReason != nil {
 		logger.Error(errWithReason, "secret verification failed")
+		return
 	}
 	if err := h.moduleResourceManager.DeleteOutdatedResources(ctx); err != nil {
 		logger.Error(err, "outdated resources deletion failed")

--- a/internal/provisioning/handler_test.go
+++ b/internal/provisioning/handler_test.go
@@ -1,0 +1,48 @@
+package provisioning
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestVerifySecret_AllKeysPresent(t *testing.T) {
+	s := &corev1.Secret{
+		Data: map[string][]byte{
+			"clientid":     []byte("id"),
+			"clientsecret": []byte("secret"),
+			"sm_url":       []byte("url"),
+			"tokenurl":     []byte("turl"),
+			"cluster_id":   []byte("cid"),
+		},
+	}
+	if err := verifySecret(s); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+}
+
+func TestVerifySecret_MissingKey(t *testing.T) {
+	s := &corev1.Secret{
+		Data: map[string][]byte{
+			"clientid": []byte("id"),
+		},
+	}
+	if err := verifySecret(s); err == nil {
+		t.Fatal("expected error for missing keys, got nil")
+	}
+}
+
+func TestVerifySecret_EmptyValue(t *testing.T) {
+	s := &corev1.Secret{
+		Data: map[string][]byte{
+			"clientid":     []byte(""),
+			"clientsecret": []byte("s"),
+			"sm_url":       []byte("u"),
+			"tokenurl":     []byte("t"),
+			"cluster_id":   []byte("c"),
+		},
+	}
+	if err := verifySecret(s); err == nil {
+		t.Fatal("expected error for empty value, got nil")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ import (
 	"github.com/kyma-project/btp-manager/internal/manager/moduleresource"
 	"github.com/kyma-project/btp-manager/internal/manifest"
 	btpmanagermetrics "github.com/kyma-project/btp-manager/internal/metrics"
+	"github.com/kyma-project/btp-manager/internal/provisioning"
 	"github.com/kyma-project/btp-manager/internal/webhook/certificate"
 	//+kubebuilder:scaffold:imports
 )
@@ -141,6 +142,7 @@ func main() {
 	moduleResourceManager := moduleresource.NewManager(mgr.GetClient(), scheme, driftDetector)
 	secretsManager := secrets.NewManager(generic.NewObjectManager[*corev1.Secret, *corev1.SecretList](mgr.GetClient()))
 	certManager := certificate.NewManager(secretsManager, webhookMetrics)
+	provisioningHandler := provisioning.NewHandler(mgr.GetClient(), driftDetector, moduleResourceManager, networkPolicyManager, certManager, cleanupReconciler)
 	reconciler := controllers.NewBtpOperatorReconciler(
 		mgr.GetClient(),
 		apiServerClient,
@@ -154,6 +156,7 @@ func main() {
 		driftDetector,
 		moduleResourceManager,
 		certManager,
+		provisioningHandler,
 	)
 
 	if err = reconciler.SetupWithManager(mgr); err != nil {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `internal/provisioning` package with `Handler` interface and `handler` struct
- Move provisioning logic out of `BtpOperatorReconciler`: secret fetch/validation, drift checks, resource reconciliation, network policy helpers
- Replace `HandleProcessingState` body with a delegation to `provisioningHandler.Provision()`
- Expose `GetAndVerifyRequiredSecret` and `ReconcileResources` on the handler interface for reuse by the Ready state path
- Inject `provisioning.Handler` into `BtpOperatorReconciler` via constructor and wire it in `main.go`
- Add unit tests for `verifySecret` in `internal/provisioning/handler_test.go`

**Related issue(s)**
See also #1313