### PR TITLE
Extract SapBtpServiceOperatorConfigurator From BtpOperatorReconciler

### DIFF
--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -20,13 +20,13 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/kyma-project/btp-manager/api/v1alpha1"
 	"github.com/kyma-project/btp-manager/controllers/config"
 	"github.com/kyma-project/btp-manager/internal/conditions"
+	"github.com/kyma-project/btp-manager/internal/configurator"
 	"github.com/kyma-project/btp-manager/internal/credentials/drift"
 	"github.com/kyma-project/btp-manager/internal/deprovisioning"
 	"github.com/kyma-project/btp-manager/internal/k8s/networkpolicy"
@@ -157,11 +157,12 @@ type BtpOperatorReconciler struct {
 	moduleResourceManager  moduleresource.ResourceManager
 	certManager            certificate.CertificateManager
 	provisioningHandler    provisioning.Handler
+	configurator           configurator.SapBtpServiceOperatorConfigurator
 	watchHandlers          []config.WatchHandler
 	deprovisioningHandler  deprovisioning.Handler
 }
 
-func NewBtpOperatorReconciler(client client.Client, apiServerClient client.Client, scheme *runtime.Scheme, instanceBindingSerivice InstanceBindingSerivce, metrics *metrics.WebhookMetrics, watchHandlers []config.WatchHandler, networkPolicyManager networkpolicy.NetworkPolicyManager, driftDetector drift.Detector, moduleResourceManager moduleresource.ResourceManager, certManager certificate.CertificateManager, provisioningHandler provisioning.Handler) *BtpOperatorReconciler {
+func NewBtpOperatorReconciler(client client.Client, apiServerClient client.Client, scheme *runtime.Scheme, instanceBindingSerivice InstanceBindingSerivce, metrics *metrics.WebhookMetrics, watchHandlers []config.WatchHandler, networkPolicyManager networkpolicy.NetworkPolicyManager, driftDetector drift.Detector, moduleResourceManager moduleresource.ResourceManager, certManager certificate.CertificateManager, provisioningHandler provisioning.Handler, cfg configurator.SapBtpServiceOperatorConfigurator) *BtpOperatorReconciler {
 	return &BtpOperatorReconciler{
 		Client:                 client,
 		apiServerClient:        apiServerClient,
@@ -174,6 +175,7 @@ func NewBtpOperatorReconciler(client client.Client, apiServerClient client.Clien
 		moduleResourceManager:  moduleResourceManager,
 		certManager:            certManager,
 		provisioningHandler:    provisioningHandler,
+		configurator:           cfg,
 	}
 }
 
@@ -393,34 +395,12 @@ func (r *BtpOperatorReconciler) HandleReadyState(ctx context.Context, cr *v1alph
 
 	r.driftDetector.InitializeFromSecret(requiredSecret)
 
-	defaultCredentialsSecret, err := r.driftDetector.GetDefaultCredentialsSecret(ctx)
-	if err != nil {
-		logger.Error(err, fmt.Sprintf("while getting %s Secret", sapBtpServiceOperatorSecretName))
-		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, conditions.GettingDefaultCredentialsSecretFailed, err.Error())
+	result := r.configurator.Check(ctx)
+	if result.ErrorReason != "" {
+		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, result.ErrorReason, result.ErrorMessage)
 	}
-
-	if defaultCredentialsSecret != nil {
-		managerNs := r.driftDetector.CredentialsNamespaceFromManager()
-		if managerNs != defaultCredentialsSecret.Namespace {
-			msg := fmt.Sprintf("credentials namespace changed from %s to %s", defaultCredentialsSecret.Namespace, managerNs)
-			logger.Info(msg)
-			return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateProcessing, conditions.CredentialsNamespaceChanged, msg)
-		}
-	}
-
-	sapBtpOperatorConfigMap, err := r.driftDetector.GetSapBtpServiceOperatorConfigMap(ctx)
-	if err != nil {
-		logger.Error(err, fmt.Sprintf("while getting %s ConfigMap", sapBtpServiceOperatorConfigMapName))
-		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, conditions.GettingSapBtpServiceOperatorConfigMapFailed, err.Error())
-	}
-
-	if sapBtpOperatorConfigMap != nil {
-		clusterIdFromCM := sapBtpOperatorConfigMap.Data[strings.ToUpper(ClusterIdSecretKey)]
-		if r.driftDetector.ClusterIdFromManager() != clusterIdFromCM {
-			msg := fmt.Sprintf("cluster ID changed from %s to %s", clusterIdFromCM, r.driftDetector.ClusterIdFromManager())
-			logger.Info(msg)
-			return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateProcessing, conditions.ClusterIdChanged, msg)
-		}
+	if result.ReprocessReason != "" {
+		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateProcessing, result.ReprocessReason, result.ReprocessMessage)
 	}
 
 	if err := r.moduleResourceManager.DeleteOutdatedResources(ctx); err != nil {

--- a/controllers/btpoperator_controller_test.go
+++ b/controllers/btpoperator_controller_test.go
@@ -34,7 +34,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should return error from client.Get", func(t *testing.T) {
 		// given
 		retryK8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil, nil)
