### PR TITLE
Move Cert Helper Methods From Reconciler Into CertificateManager

### DIFF
--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -26,7 +26,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/kyma-project/btp-manager/api/v1alpha1"
 	"github.com/kyma-project/btp-manager/controllers/config"
-	"github.com/kyma-project/btp-manager/internal/certs"
 	"github.com/kyma-project/btp-manager/internal/conditions"
 	"github.com/kyma-project/btp-manager/internal/credentials/drift"
 	"github.com/kyma-project/btp-manager/internal/deprovisioning"
@@ -684,60 +683,6 @@ func (r *BtpOperatorReconciler) watchMutatingWebhooksPredicates() predicate.Func
 	}
 }
 
-func (r *BtpOperatorReconciler) isWebhookCertSignedBySelfSignedCa(ctx context.Context) (bool, error) {
-	caCertificate, err := r.getCertificateFromSecret(ctx, caCertSecretName)
-	if err != nil {
-		return false, err
-	}
-
-	webhookCertificate, err := r.getCertificateFromSecret(ctx, webhookCertSecretName)
-	if err != nil {
-		return false, err
-	}
-
-	ok, err := certs.VerifyIfLeafIsSignedByGivenCA(caCertificate, webhookCertificate)
-	if err != nil {
-		return false, err
-	}
-
-	return ok, nil
-}
-
-func (r *BtpOperatorReconciler) getDataFromSecret(ctx context.Context, name string) (map[string][]byte, error) {
-	secret := &corev1.Secret{}
-	if err := r.Get(ctx, client.ObjectKey{Namespace: config.ChartNamespace, Name: name}, secret); err != nil {
-		return nil, err
-	}
-	return secret.Data, nil
-}
-
-func (r *BtpOperatorReconciler) getCertificateFromSecret(ctx context.Context, secretName string) ([]byte, error) {
-	data, err := r.getDataFromSecret(ctx, secretName)
-	if err != nil {
-		return nil, err
-	}
-	key, err := certFieldFromSecretBySecretName(secretName)
-	if err != nil {
-		return nil, err
-	}
-	cert, err := r.getSecretDataValueByKey(key, data)
-	if err != nil {
-		return nil, err
-	}
-	return cert, nil
-}
-
-func (r *BtpOperatorReconciler) getSecretDataValueByKey(key string, data map[string][]byte) ([]byte, error) {
-	value, ok := data[key]
-	if !ok {
-		return nil, fmt.Errorf("missing key: %s", key)
-	}
-	if len(value) == 0 {
-		return nil, fmt.Errorf("empty value for key: %s", key)
-	}
-	return value, nil
-}
-
 func (r *BtpOperatorReconciler) isManagedSecret(s *corev1.Secret) bool {
 	return r.isCredentialsSecret(s) || r.isCertSecret(s)
 }