+		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil, nil, nil)
 		retryK8sClient.EnableErrorOnGet()
 
 		// when
@@ -57,7 +57,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should return error from client.Update", func(t *testing.T) {
 		// given
 		retryK8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil, nil)
+		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil, nil, nil)
 		retryK8sClient.EnableErrorOnUpdate()
 
 		// when
@@ -80,7 +80,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should time out", func(t *testing.T) {
 		// given
 		disabledUpdatek8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(disabledUpdatek8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil, nil)
+		btpOperatorReconciler := NewBtpOperatorReconciler(disabledUpdatek8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil, nil, nil)
 		disabledUpdatek8sClient.DisableUpdate()
 
 		// when
@@ -102,7 +102,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should update BtpOperator status after a few retries", func(t *testing.T) {
 		// given
 		retryK8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil, nil)
+		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil, nil, nil)
 
 		// when
 		err := btpOperatorReconciler.UpdateBtpOperatorStatus(ctx, btpOperator, v1alpha1.StateProcessing, conditions.Initialized, "test")
@@ -124,7 +124,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should update BtpOperator status three times", func(t *testing.T) {
 		// given
 		retryK8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil, nil)
+		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil, nil, nil)
 		conditionMsg1 := "test1"
 		conditionMsg2 := "test2"
 		conditionMsg3 := "test3"

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/kyma-project/btp-manager/api/v1alpha1"
 	"github.com/kyma-project/btp-manager/controllers/config"
 	"github.com/kyma-project/btp-manager/internal/certs"
+	"github.com/kyma-project/btp-manager/internal/configurator"
 	"github.com/kyma-project/btp-manager/internal/credentials/drift"
 	"github.com/kyma-project/btp-manager/internal/deprovisioning"
 	"github.com/kyma-project/btp-manager/internal/k8s/generic"