@@ -748,14 +693,4 @@ func (r *BtpOperatorReconciler) isCredentialsSecret(s *corev1.Secret) bool {
 
 func (r *BtpOperatorReconciler) isCertSecret(s *corev1.Secret) bool {
 	return s.Namespace == config.ChartNamespace && (s.Name == caCertSecretName || s.Name == webhookCertSecretName)
-}
-
-func certFieldFromSecretBySecretName(secretName string) (string, error) {
-	switch secretName {
-	case caCertSecretName:
-		return caCertSecretCertField, nil
-	case webhookCertSecretName:
-		return webhookCertSecretCertField, nil
-	}
-	return "", fmt.Errorf("unknown secret %q - cert field undefined", secretName)
 }

--- a/controllers/btpoperator_controller_certificates_test.go
+++ b/controllers/btpoperator_controller_certificates_test.go
@@ -92,7 +92,7 @@ var _ = Describe("BTP Operator controller - certificates", Label("certs"), func(
 
 	ensureCorrectState := func() {
 		ensureReconciliationQueueIsEmpty()
-		ok, err := reconciler.isWebhookCertSignedBySelfSignedCa(ctx)
+		ok, err := reconciler.certManager.IsWebhookCertSignedBySelfSignedCA(ctx)
 		Expect(err).To(BeNil())
 		Expect(ok).To(BeTrue())
 		ensureAllWebhooksManagedByBtpOperatorHaveCorrectCABundles()
@@ -160,12 +160,10 @@ var _ = Describe("BTP Operator controller - certificates", Label("certs"), func(
 			It("CA certificate is not changed, webhook certificate is regenerated", func() {
 				beforeCaSecret := getSecret(caCertSecretName)
 
-				currentCa, err := reconciler.getDataFromSecret(ctx, caCertSecretName)
+				currentCa, err := reconciler.certManager.GetSecretData(ctx, caCertSecretName)
 				Expect(err).To(BeNil())
-				ca, err := reconciler.getSecretDataValueByKey(caCertSecretCertField, currentCa)
-				Expect(err).To(BeNil())
-				pk, err := reconciler.getSecretDataValueByKey(caCertSecretKeyField, currentCa)
-				Expect(err).To(BeNil())
+				ca := currentCa[caCertSecretCertField]
+				pk := currentCa[caCertSecretKeyField]
 				currentWebhookSecret := getSecret(webhookCertSecretName)
 				originalWebhookSecret := currentWebhookSecret
 

--- a/controllers/btpoperator_controller_certificates_test.go
+++ b/controllers/btpoperator_controller_certificates_test.go
@@ -162,8 +162,10 @@ var _ = Describe("BTP Operator controller - certificates", Label("certs"), func(
 
 				currentCa, err := reconciler.certManager.GetSecretData(ctx, caCertSecretName)
 				Expect(err).To(BeNil())
-				ca := currentCa[caCertSecretCertField]
-				pk := currentCa[caCertSecretKeyField]
+				ca, ok := currentCa[caCertSecretCertField]
+				Expect(ok).To(BeTrue(), "ca.crt key missing from CA secret")
+				pk, ok := currentCa[caCertSecretKeyField]
+				Expect(ok).To(BeTrue(), "ca.key key missing from CA secret")
 				currentWebhookSecret := getSecret(webhookCertSecretName)
 				originalWebhookSecret := currentWebhookSecret
 

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -729,12 +729,12 @@ func getConfigMap(name string) *corev1.ConfigMap {
 }
 
 func checkHowManySecondsToExpiration(name string) float64 {
-	data, err := reconciler.getDataFromSecret(ctx, name)
+	data, err := reconciler.certManager.GetSecretData(ctx, name)
 	Expect(err).To(BeNil())
-	key, err := certFieldFromSecretBySecretName(name)
-	Expect(err).To(BeNil())
-	value, err := reconciler.getSecretDataValueByKey(key, data)
-	Expect(err).To(BeNil())
+	value := data[caCertSecretCertField]
+	if name == webhookCertSecretName {
+		value = data[webhookCertSecretCertField]
+	}
 	decoded, _ := pem.Decode(value)
 	cert, err := x509.ParseCertificate(decoded.Bytes)
 	Expect(err).To(BeNil())

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -736,6 +736,7 @@ func checkHowManySecondsToExpiration(name string) float64 {
 		value = data[webhookCertSecretCertField]
 	}
 	decoded, _ := pem.Decode(value)
+	Expect(decoded).NotTo(BeNil(), "pem.Decode returned nil for secret %q", name)
 	cert, err := x509.ParseCertificate(decoded.Bytes)
 	Expect(err).To(BeNil())
 	diff := cert.NotAfter.Sub(time.Now())

--- a/internal/webhook/certificate/manager.go
+++ b/internal/webhook/certificate/manager.go
@@ -48,6 +48,8 @@ func (e CertificateSignError) Error() string {
 
 type CertificateManager interface {
 	PrepareAdmissionWebhooks(ctx context.Context, webhookResources []*unstructured.Unstructured) ([]*unstructured.Unstructured, error)
+	IsWebhookCertSignedBySelfSignedCA(ctx context.Context) (bool, error)
+	GetSecretData(ctx context.Context, name string) (map[string][]byte, error)
 }
 
 // WebhookMetrics is the metrics sink consumed by the certificate manager.
@@ -87,6 +89,36 @@ func NewManager(secretsManager secrets.Manager, webhookMetrics WebhookMetrics) *
 }
 
 var _ CertificateManager = (*Manager)(nil)
+
+func (m *Manager) IsWebhookCertSignedBySelfSignedCA(ctx context.Context) (bool, error) {
+	caSecret, err := m.secretsManager.GetCaServerCertSecret(ctx)
+	if err != nil || caSecret == nil {
+		return false, err
+	}
+	webhookSecret, err := m.secretsManager.GetWebhookServerCertSecret(ctx)
+	if err != nil || webhookSecret == nil {
+		return false, err
+	}
+	return certs.VerifyIfLeafIsSignedByGivenCA(caSecret.Data[caCertSecretCertField], webhookSecret.Data[webhookCertSecretCertField])
+}
+
+func (m *Manager) GetSecretData(ctx context.Context, name string) (map[string][]byte, error) {
+	switch name {
+	case caCertSecretName:
+		s, err := m.secretsManager.GetCaServerCertSecret(ctx)
+		if err != nil || s == nil {
+			return nil, err
+		}
+		return s.Data, nil
+	case webhookCertSecretName:
+		s, err := m.secretsManager.GetWebhookServerCertSecret(ctx)
+		if err != nil || s == nil {
+			return nil, err
+		}
+		return s.Data, nil
+	}
+	return nil, fmt.Errorf("unknown secret %q", name)
+}
 
 func (m *Manager) PrepareAdmissionWebhooks(ctx context.Context, webhookResources []*unstructured.Unstructured) ([]*unstructured.Unstructured, error) {
 	logger := log.FromContext(ctx)

--- a/internal/webhook/certificate/manager.go
+++ b/internal/webhook/certificate/manager.go
@@ -92,12 +92,18 @@ var _ CertificateManager = (*Manager)(nil)
 
 func (m *Manager) IsWebhookCertSignedBySelfSignedCA(ctx context.Context) (bool, error) {
 	caSecret, err := m.secretsManager.GetCaServerCertSecret(ctx)
-	if err != nil || caSecret == nil {
+	if err != nil {
 		return false, err
 	}
+	if caSecret == nil {
+		return false, fmt.Errorf("secret %q not found", caCertSecretName)
+	}
 	webhookSecret, err := m.secretsManager.GetWebhookServerCertSecret(ctx)
-	if err != nil || webhookSecret == nil {
+	if err != nil {
 		return false, err
+	}
+	if webhookSecret == nil {
+		return false, fmt.Errorf("secret %q not found", webhookCertSecretName)
 	}
 	return certs.VerifyIfLeafIsSignedByGivenCA(caSecret.Data[caCertSecretCertField], webhookSecret.Data[webhookCertSecretCertField])
 }
@@ -106,14 +112,20 @@ func (m *Manager) GetSecretData(ctx context.Context, name string) (map[string][]
 	switch name {
 	case caCertSecretName:
 		s, err := m.secretsManager.GetCaServerCertSecret(ctx)
-		if err != nil || s == nil {
+		if err != nil {
 			return nil, err
+		}
+		if s == nil {
+			return nil, fmt.Errorf("secret %q not found", name)
 		}
 		return s.Data, nil
 	case webhookCertSecretName:
 		s, err := m.secretsManager.GetWebhookServerCertSecret(ctx)
-		if err != nil || s == nil {
+		if err != nil {
 			return nil, err
+		}
+		if s == nil {
+			return nil, fmt.Errorf("secret %q not found", name)
 		}
 		return s.Data, nil
 	}

--- a/internal/webhook/certificate/manager.go
+++ b/internal/webhook/certificate/manager.go
@@ -98,6 +98,10 @@ func (m *Manager) IsWebhookCertSignedBySelfSignedCA(ctx context.Context) (bool, 
 	if caSecret == nil {
 		return false, fmt.Errorf("secret %q not found", caCertSecretName)
 	}
+	caCert, err := getSecretDataValueByKey(caCertSecretCertField, caSecret.Data)
+	if err != nil {
+		return false, fmt.Errorf("CA secret %q: %w", caCertSecretName, err)
+	}
 	webhookSecret, err := m.secretsManager.GetWebhookServerCertSecret(ctx)
 	if err != nil {
 		return false, err
@@ -105,7 +109,11 @@ func (m *Manager) IsWebhookCertSignedBySelfSignedCA(ctx context.Context) (bool, 
 	if webhookSecret == nil {
 		return false, fmt.Errorf("secret %q not found", webhookCertSecretName)
 	}
-	return certs.VerifyIfLeafIsSignedByGivenCA(caSecret.Data[caCertSecretCertField], webhookSecret.Data[webhookCertSecretCertField])
+	webhookCert, err := getSecretDataValueByKey(webhookCertSecretCertField, webhookSecret.Data)
+	if err != nil {
+		return false, fmt.Errorf("webhook secret %q: %w", webhookCertSecretName, err)
+	}
+	return certs.VerifyIfLeafIsSignedByGivenCA(caCert, webhookCert)
 }
 
 func (m *Manager) GetSecretData(ctx context.Context, name string) (map[string][]byte, error) {

--- a/internal/webhook/certificate/manager_test.go
+++ b/internal/webhook/certificate/manager_test.go
@@ -210,6 +210,153 @@ var _ = Describe("Certificate Manager", func() {
 		})
 	})
 
+	Describe("IsWebhookCertSignedBySelfSignedCA", func() {
+		Context("when CA secret is missing", func() {
+			BeforeEach(func() {
+				secretsMgr.caCertSecret = nil
+			})
+
+			It("returns an error", func() {
+				_, err := mgr.IsWebhookCertSignedBySelfSignedCA(ctx)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("ca-server-cert"))
+			})
+		})
+
+		Context("when fetching the CA secret fails", func() {
+			BeforeEach(func() {
+				secretsMgr.caCertSecretErr = errors.New("api error")
+			})
+
+			It("returns the error", func() {
+				_, err := mgr.IsWebhookCertSignedBySelfSignedCA(ctx)
+				Expect(err).To(MatchError("api error"))
+			})
+		})
+
+		Context("when webhook secret is missing", func() {
+			BeforeEach(func() {
+				secretsMgr.caCertSecret = caSecret(validCACert, validCAKey)
+				secretsMgr.webhookCertSecret = nil
+			})
+
+			It("returns an error", func() {
+				_, err := mgr.IsWebhookCertSignedBySelfSignedCA(ctx)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("webhook-server-cert"))
+			})
+		})
+
+		Context("when fetching the webhook secret fails", func() {
+			BeforeEach(func() {
+				secretsMgr.caCertSecret = caSecret(validCACert, validCAKey)
+				secretsMgr.webhookCertErr = errors.New("api error")
+			})
+
+			It("returns the error", func() {
+				_, err := mgr.IsWebhookCertSignedBySelfSignedCA(ctx)
+				Expect(err).To(MatchError("api error"))
+			})
+		})
+
+		Context("when webhook cert is signed by the CA", func() {
+			BeforeEach(func() {
+				secretsMgr.caCertSecret = caSecret(validCACert, validCAKey)
+				secretsMgr.webhookCertSecret = webhookSecret(validWebhookCert, validWebhookKey)
+			})
+
+			It("returns true", func() {
+				ok, err := mgr.IsWebhookCertSignedBySelfSignedCA(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ok).To(BeTrue())
+			})
+		})
+
+		Context("when webhook cert is signed by a different CA", func() {
+			BeforeEach(func() {
+				secretsMgr.caCertSecret = caSecret(validCACert, validCAKey)
+				secretsMgr.webhookCertSecret = webhookSecret(wrongSignedWebhookCert, wrongSignedWebhookKey)
+			})
+
+			It("returns false and an error", func() {
+				ok, err := mgr.IsWebhookCertSignedBySelfSignedCA(ctx)
+				Expect(err).To(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+	})
+
+	Describe("GetSecretData", func() {
+		Context("when requesting CA secret data", func() {
+			BeforeEach(func() {
+				secretsMgr.caCertSecret = caSecret(validCACert, validCAKey)
+			})
+
+			It("returns the secret data", func() {
+				data, err := mgr.GetSecretData(ctx, caCertSecretName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(data[caCertField]).To(Equal(validCACert))
+				Expect(data[caKeyField]).To(Equal(validCAKey))
+			})
+		})
+
+		Context("when CA secret is missing", func() {
+			BeforeEach(func() {
+				secretsMgr.caCertSecret = nil
+			})
+
+			It("returns an error", func() {
+				_, err := mgr.GetSecretData(ctx, caCertSecretName)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("ca-server-cert"))
+			})
+		})
+
+		Context("when requesting webhook secret data", func() {
+			BeforeEach(func() {
+				secretsMgr.webhookCertSecret = webhookSecret(validWebhookCert, validWebhookKey)
+			})
+
+			It("returns the secret data", func() {
+				data, err := mgr.GetSecretData(ctx, webhookCertSecretName)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(data[webhookCertField]).To(Equal(validWebhookCert))
+				Expect(data[webhookKeyField]).To(Equal(validWebhookKey))
+			})
+		})
+
+		Context("when webhook secret is missing", func() {
+			BeforeEach(func() {
+				secretsMgr.webhookCertSecret = nil
+			})
+
+			It("returns an error", func() {
+				_, err := mgr.GetSecretData(ctx, webhookCertSecretName)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("webhook-server-cert"))
+			})
+		})
+
+		Context("when fetching CA secret fails", func() {
+			BeforeEach(func() {
+				secretsMgr.caCertSecretErr = errors.New("api error")
+			})
+
+			It("returns the error", func() {
+				_, err := mgr.GetSecretData(ctx, caCertSecretName)
+				Expect(err).To(MatchError("api error"))
+			})
+		})
+
+		Context("when an unknown secret name is requested", func() {
+			It("returns an error", func() {
+				_, err := mgr.GetSecretData(ctx, "unknown-secret")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("unknown secret"))
+			})
+		})
+	})
+
 	Describe("PartitionWebhooks", func() {
 		It("splits webhook configurations from other resources", func() {
 			mutating := mutatingWebhookConfig("test-mutating")


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `IsWebhookCertSignedBySelfSignedCA` and `GetSecretData` methods to the `CertificateManager` interface and implement them on `Manager` using the existing `secretsManager`
- Remove `isWebhookCertSignedBySelfSignedCa`, `getCertificateFromSecret`, `getDataFromSecret`, `getSecretDataValueByKey`, and `certFieldFromSecretBySecretName` from `BtpOperatorReconciler`
- Update `controllers/btpoperator_controller_certificates_test.go` and `controllers/utils_test.go` to call the new methods via `reconciler.certManager`

**Related issue(s)**
See also #1313