@@ -196,6 +197,7 @@ var _ = SynchronizedBeforeSuite(func() {
 	secretsManager := secrets.NewManager(generic.NewObjectManager[*corev1.Secret, *corev1.SecretList](k8sManager.GetClient()))
 	certManager := certificate.NewManager(secretsManager, metrics)
 	provisioningHandler := provisioning.NewHandler(k8sManager.GetClient(), driftDetector, moduleResourceManager, networkPolicyManager, certManager, cleanupReconciler)
+	sapBtpConfigurator := configurator.NewConfigurator(driftDetector)
 	reconciler = NewBtpOperatorReconciler(
 		k8sManager.GetClient(),
 		k8sClient,
@@ -210,6 +212,7 @@ var _ = SynchronizedBeforeSuite(func() {
 		moduleResourceManager,
 		certManager,
 		provisioningHandler,
+		sapBtpConfigurator,
 	)
 	reconciler.SetDeprovisioningHandler(deprovisioning.NewHandler(k8sManager.GetClient(), k8sClient, reconciler, reconciler, cleanupReconciler, driftDetector, moduleResourceManager, networkPolicyManager))
 

--- a/internal/configurator/configurator.go
+++ b/internal/configurator/configurator.go
@@ -9,8 +9,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const clusterIdKey = "CLUSTER_ID"
-
 // CheckResult tells the reconciler what state transition (if any) to make.
 // All fields empty means no action needed.
 type CheckResult struct {
@@ -63,7 +61,7 @@ func (c *configurator) Check(ctx context.Context) CheckResult {
 		}
 	}
 	if sapBtpOperatorConfigMap != nil {
-		clusterIdFromCM := sapBtpOperatorConfigMap.Data[clusterIdKey]
+		clusterIdFromCM := sapBtpOperatorConfigMap.Data[drift.ClusterIdConfigMapKey]
 		if c.driftDetector.ClusterIdFromManager() != clusterIdFromCM {
 			msg := fmt.Sprintf("cluster ID changed from %s to %s", clusterIdFromCM, c.driftDetector.ClusterIdFromManager())
 			logger.Info(msg)

--- a/internal/configurator/configurator.go
+++ b/internal/configurator/configurator.go
@@ -3,7 +3,6 @@ package configurator
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/kyma-project/btp-manager/internal/conditions"
 	"github.com/kyma-project/btp-manager/internal/credentials/drift"
@@ -64,7 +63,7 @@ func (c *configurator) Check(ctx context.Context) CheckResult {
 		}
 	}
 	if sapBtpOperatorConfigMap != nil {
-		clusterIdFromCM := sapBtpOperatorConfigMap.Data[strings.ToUpper(clusterIdKey)]
+		clusterIdFromCM := sapBtpOperatorConfigMap.Data[clusterIdKey]
 		if c.driftDetector.ClusterIdFromManager() != clusterIdFromCM {
 			msg := fmt.Sprintf("cluster ID changed from %s to %s", clusterIdFromCM, c.driftDetector.ClusterIdFromManager())
 			logger.Info(msg)

--- a/internal/configurator/configurator.go
+++ b/internal/configurator/configurator.go
@@ -1,0 +1,76 @@
+package configurator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/kyma-project/btp-manager/internal/conditions"
+	"github.com/kyma-project/btp-manager/internal/credentials/drift"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const clusterIdKey = "CLUSTER_ID"
+
+// CheckResult tells the reconciler what state transition (if any) to make.
+// All fields empty means no action needed.
+type CheckResult struct {
+	ReprocessReason  conditions.Reason
+	ReprocessMessage string
+	ErrorReason      conditions.Reason
+	ErrorMessage     string
+}
+
+type SapBtpServiceOperatorConfigurator interface {
+	Check(ctx context.Context) CheckResult
+}
+
+type configurator struct {
+	driftDetector drift.Detector
+}
+
+func NewConfigurator(d drift.Detector) SapBtpServiceOperatorConfigurator {
+	return &configurator{driftDetector: d}
+}
+
+var _ SapBtpServiceOperatorConfigurator = (*configurator)(nil)
+
+func (c *configurator) Check(ctx context.Context) CheckResult {
+	logger := log.FromContext(ctx)
+
+	defaultCredentialsSecret, err := c.driftDetector.GetDefaultCredentialsSecret(ctx)
+	if err != nil {
+		logger.Error(err, "while getting default credentials secret")
+		return CheckResult{
+			ErrorReason:  conditions.GettingDefaultCredentialsSecretFailed,
+			ErrorMessage: err.Error(),
+		}
+	}
+	if defaultCredentialsSecret != nil {
+		managerNs := c.driftDetector.CredentialsNamespaceFromManager()
+		if managerNs != defaultCredentialsSecret.Namespace {
+			msg := fmt.Sprintf("credentials namespace changed from %s to %s", defaultCredentialsSecret.Namespace, managerNs)
+			logger.Info(msg)
+			return CheckResult{ReprocessReason: conditions.CredentialsNamespaceChanged, ReprocessMessage: msg}
+		}
+	}
+
+	sapBtpOperatorConfigMap, err := c.driftDetector.GetSapBtpServiceOperatorConfigMap(ctx)
+	if err != nil {
+		logger.Error(err, "while getting sap-btp-operator config map")
+		return CheckResult{
+			ErrorReason:  conditions.GettingSapBtpServiceOperatorConfigMapFailed,
+			ErrorMessage: err.Error(),
+		}
+	}
+	if sapBtpOperatorConfigMap != nil {
+		clusterIdFromCM := sapBtpOperatorConfigMap.Data[strings.ToUpper(clusterIdKey)]
+		if c.driftDetector.ClusterIdFromManager() != clusterIdFromCM {
+			msg := fmt.Sprintf("cluster ID changed from %s to %s", clusterIdFromCM, c.driftDetector.ClusterIdFromManager())
+			logger.Info(msg)
+			return CheckResult{ReprocessReason: conditions.ClusterIdChanged, ReprocessMessage: msg}
+		}
+	}
+
+	return CheckResult{}
+}

--- a/internal/configurator/configurator.go
+++ b/internal/configurator/configurator.go
@@ -6,8 +6,16 @@ import (
 
 	"github.com/kyma-project/btp-manager/internal/conditions"
 	"github.com/kyma-project/btp-manager/internal/credentials/drift"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+type OperatorStateReader interface {
+	GetDefaultCredentialsSecret(ctx context.Context) (*corev1.Secret, error)
+	GetSapBtpServiceOperatorConfigMap(ctx context.Context) (*corev1.ConfigMap, error)
+	CredentialsNamespaceFromManager() string
+	ClusterIdFromManager() string
+}
 
 // CheckResult tells the reconciler what state transition (if any) to make.
 // All fields empty means no action needed.
@@ -23,11 +31,11 @@ type SapBtpServiceOperatorConfigurator interface {
 }
 
 type configurator struct {
-	driftDetector drift.Detector
+	reader OperatorStateReader
 }
 
-func NewConfigurator(d drift.Detector) SapBtpServiceOperatorConfigurator {
-	return &configurator{driftDetector: d}
+func NewConfigurator(r OperatorStateReader) SapBtpServiceOperatorConfigurator {
+	return &configurator{reader: r}
 }
 
 var _ SapBtpServiceOperatorConfigurator = (*configurator)(nil)
@@ -35,7 +43,7 @@ var _ SapBtpServiceOperatorConfigurator = (*configurator)(nil)
 func (c *configurator) Check(ctx context.Context) CheckResult {
 	logger := log.FromContext(ctx)
 
-	defaultCredentialsSecret, err := c.driftDetector.GetDefaultCredentialsSecret(ctx)
+	defaultCredentialsSecret, err := c.reader.GetDefaultCredentialsSecret(ctx)
 	if err != nil {
 		logger.Error(err, "while getting default credentials secret")
 		return CheckResult{
@@ -44,7 +52,7 @@ func (c *configurator) Check(ctx context.Context) CheckResult {
 		}
 	}
 	if defaultCredentialsSecret != nil {
-		managerNs := c.driftDetector.CredentialsNamespaceFromManager()
+		managerNs := c.reader.CredentialsNamespaceFromManager()
 		if managerNs != defaultCredentialsSecret.Namespace {
 			msg := fmt.Sprintf("credentials namespace changed from %s to %s", defaultCredentialsSecret.Namespace, managerNs)
 			logger.Info(msg)
@@ -52,7 +60,7 @@ func (c *configurator) Check(ctx context.Context) CheckResult {
 		}
 	}
 
-	sapBtpOperatorConfigMap, err := c.driftDetector.GetSapBtpServiceOperatorConfigMap(ctx)
+	sapBtpOperatorConfigMap, err := c.reader.GetSapBtpServiceOperatorConfigMap(ctx)
 	if err != nil {
 		logger.Error(err, "while getting sap-btp-operator config map")
 		return CheckResult{
@@ -62,8 +70,8 @@ func (c *configurator) Check(ctx context.Context) CheckResult {
 	}
 	if sapBtpOperatorConfigMap != nil {
 		clusterIdFromCM := sapBtpOperatorConfigMap.Data[drift.ClusterIdConfigMapKey]
-		if c.driftDetector.ClusterIdFromManager() != clusterIdFromCM {
-			msg := fmt.Sprintf("cluster ID changed from %s to %s", clusterIdFromCM, c.driftDetector.ClusterIdFromManager())
+		if c.reader.ClusterIdFromManager() != clusterIdFromCM {
+			msg := fmt.Sprintf("cluster ID changed from %s to %s", clusterIdFromCM, c.reader.ClusterIdFromManager())
 			logger.Info(msg)
 			return CheckResult{ReprocessReason: conditions.ClusterIdChanged, ReprocessMessage: msg}
 		}

--- a/internal/configurator/configurator_test.go
+++ b/internal/configurator/configurator_test.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type stubDetector struct {
+type stubReader struct {
 	credNs           string
 	clusterId        string
 	defaultSecret    *corev1.Secret
@@ -19,30 +19,14 @@ type stubDetector struct {
 	configMapErr     error
 }
 
-func (s *stubDetector) InitializeFromSecret(_ *corev1.Secret)        {}
-func (s *stubDetector) CredentialsNamespaceFromManager() string      { return s.credNs }
-func (s *stubDetector) CredentialsNamespaceFromOperator() string     { return "" }
-func (s *stubDetector) ClusterIdFromManager() string                 { return s.clusterId }
-func (s *stubDetector) ClusterIdFromOperatorConfigMap() string       { return "" }
-func (s *stubDetector) ClusterIdFromOperatorClusterIdSecret() string { return "" }
-func (s *stubDetector) PreviousCredentialsNamespace() string         { return "" }
-func (s *stubDetector) CheckCredentialsNamespaceDrift(_ context.Context, _ *corev1.Secret) *conditions.ErrorWithReason {
-	return nil
-}
-func (s *stubDetector) CheckClusterIdConfigMapDrift(_ context.Context, _ *corev1.Secret) *conditions.ErrorWithReason {
-	return nil
-}
-func (s *stubDetector) ResolveClusterIdSecretDrift(_ context.Context, _ *corev1.Secret) *conditions.ErrorWithReason {
-	return nil
-}
-func (s *stubDetector) GetDefaultCredentialsSecret(_ context.Context) (*corev1.Secret, error) {
+func (s *stubReader) CredentialsNamespaceFromManager() string { return s.credNs }
+func (s *stubReader) ClusterIdFromManager() string            { return s.clusterId }
+func (s *stubReader) GetDefaultCredentialsSecret(_ context.Context) (*corev1.Secret, error) {
 	return s.defaultSecret, s.defaultSecretErr
 }
-func (s *stubDetector) GetSapBtpServiceOperatorConfigMap(_ context.Context) (*corev1.ConfigMap, error) {
+func (s *stubReader) GetSapBtpServiceOperatorConfigMap(_ context.Context) (*corev1.ConfigMap, error) {
 	return s.configMap, s.configMapErr
 }
-func (s *stubDetector) DeleteClusterIdSecret(_ context.Context) error  { return nil }
-func (s *stubDetector) DeleteChangedResources(_ context.Context) error { return nil }
 
 func secret(ns string) *corev1.Secret {
 	return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: ns}}
@@ -53,7 +37,7 @@ func configMap(clusterId string) *corev1.ConfigMap {
 }
 
 func TestCheck_NoChanges(t *testing.T) {
-	c := NewConfigurator(&stubDetector{
+	c := NewConfigurator(&stubReader{
 		credNs:        "kyma-system",
 		clusterId:     "c1",
 		defaultSecret: secret("kyma-system"),
@@ -66,7 +50,7 @@ func TestCheck_NoChanges(t *testing.T) {
 }
 
 func TestCheck_NoDefaultSecret_NoConfigMap(t *testing.T) {
-	c := NewConfigurator(&stubDetector{credNs: "kyma-system", clusterId: "c1"})
+	c := NewConfigurator(&stubReader{credNs: "kyma-system", clusterId: "c1"})
 	result := c.Check(context.Background())
 	if result.ReprocessReason != "" || result.ErrorReason != "" {
 		t.Fatalf("expected empty result when no operand resources exist, got %+v", result)
@@ -74,7 +58,7 @@ func TestCheck_NoDefaultSecret_NoConfigMap(t *testing.T) {
 }
 
 func TestCheck_CredentialsNamespaceDrift(t *testing.T) {
-	c := NewConfigurator(&stubDetector{
+	c := NewConfigurator(&stubReader{
 		credNs:        "new-ns",
 		clusterId:     "c1",
 		defaultSecret: secret("old-ns"),
@@ -89,7 +73,7 @@ func TestCheck_CredentialsNamespaceDrift(t *testing.T) {
 }
 
 func TestCheck_ClusterIdDrift(t *testing.T) {
-	c := NewConfigurator(&stubDetector{
+	c := NewConfigurator(&stubReader{
 		credNs:        "kyma-system",
 		clusterId:     "new-id",
 		defaultSecret: secret("kyma-system"),
@@ -105,7 +89,7 @@ func TestCheck_ClusterIdDrift(t *testing.T) {
 }
 
 func TestCheck_DefaultSecretError(t *testing.T) {
-	c := NewConfigurator(&stubDetector{defaultSecretErr: errors.New("api down")})
+	c := NewConfigurator(&stubReader{defaultSecretErr: errors.New("api down")})
 	result := c.Check(context.Background())
 	if result.ErrorReason != conditions.GettingDefaultCredentialsSecretFailed {
 		t.Fatalf("expected GettingDefaultCredentialsSecretFailed, got %v", result.ErrorReason)
@@ -113,7 +97,7 @@ func TestCheck_DefaultSecretError(t *testing.T) {
 }
 
 func TestCheck_ConfigMapError(t *testing.T) {
-	c := NewConfigurator(&stubDetector{
+	c := NewConfigurator(&stubReader{
 		credNs:        "kyma-system",
 		clusterId:     "c1",
 		defaultSecret: secret("kyma-system"),

--- a/internal/configurator/configurator_test.go
+++ b/internal/configurator/configurator_test.go
@@ -1,0 +1,126 @@
+package configurator
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/kyma-project/btp-manager/internal/conditions"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type stubDetector struct {
+	credNs           string
+	clusterId        string
+	defaultSecret    *corev1.Secret
+	configMap        *corev1.ConfigMap
+	defaultSecretErr error
+	configMapErr     error
+}
+
+func (s *stubDetector) InitializeFromSecret(_ *corev1.Secret)        {}
+func (s *stubDetector) CredentialsNamespaceFromManager() string      { return s.credNs }
+func (s *stubDetector) CredentialsNamespaceFromOperator() string     { return "" }
+func (s *stubDetector) ClusterIdFromManager() string                 { return s.clusterId }
+func (s *stubDetector) ClusterIdFromOperatorConfigMap() string       { return "" }
+func (s *stubDetector) ClusterIdFromOperatorClusterIdSecret() string { return "" }
+func (s *stubDetector) PreviousCredentialsNamespace() string         { return "" }
+func (s *stubDetector) CheckCredentialsNamespaceDrift(_ context.Context, _ *corev1.Secret) *conditions.ErrorWithReason {
+	return nil
+}
+func (s *stubDetector) CheckClusterIdConfigMapDrift(_ context.Context, _ *corev1.Secret) *conditions.ErrorWithReason {
+	return nil
+}
+func (s *stubDetector) ResolveClusterIdSecretDrift(_ context.Context, _ *corev1.Secret) *conditions.ErrorWithReason {
+	return nil
+}
+func (s *stubDetector) GetDefaultCredentialsSecret(_ context.Context) (*corev1.Secret, error) {
+	return s.defaultSecret, s.defaultSecretErr
+}
+func (s *stubDetector) GetSapBtpServiceOperatorConfigMap(_ context.Context) (*corev1.ConfigMap, error) {
+	return s.configMap, s.configMapErr
+}
+func (s *stubDetector) DeleteClusterIdSecret(_ context.Context) error  { return nil }
+func (s *stubDetector) DeleteChangedResources(_ context.Context) error { return nil }
+
+func secret(ns string) *corev1.Secret {
+	return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: ns}}
+}
+
+func configMap(clusterId string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{Data: map[string]string{"CLUSTER_ID": clusterId}}
+}
+
+func TestCheck_NoChanges(t *testing.T) {
+	c := NewConfigurator(&stubDetector{
+		credNs:        "kyma-system",
+		clusterId:     "c1",
+		defaultSecret: secret("kyma-system"),
+		configMap:     configMap("c1"),
+	})
+	result := c.Check(context.Background())
+	if result.ReprocessReason != "" || result.ErrorReason != "" {
+		t.Fatalf("expected empty result, got %+v", result)
+	}
+}
+
+func TestCheck_NoDefaultSecret_NoConfigMap(t *testing.T) {
+	c := NewConfigurator(&stubDetector{credNs: "kyma-system", clusterId: "c1"})
+	result := c.Check(context.Background())
+	if result.ReprocessReason != "" || result.ErrorReason != "" {
+		t.Fatalf("expected empty result when no operand resources exist, got %+v", result)
+	}
+}
+
+func TestCheck_CredentialsNamespaceDrift(t *testing.T) {
+	c := NewConfigurator(&stubDetector{
+		credNs:        "new-ns",
+		clusterId:     "c1",
+		defaultSecret: secret("old-ns"),
+	})
+	result := c.Check(context.Background())
+	if result.ReprocessReason != conditions.CredentialsNamespaceChanged {
+		t.Fatalf("expected CredentialsNamespaceChanged, got %v", result.ReprocessReason)
+	}
+	if result.ErrorReason != "" {
+		t.Fatalf("expected no error reason, got %v", result.ErrorReason)
+	}
+}
+
+func TestCheck_ClusterIdDrift(t *testing.T) {
+	c := NewConfigurator(&stubDetector{
+		credNs:        "kyma-system",
+		clusterId:     "new-id",
+		defaultSecret: secret("kyma-system"),
+		configMap:     configMap("old-id"),
+	})
+	result := c.Check(context.Background())
+	if result.ReprocessReason != conditions.ClusterIdChanged {
+		t.Fatalf("expected ClusterIdChanged, got %v", result.ReprocessReason)
+	}
+	if result.ErrorReason != "" {
+		t.Fatalf("expected no error reason, got %v", result.ErrorReason)
+	}
+}
+
+func TestCheck_DefaultSecretError(t *testing.T) {
+	c := NewConfigurator(&stubDetector{defaultSecretErr: errors.New("api down")})
+	result := c.Check(context.Background())
+	if result.ErrorReason != conditions.GettingDefaultCredentialsSecretFailed {
+		t.Fatalf("expected GettingDefaultCredentialsSecretFailed, got %v", result.ErrorReason)
+	}
+}
+
+func TestCheck_ConfigMapError(t *testing.T) {
+	c := NewConfigurator(&stubDetector{
+		credNs:        "kyma-system",
+		clusterId:     "c1",
+		defaultSecret: secret("kyma-system"),
+		configMapErr:  errors.New("api down"),
+	})
+	result := c.Check(context.Background())
+	if result.ErrorReason != conditions.GettingSapBtpServiceOperatorConfigMapFailed {
+		t.Fatalf("expected GettingSapBtpServiceOperatorConfigMapFailed, got %v", result.ErrorReason)
+	}
+}

--- a/internal/credentials/drift/detector.go
+++ b/internal/credentials/drift/detector.go
@@ -16,6 +16,8 @@ import (
 )
 
 const (
+	ClusterIdConfigMapKey = "CLUSTER_ID"
+
 	clusterIdSecretKey            = "cluster_id"
 	credentialsNamespaceSecretKey = "credentials_namespace"
 	initialClusterIdSecretKey     = "INITIAL_CLUSTER_ID"

--- a/main.go
+++ b/main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/kyma-project/btp-manager/api/v1alpha1"
 	"github.com/kyma-project/btp-manager/controllers"
 	"github.com/kyma-project/btp-manager/controllers/config"
+	"github.com/kyma-project/btp-manager/internal/configurator"
 	"github.com/kyma-project/btp-manager/internal/credentials/drift"
 	"github.com/kyma-project/btp-manager/internal/deprovisioning"
 	"github.com/kyma-project/btp-manager/internal/k8s/generic"
@@ -144,6 +145,7 @@ func main() {
 	secretsManager := secrets.NewManager(generic.NewObjectManager[*corev1.Secret, *corev1.SecretList](mgr.GetClient()))
 	certManager := certificate.NewManager(secretsManager, webhookMetrics)
 	provisioningHandler := provisioning.NewHandler(mgr.GetClient(), driftDetector, moduleResourceManager, networkPolicyManager, certManager, cleanupReconciler)
+	sapBtpConfigurator := configurator.NewConfigurator(driftDetector)
 	reconciler := controllers.NewBtpOperatorReconciler(
 		mgr.GetClient(),
 		apiServerClient,
@@ -158,6 +160,7 @@ func main() {
 		moduleResourceManager,
 		certManager,
 		provisioningHandler,
+		sapBtpConfigurator,
 	)
 	reconciler.SetDeprovisioningHandler(deprovisioning.NewHandler(mgr.GetClient(), apiServerClient, reconciler, reconciler, cleanupReconciler, driftDetector, moduleResourceManager, networkPolicyManager))
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Extract the credentials namespace and cluster ID drift-check logic from `HandleReadyState` into a new `internal/configurator` package with a `SapBtpServiceOperatorConfigurator` interface and `Check(ctx)` method
- Inject the configurator into `BtpOperatorReconciler` via constructor parameter, matching the established handler injection pattern
- Simplify `HandleReadyState` to delegate the drift check to the configurator and act on the returned `CheckResult`
- Add unit tests for `SapBtpServiceOperatorConfigurator` covering no-drift, credentials namespace drift, cluster ID drift, and error paths
- Wire the configurator in `main.go` and the test suite

**Related issue(s)**
See also #1313