### PR TITLE
Remove Direct Handler Dependencies From BtpOperatorReconciler

### DIFF
--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -65,8 +65,7 @@ const (
 )
 
 const (
-	SapBtpServiceOperatorName = "sap-btp-service-operator"
-	SapBtpServiceOperatorEnv  = "SAP_BTP_SERVICE_OPERATOR"
+	SapBtpServiceOperatorEnv = "SAP_BTP_SERVICE_OPERATOR"
 
 	moduleName   = "btp-operator"
 	operatorName = "btp-manager"

--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kyma-project/btp-manager/controllers/config"
 	"github.com/kyma-project/btp-manager/internal/conditions"
 	"github.com/kyma-project/btp-manager/internal/configurator"
+	"github.com/kyma-project/btp-manager/internal/credentials/drift"
 	"github.com/kyma-project/btp-manager/internal/deprovisioning"
 	"github.com/kyma-project/btp-manager/internal/k8s/networkpolicy"
 	"github.com/kyma-project/btp-manager/internal/metrics"
@@ -56,7 +57,7 @@ const (
 	ClusterIdSecretKey            = "cluster_id"
 	CredentialsNamespaceSecretKey = "credentials_namespace"
 
-	ClusterIdConfigMapKey           = "CLUSTER_ID"
+	ClusterIdConfigMapKey           = drift.ClusterIdConfigMapKey
 	ReleaseNamespaceConfigMapKey    = "RELEASE_NAMESPACE"
 	ManagementNamespaceConfigMapKey = "MANAGEMENT_NAMESPACE"
 	InitialClusterIdSecretKey       = "INITIAL_CLUSTER_ID"
@@ -71,12 +72,6 @@ const (
 	operatorName = "btp-manager"
 	operandName  = "sap-btp-operator"
 
-	sapBtpServiceOperatorSecretName          = SapBtpServiceOperatorName
-	sapBtpServiceOperatorClusterIdSecretName = operandName + "-clusterid"
-	sapBtpServiceOperatorConfigMapName       = operandName + "-config"
-
-	caCertSecretName      = "ca-server-cert"
-	webhookCertSecretName = "webhook-server-cert"
 	mutatingWebhookName   = operandName + "-mutating-webhook-configuration"
 	validatingWebhookName = operandName + "-validating-webhook-configuration"
 
@@ -97,18 +92,9 @@ const (
 )
 
 const (
-	caCertSecretCertField      = "ca.crt"
-	caCertSecretKeyField       = "ca.key"
-	webhookCertSecretCertField = "tls.crt"
-	webhookCertSecretKeyField  = "tls.key"
-)
-
-const (
-	secretKind                         = "Secret"
-	configMapKind                      = "ConfigMap"
-	deploymentKind                     = "Deployment"
-	mutatingWebhookConfigurationKind   = "MutatingWebhookConfiguration"
-	validatingWebhookConfigurationKind = "ValidatingWebhookConfiguration"
+	secretKind     = "Secret"
+	configMapKind  = "ConfigMap"
+	deploymentKind = "Deployment"
 
 	deploymentAvailableConditionType   = "Available"
 	deploymentProgressingConditionType = "Progressing"
@@ -647,5 +633,5 @@ func (r *BtpOperatorReconciler) isCredentialsSecret(s *corev1.Secret) bool {
 }
 
 func (r *BtpOperatorReconciler) isCertSecret(s *corev1.Secret) bool {
-	return s.Namespace == config.ChartNamespace && (s.Name == caCertSecretName || s.Name == webhookCertSecretName)
+	return s.Namespace == config.ChartNamespace && (s.Name == certificate.CaCertSecretName || s.Name == certificate.WebhookCertSecretName)
 }

--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -22,15 +22,12 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/go-logr/logr"
 	"github.com/kyma-project/btp-manager/api/v1alpha1"
 	"github.com/kyma-project/btp-manager/controllers/config"
 	"github.com/kyma-project/btp-manager/internal/conditions"
 	"github.com/kyma-project/btp-manager/internal/configurator"
-	"github.com/kyma-project/btp-manager/internal/credentials/drift"
 	"github.com/kyma-project/btp-manager/internal/deprovisioning"
 	"github.com/kyma-project/btp-manager/internal/k8s/networkpolicy"
-	"github.com/kyma-project/btp-manager/internal/manager/moduleresource"
 	"github.com/kyma-project/btp-manager/internal/metrics"
 	"github.com/kyma-project/btp-manager/internal/provisioning"
 	"github.com/kyma-project/btp-manager/internal/webhook/certificate"
@@ -153,8 +150,6 @@ type BtpOperatorReconciler struct {
 	instanceBindingService InstanceBindingSerivce
 	workqueueSize          int
 	networkPolicyManager   networkpolicy.NetworkPolicyManager
-	driftDetector          drift.Detector
-	moduleResourceManager  moduleresource.ResourceManager
 	certManager            certificate.CertificateManager
 	provisioningHandler    provisioning.Handler
 	configurator           configurator.SapBtpServiceOperatorConfigurator
@@ -162,7 +157,7 @@ type BtpOperatorReconciler struct {
 	deprovisioningHandler  deprovisioning.Handler
 }
 
-func NewBtpOperatorReconciler(client client.Client, apiServerClient client.Client, scheme *runtime.Scheme, instanceBindingSerivice InstanceBindingSerivce, metrics *metrics.WebhookMetrics, watchHandlers []config.WatchHandler, networkPolicyManager networkpolicy.NetworkPolicyManager, driftDetector drift.Detector, moduleResourceManager moduleresource.ResourceManager, certManager certificate.CertificateManager, provisioningHandler provisioning.Handler, cfg configurator.SapBtpServiceOperatorConfigurator) *BtpOperatorReconciler {
+func NewBtpOperatorReconciler(client client.Client, apiServerClient client.Client, scheme *runtime.Scheme, instanceBindingSerivice InstanceBindingSerivce, metrics *metrics.WebhookMetrics, watchHandlers []config.WatchHandler, networkPolicyManager networkpolicy.NetworkPolicyManager, certManager certificate.CertificateManager, provisioningHandler provisioning.Handler, cfg configurator.SapBtpServiceOperatorConfigurator) *BtpOperatorReconciler {
 	return &BtpOperatorReconciler{
 		Client:                 client,
 		apiServerClient:        apiServerClient,
@@ -171,8 +166,6 @@ func NewBtpOperatorReconciler(client client.Client, apiServerClient client.Clien
 		webhookMetrics:         metrics,
 		watchHandlers:          watchHandlers,
 		networkPolicyManager:   networkPolicyManager,
-		driftDetector:          driftDetector,
-		moduleResourceManager:  moduleResourceManager,
 		certManager:            certManager,
 		provisioningHandler:    provisioningHandler,
 		configurator:           cfg,
@@ -328,22 +321,6 @@ func (r *BtpOperatorReconciler) HandleProcessingState(ctx context.Context, cr *v
 	return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateReady, conditions.ReconcileSucceeded, "Module provisioning succeeded")
 }
 
-func (r *BtpOperatorReconciler) handleSecretVerificationFailure(ctx context.Context, cr *v1alpha1.BtpOperator, logger logr.Logger, errWithReason *ErrorWithReason) error {
-	logger.Info("secret verification failed: " + errWithReason.Error())
-	if errWithReason.Reason == conditions.InvalidSecret {
-		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.Reason, errWithReason.Message)
-	}
-	return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateWarning, errWithReason.Reason, errWithReason.Message)
-}
-
-func (r *BtpOperatorReconciler) getAndVerifyRequiredSecret(ctx context.Context) (*corev1.Secret, *ErrorWithReason) {
-	return r.provisioningHandler.GetAndVerifyRequiredSecret(ctx)
-}
-
-func (r *BtpOperatorReconciler) reconcileResources(ctx context.Context, cr *v1alpha1.BtpOperator, s *corev1.Secret) error {
-	return r.provisioningHandler.ReconcileResources(ctx, cr, s)
-}
-
 func (r *BtpOperatorReconciler) HandleWarningState(ctx context.Context, cr *v1alpha1.BtpOperator) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("Handling Warning state")
@@ -388,14 +365,16 @@ func (r *BtpOperatorReconciler) HandleReadyState(ctx context.Context, cr *v1alph
 	logger := log.FromContext(ctx)
 	logger.Info("Handling Ready state")
 
-	requiredSecret, errWithReason := r.getAndVerifyRequiredSecret(ctx)
+	requiredSecret, errWithReason := r.provisioningHandler.GetAndVerifyRequiredSecret(ctx)
 	if errWithReason != nil {
-		return r.handleSecretVerificationFailure(ctx, cr, logger, errWithReason)
+		logger.Info("secret verification failed: " + errWithReason.Error())
+		if errWithReason.Reason == conditions.InvalidSecret {
+			return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, errWithReason.Reason, errWithReason.Message)
+		}
+		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateWarning, errWithReason.Reason, errWithReason.Message)
 	}
 
-	r.driftDetector.InitializeFromSecret(requiredSecret)
-
-	result := r.configurator.Check(ctx)
+	result := r.configurator.Check(ctx, requiredSecret)
 	if result.ErrorReason != "" {
 		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, result.ErrorReason, result.ErrorMessage)
 	}
@@ -403,11 +382,7 @@ func (r *BtpOperatorReconciler) HandleReadyState(ctx context.Context, cr *v1alph
 		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateProcessing, result.ReprocessReason, result.ReprocessMessage)
 	}
 
-	if err := r.moduleResourceManager.DeleteOutdatedResources(ctx); err != nil {
-		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, conditions.ReconcileFailed, err.Error())
-	}
-
-	if err := r.reconcileResources(ctx, cr, requiredSecret); err != nil {
+	if err := r.provisioningHandler.ReconcileReady(ctx, cr, requiredSecret); err != nil {
 		return r.UpdateBtpOperatorStatus(ctx, cr, v1alpha1.StateError, conditions.ReconcileFailed, err.Error())
 	}
 

--- a/controllers/btpoperator_controller.go
+++ b/controllers/btpoperator_controller.go
@@ -80,10 +80,8 @@ const (
 	chartVersionLabelKey      = "chart-version"
 	kymaProjectModuleLabelKey = "kyma-project.io/module"
 
-	operatorLabelPrefix                       = "operator.kyma-project.io/"
-	previousClusterIdAnnotationKey            = operatorLabelPrefix + "previous-cluster-id"
-	previousCredentialsNamespaceAnnotationKey = operatorLabelPrefix + "previous-credentials-namespace"
-	deletionFinalizer                         = operatorLabelPrefix + operatorName
+	operatorLabelPrefix = "operator.kyma-project.io/"
+	deletionFinalizer   = operatorLabelPrefix + operatorName
 
 	kubernetesAppLabelPrefix = "app.kubernetes.io/"
 	managedByLabelKey        = kubernetesAppLabelPrefix + "managed-by"

--- a/controllers/btpoperator_controller_certificates_test.go
+++ b/controllers/btpoperator_controller_certificates_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kyma-project/btp-manager/controllers/config"
 	"github.com/kyma-project/btp-manager/internal/certs"
 
+	"github.com/kyma-project/btp-manager/internal/webhook/certificate"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -119,33 +120,33 @@ var _ = Describe("BTP Operator controller - certificates", Label("certs"), func(
 				testGeneratedPrivateKeyArray, err := structToByteArray(testGeneratedPrivateKey)
 				Expect(err).To(BeNil())
 
-				caSecret := getSecret(caCertSecretName)
-				caCertificateOriginal, ok := caSecret.Data[caCertSecretCertField]
+				caSecret := getSecret(certificate.CaCertSecretName)
+				caCertificateOriginal, ok := caSecret.Data[certificate.CaCertSecretCertField]
 				Expect(ok).To(BeTrue())
 
-				caPrivateKeyOriginal, ok := caSecret.Data[caCertSecretKeyField]
+				caPrivateKeyOriginal, ok := caSecret.Data[certificate.CaCertSecretKeyField]
 				Expect(ok).To(BeTrue())
 
-				initialWebhookSecret := getSecret(webhookCertSecretName)
-				initialWebhookCert, ok := initialWebhookSecret.Data[webhookCertSecretCertField]
+				initialWebhookSecret := getSecret(certificate.WebhookCertSecretName)
+				initialWebhookCert, ok := initialWebhookSecret.Data[certificate.WebhookCertSecretCertField]
 				Expect(ok).To(BeTrue())
 
 				// this forces full regeneration by change of CA certificate
-				replaceSecretData(caSecret, caCertSecretCertField, testGeneratedCaCert, caCertSecretKeyField, testGeneratedPrivateKeyArray)
+				replaceSecretData(caSecret, certificate.CaCertSecretCertField, testGeneratedCaCert, certificate.CaCertSecretKeyField, testGeneratedPrivateKeyArray)
 
 				GinkgoWriter.Println("Secret overwritten: ", time.Now().Format(time.RFC3339Nano))
 
 				// updated CA certificate should be the result of full regeneration so it is different from initial one and test generated one
 				Eventually(func() bool {
-					currentSecret := getSecret(caCertSecretName)
-					currentCaCert, ok := currentSecret.Data[caCertSecretCertField]
+					currentSecret := getSecret(certificate.CaCertSecretName)
+					currentCaCert, ok := currentSecret.Data[certificate.CaCertSecretCertField]
 					isRegeneratedCA := ok && !bytes.Equal(currentCaCert, testGeneratedCaCert) && !bytes.Equal(currentCaCert, caCertificateOriginal)
 
-					currentPrivateKey, ok := currentSecret.Data[caCertSecretKeyField]
+					currentPrivateKey, ok := currentSecret.Data[certificate.CaCertSecretKeyField]
 					isRegeneratedPrivateKey := ok && !bytes.Equal(currentPrivateKey, testGeneratedPrivateKey) && !bytes.Equal(currentPrivateKey, caPrivateKeyOriginal)
 
-					currentWebhookSecret := getSecret(webhookCertSecretName)
-					currentWebhookCert, ok := currentWebhookSecret.Data[webhookCertSecretCertField]
+					currentWebhookSecret := getSecret(certificate.WebhookCertSecretName)
+					currentWebhookCert, ok := currentWebhookSecret.Data[certificate.WebhookCertSecretCertField]
 					isRegeneratedWebhookCert := ok && !bytes.Equal(currentWebhookCert, initialWebhookCert)
 
 					return isRegeneratedCA && isRegeneratedPrivateKey && isRegeneratedWebhookCert
@@ -158,15 +159,15 @@ var _ = Describe("BTP Operator controller - certificates", Label("certs"), func(
 
 		When("webhook certificate changes and is signed by same CA certificate", func() {
 			It("CA certificate is not changed, webhook certificate is regenerated", func() {
-				beforeCaSecret := getSecret(caCertSecretName)
+				beforeCaSecret := getSecret(certificate.CaCertSecretName)
 
-				currentCa, err := reconciler.certManager.GetSecretData(ctx, caCertSecretName)
+				currentCa, err := reconciler.certManager.GetSecretData(ctx, certificate.CaCertSecretName)
 				Expect(err).To(BeNil())
-				ca, ok := currentCa[caCertSecretCertField]
+				ca, ok := currentCa[certificate.CaCertSecretCertField]
 				Expect(ok).To(BeTrue(), "ca.crt key missing from CA secret")
-				pk, ok := currentCa[caCertSecretKeyField]
+				pk, ok := currentCa[certificate.CaCertSecretKeyField]
 				Expect(ok).To(BeTrue(), "ca.key key missing from CA secret")
-				currentWebhookSecret := getSecret(webhookCertSecretName)
+				currentWebhookSecret := getSecret(certificate.WebhookCertSecretName)
 				originalWebhookSecret := currentWebhookSecret
 
 				newWebhookCertificate, newWebhookPrivateKey, err := certs.GenerateSignedCertificate(time.Now().Add(config.WebhookCertificateExpiration), ca, pk)
@@ -174,21 +175,21 @@ var _ = Describe("BTP Operator controller - certificates", Label("certs"), func(
 				newWebhookPrivateKeyStructured, err := structToByteArray(newWebhookPrivateKey)
 				Expect(err).To(BeNil())
 
-				webhookCert := getSecret(webhookCertSecretName)
-				replaceSecretData(webhookCert, webhookCertSecretCertField, newWebhookCertificate, webhookCertSecretKeyField, newWebhookPrivateKeyStructured)
+				webhookCert := getSecret(certificate.WebhookCertSecretName)
+				replaceSecretData(webhookCert, certificate.WebhookCertSecretCertField, newWebhookCertificate, certificate.WebhookCertSecretKeyField, newWebhookPrivateKeyStructured)
 				ensureReconciliationQueueIsEmpty()
 
-				originalWebhookCert, ok := originalWebhookSecret.Data[webhookCertSecretCertField]
+				originalWebhookCert, ok := originalWebhookSecret.Data[certificate.WebhookCertSecretCertField]
 				Expect(!bytes.Equal(originalWebhookCert, newWebhookCertificate))
 
-				currentWebhookSecret = getSecret(webhookCertSecretName)
-				currentWebhookCert, ok := currentWebhookSecret.Data[webhookCertSecretCertField]
+				currentWebhookSecret = getSecret(certificate.WebhookCertSecretName)
+				currentWebhookCert, ok := currentWebhookSecret.Data[certificate.WebhookCertSecretCertField]
 				Expect(ok).To(BeTrue())
 				Expect(bytes.Equal(currentWebhookCert, newWebhookCertificate))
 
-				afterCaSecret := getSecret(caCertSecretName)
-				afterCaSecretCert, ok := afterCaSecret.Data[caCertSecretCertField]
-				beforeCaSecretCert, ok := beforeCaSecret.Data[caCertSecretCertField]
+				afterCaSecret := getSecret(certificate.CaCertSecretName)
+				afterCaSecretCert, ok := afterCaSecret.Data[certificate.CaCertSecretCertField]
+				beforeCaSecretCert, ok := beforeCaSecret.Data[certificate.CaCertSecretCertField]
 				Expect(bytes.Equal(afterCaSecretCert, beforeCaSecretCert))
 				ensureCorrectState()
 			})
@@ -204,17 +205,17 @@ var _ = Describe("BTP Operator controller - certificates", Label("certs"), func(
 				testGeneratedPrivateKeyArray, err := structToByteArray(newWebhookPrivateKey)
 				Expect(err).To(BeNil())
 
-				initialCaSecret := getSecret(caCertSecretName)
-				initialCaCert, ok := initialCaSecret.Data[caCertSecretCertField]
+				initialCaSecret := getSecret(certificate.CaCertSecretName)
+				initialCaCert, ok := initialCaSecret.Data[certificate.CaCertSecretCertField]
 				Expect(ok).To(BeTrue())
 
-				initialWebhookSecret := getSecret(webhookCertSecretName)
-				initialWebhhookCert, ok := initialWebhookSecret.Data[webhookCertSecretCertField]
+				initialWebhookSecret := getSecret(certificate.WebhookCertSecretName)
+				initialWebhhookCert, ok := initialWebhookSecret.Data[certificate.WebhookCertSecretCertField]
 				Expect(ok).To(BeTrue())
 
 				webhookCertSecret := initialWebhookSecret
 				// this forces full regeneration since this webhook certificate is signed by different CA certificate (test generated)
-				replaceSecretData(webhookCertSecret, webhookCertSecretCertField, testGeneratedWebhookCert, webhookCertSecretKeyField, testGeneratedPrivateKeyArray)
+				replaceSecretData(webhookCertSecret, certificate.WebhookCertSecretCertField, testGeneratedWebhookCert, certificate.WebhookCertSecretKeyField, testGeneratedPrivateKeyArray)
 
 				GinkgoWriter.Println("Secret overwritten: ", time.Now().Format(time.RFC3339Nano))
 
@@ -222,12 +223,12 @@ var _ = Describe("BTP Operator controller - certificates", Label("certs"), func(
 				// accordingly webhook certificate should be different from old one and new one
 
 				Eventually(func() bool {
-					currentCaSecret := getSecret(caCertSecretName)
-					currentCaCert, ok := currentCaSecret.Data[caCertSecretCertField]
+					currentCaSecret := getSecret(certificate.CaCertSecretName)
+					currentCaCert, ok := currentCaSecret.Data[certificate.CaCertSecretCertField]
 					isRegeneratedCA := ok && !bytes.Equal(currentCaCert, testGeneratedCaCertificate) && !bytes.Equal(currentCaCert, initialCaCert)
 
-					currentWebhookSecret := getSecret(webhookCertSecretName)
-					currentWebhookCert, ok := currentWebhookSecret.Data[webhookCertSecretCertField]
+					currentWebhookSecret := getSecret(certificate.WebhookCertSecretName)
+					currentWebhookCert, ok := currentWebhookSecret.Data[certificate.WebhookCertSecretCertField]
 					isRegeneratedWebhookCert := ok && !bytes.Equal(currentWebhookCert, testGeneratedWebhookCert) && !bytes.Equal(currentWebhookCert, initialWebhhookCert)
 
 					return isRegeneratedCA && isRegeneratedWebhookCert
@@ -283,9 +284,9 @@ var _ = Describe("BTP Operator controller - certificates", Label("certs"), func(
 			})
 
 			It("CA certificate is not changed, webhook certificate is regenerated", func() {
-				caSecretBeforeExpiration := getSecret(caCertSecretName)
-				webhookSecretBeforeExpiration := getSecret(webhookCertSecretName)
-				Expect(checkHowManySecondsToExpiration(webhookCertSecretName)).Should(BeNumerically("<=", fakeSeconds))
+				caSecretBeforeExpiration := getSecret(certificate.CaCertSecretName)
+				webhookSecretBeforeExpiration := getSecret(certificate.WebhookCertSecretName)
+				Expect(checkHowManySecondsToExpiration(certificate.WebhookCertSecretName)).Should(BeNumerically("<=", fakeSeconds))
 
 				restoreOriginalCertificateTimes()
 				ensureReconciliationQueueIsEmpty()
@@ -295,11 +296,11 @@ var _ = Describe("BTP Operator controller - certificates", Label("certs"), func(
 				}})
 				Expect(err).To(BeNil())
 				ensureReconciliationQueueIsEmpty()
-				caSecretAfterExpiration := getSecret(caCertSecretName)
-				webhookSecretAfterExpiration := getSecret(webhookCertSecretName)
+				caSecretAfterExpiration := getSecret(certificate.CaCertSecretName)
+				webhookSecretAfterExpiration := getSecret(certificate.WebhookCertSecretName)
 				Expect(reflect.DeepEqual(caSecretBeforeExpiration.Data, caSecretAfterExpiration.Data)).To(BeTrue())
 				Expect(reflect.DeepEqual(webhookSecretBeforeExpiration.Data, webhookSecretAfterExpiration.Data)).To(BeFalse())
-				Expect(checkHowManySecondsToExpiration(webhookCertSecretName)).Should(BeNumerically(">=", fakeSeconds))
+				Expect(checkHowManySecondsToExpiration(certificate.WebhookCertSecretName)).Should(BeNumerically(">=", fakeSeconds))
 
 				ensureCorrectState()
 			})
@@ -316,9 +317,9 @@ var _ = Describe("BTP Operator controller - certificates", Label("certs"), func(
 			})
 
 			It("fully regenerate of CA certificate and webhook certificate", func() {
-				caSecretBeforeExpiration := getSecret(caCertSecretName)
-				webhookSecretBeforeExpiration := getSecret(webhookCertSecretName)
-				Expect(checkHowManySecondsToExpiration(caCertSecretName)).Should(BeNumerically("<=", fakeSeconds))
+				caSecretBeforeExpiration := getSecret(certificate.CaCertSecretName)
+				webhookSecretBeforeExpiration := getSecret(certificate.WebhookCertSecretName)
+				Expect(checkHowManySecondsToExpiration(certificate.CaCertSecretName)).Should(BeNumerically("<=", fakeSeconds))
 				restoreOriginalCertificateTimes()
 				ensureReconciliationQueueIsEmpty()
 				_, err := reconciler.Reconcile(ctx, controllerruntime.Request{NamespacedName: apimachienerytypes.NamespacedName{
@@ -327,12 +328,12 @@ var _ = Describe("BTP Operator controller - certificates", Label("certs"), func(
 				}})
 				Expect(err).To(BeNil())
 				ensureReconciliationQueueIsEmpty()
-				caSecretAfterExpiration := getSecret(caCertSecretName)
-				webhookSecretAfterExpiration := getSecret(webhookCertSecretName)
+				caSecretAfterExpiration := getSecret(certificate.CaCertSecretName)
+				webhookSecretAfterExpiration := getSecret(certificate.WebhookCertSecretName)
 				Expect(reflect.DeepEqual(caSecretBeforeExpiration.Data, caSecretAfterExpiration.Data)).To(BeFalse())
 				Expect(reflect.DeepEqual(webhookSecretBeforeExpiration.Data, webhookSecretAfterExpiration.Data)).To(BeFalse())
-				Expect(checkHowManySecondsToExpiration(webhookCertSecretName)).Should(BeNumerically(">=", fakeSeconds))
-				Expect(checkHowManySecondsToExpiration(caCertSecretName)).Should(BeNumerically(">=", fakeSeconds))
+				Expect(checkHowManySecondsToExpiration(certificate.WebhookCertSecretName)).Should(BeNumerically(">=", fakeSeconds))
+				Expect(checkHowManySecondsToExpiration(certificate.CaCertSecretName)).Should(BeNumerically(">=", fakeSeconds))
 				ensureCorrectState()
 			})
 		})

--- a/controllers/btpoperator_controller_configuration_test.go
+++ b/controllers/btpoperator_controller_configuration_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kyma-project/btp-manager/api/v1alpha1"
 	"github.com/kyma-project/btp-manager/controllers/config"
 
+	"github.com/kyma-project/btp-manager/internal/credentials/drift"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -29,7 +30,7 @@ var _ = Describe("Configuration controller", func() {
 			Eventually(updateCh).Should(Receive(matchState(v1alpha1.StateReady)))
 
 			existing := &corev1.ConfigMap{}
-			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: sapBtpServiceOperatorConfigMapName, Namespace: kymaNamespace}, existing)).To(Succeed())
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: drift.SapBtpServiceOperatorConfigMapName, Namespace: kymaNamespace}, existing)).To(Succeed())
 			existing.Data = map[string]string{
 				EnableLimitedCacheConfigMapKey: "false",
 			}

--- a/controllers/btpoperator_controller_secret_customization_test.go
+++ b/controllers/btpoperator_controller_secret_customization_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kyma-project/btp-manager/controllers/config"
 	"github.com/kyma-project/btp-manager/internal/conditions"
 
+	"github.com/kyma-project/btp-manager/internal/credentials/drift"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
@@ -118,13 +119,13 @@ var _ = Describe("BTP Operator controller - secret customization", Label("custom
 			btpServiceOperatorDeployment := &appsv1.Deployment{}
 			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: config.DeploymentName, Namespace: kymaNamespace}, btpServiceOperatorDeployment)).To(Succeed())
 
-			expectSecretToHaveCredentials(getSecretFromNamespace(sapBtpServiceOperatorSecretName, customCredentialsNamespace), defaultClientId, defaultClientSecret, defaultSmUrl, defaultTokenUrl)
+			expectSecretToHaveCredentials(getSecretFromNamespace(drift.SapBtpServiceOperatorSecretName, customCredentialsNamespace), defaultClientId, defaultClientSecret, defaultSmUrl, defaultTokenUrl)
 			expectConfigMapToHave(getOperatorConfigMap(), defaultClusterId, customCredentialsNamespace, customCredentialsNamespace)
 
 			_, err = reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKey{Name: btpOperatorName, Namespace: kymaNamespace}})
 			Expect(err).To(BeNil())
 
-			expectSecretToHaveCredentials(getSecretFromNamespace(sapBtpServiceOperatorSecretName, customCredentialsNamespace), defaultClientId, defaultClientSecret, defaultSmUrl, defaultTokenUrl)
+			expectSecretToHaveCredentials(getSecretFromNamespace(drift.SapBtpServiceOperatorSecretName, customCredentialsNamespace), defaultClientId, defaultClientSecret, defaultSmUrl, defaultTokenUrl)
 			expectConfigMapToHave(getOperatorConfigMap(), defaultClusterId, customCredentialsNamespace, customCredentialsNamespace)
 		})
 	})
@@ -184,7 +185,7 @@ var _ = Describe("BTP Operator controller - secret customization", Label("custom
 			Expect(k8sClient.Update(ctx, btpManagerSecret)).To(Succeed())
 
 			Eventually(updateCh).Should(Receive(matchReadyCondition(v1alpha1.StateReady, metav1.ConditionTrue, conditions.ReconcileSucceeded)))
-			expectSecretToHaveCredentials(getSecretFromNamespace(sapBtpServiceOperatorSecretName, customCredentialsNamespace), clientId, defaultClientSecret, defaultSmUrl, defaultTokenUrl)
+			expectSecretToHaveCredentials(getSecretFromNamespace(drift.SapBtpServiceOperatorSecretName, customCredentialsNamespace), clientId, defaultClientSecret, defaultSmUrl, defaultTokenUrl)
 			expectConfigMapToHave(getOperatorConfigMap(), clusterId, customCredentialsNamespace, customCredentialsNamespace)
 		})
 	})

--- a/controllers/btpoperator_controller_test.go
+++ b/controllers/btpoperator_controller_test.go
@@ -34,7 +34,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should return error from client.Get", func(t *testing.T) {
 		// given
 		retryK8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil, nil, nil)
+		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil)
 		retryK8sClient.EnableErrorOnGet()
 
 		// when
@@ -57,7 +57,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should return error from client.Update", func(t *testing.T) {
 		// given
 		retryK8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil, nil, nil)
+		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil)
 		retryK8sClient.EnableErrorOnUpdate()
 
 		// when
@@ -80,7 +80,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should time out", func(t *testing.T) {
 		// given
 		disabledUpdatek8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(disabledUpdatek8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil, nil, nil)
+		btpOperatorReconciler := NewBtpOperatorReconciler(disabledUpdatek8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil)
 		disabledUpdatek8sClient.DisableUpdate()
 
 		// when
@@ -102,7 +102,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should update BtpOperator status after a few retries", func(t *testing.T) {
 		// given
 		retryK8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil, nil, nil)
+		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil)
 
 		// when
 		err := btpOperatorReconciler.UpdateBtpOperatorStatus(ctx, btpOperator, v1alpha1.StateProcessing, conditions.Initialized, "test")
@@ -124,7 +124,7 @@ func TestBtpOperatorReconciler_UpdateBtpOperatorStatus(t *testing.T) {
 	t.Run("should update BtpOperator status three times", func(t *testing.T) {
 		// given
 		retryK8sClient := newLazyK8sClient(fakeK8sClient, 3)
-		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil, nil, nil)
+		btpOperatorReconciler := NewBtpOperatorReconciler(retryK8sClient, fakeK8sClient, scheme, nil, nil, []config.WatchHandler{}, nil, nil, nil, nil)
 		conditionMsg1 := "test1"
 		conditionMsg2 := "test2"
 		conditionMsg3 := "test3"

--- a/controllers/btpoperator_controller_updating_test.go
+++ b/controllers/btpoperator_controller_updating_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/kyma-project/btp-manager/internal/credentials/drift"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -104,7 +105,7 @@ var _ = Describe("BTP Operator controller - updating", func() {
 			Expect(err).To(BeNil())
 
 			err = ymlutils.AddSuffixToNameInManifests(getApplyPath(), suffix,
-				sapBtpServiceOperatorConfigMapName, sapBtpServiceOperatorSecretName, config.DeploymentName)
+				drift.SapBtpServiceOperatorConfigMapName, drift.SapBtpServiceOperatorSecretName, config.DeploymentName)
 			Expect(err).To(BeNil())
 
 			err = ymlutils.UpdateChartVersion(chartUpdatePathForProcess, newChartVersion)
@@ -145,7 +146,7 @@ var _ = Describe("BTP Operator controller - updating", func() {
 			Expect(err).To(BeNil())
 
 			err = ymlutils.AddSuffixToNameInManifests(getTempPath(), suffix,
-				sapBtpServiceOperatorConfigMapName, sapBtpServiceOperatorSecretName, config.DeploymentName)
+				drift.SapBtpServiceOperatorConfigMapName, drift.SapBtpServiceOperatorSecretName, config.DeploymentName)
 			Expect(err).To(BeNil())
 
 			err = moveOrCopyNFilesFromDirToDir(updateManifestsNum, true, getTempPath(), getApplyPath())

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -208,8 +208,6 @@ var _ = SynchronizedBeforeSuite(func() {
 			config.NewHandler(k8sManager.GetClient(), k8sManager.GetScheme(), configMetrics),
 		},
 		networkPolicyManager,
-		driftDetector,
-		moduleResourceManager,
 		certManager,
 		provisioningHandler,
 		sapBtpConfigurator,

--- a/controllers/utils_test.go
+++ b/controllers/utils_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/kyma-project/btp-manager/internal/conditions"
 	"github.com/kyma-project/btp-manager/internal/ymlutils"
 
+	"github.com/kyma-project/btp-manager/internal/credentials/drift"
+	"github.com/kyma-project/btp-manager/internal/webhook/certificate"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -715,11 +717,11 @@ func getSecret(name string) *corev1.Secret {
 }
 
 func getOperatorSecret() *corev1.Secret {
-	return getSecret(sapBtpServiceOperatorSecretName)
+	return getSecret(drift.SapBtpServiceOperatorSecretName)
 }
 
 func getOperatorConfigMap() *corev1.ConfigMap {
-	return getConfigMap(sapBtpServiceOperatorConfigMapName)
+	return getConfigMap(drift.SapBtpServiceOperatorConfigMapName)
 }
 func getConfigMap(name string) *corev1.ConfigMap {
 	configMap := &corev1.ConfigMap{}
@@ -731,9 +733,9 @@ func getConfigMap(name string) *corev1.ConfigMap {
 func checkHowManySecondsToExpiration(name string) float64 {
 	data, err := reconciler.certManager.GetSecretData(ctx, name)
 	Expect(err).To(BeNil())
-	value := data[caCertSecretCertField]
-	if name == webhookCertSecretName {
-		value = data[webhookCertSecretCertField]
+	value := data[certificate.CaCertSecretCertField]
+	if name == certificate.WebhookCertSecretName {
+		value = data[certificate.WebhookCertSecretCertField]
 	}
 	decoded, _ := pem.Decode(value)
 	Expect(decoded).NotTo(BeNil(), "pem.Decode returned nil for secret %q", name)
@@ -745,8 +747,8 @@ func checkHowManySecondsToExpiration(name string) float64 {
 
 func ensureAllWebhooksManagedByBtpOperatorHaveCorrectCABundles() {
 	Eventually(func() error {
-		secret := getSecret(caCertSecretName)
-		ca, ok := secret.Data[caCertSecretCertField]
+		secret := getSecret(certificate.CaCertSecretName)
+		ca, ok := secret.Data[certificate.CaCertSecretCertField]
 		if !ok || ca == nil {
 			return fmt.Errorf("CA bundle not found in secret")
 		}

--- a/internal/configurator/configurator.go
+++ b/internal/configurator/configurator.go
@@ -11,6 +11,7 @@ import (
 )
 
 type OperatorStateReader interface {
+	InitializeFromSecret(s *corev1.Secret)
 	GetDefaultCredentialsSecret(ctx context.Context) (*corev1.Secret, error)
 	GetSapBtpServiceOperatorConfigMap(ctx context.Context) (*corev1.ConfigMap, error)
 	CredentialsNamespaceFromManager() string
@@ -27,7 +28,7 @@ type CheckResult struct {
 }
 
 type SapBtpServiceOperatorConfigurator interface {
-	Check(ctx context.Context) CheckResult
+	Check(ctx context.Context, secret *corev1.Secret) CheckResult
 }
 
 type configurator struct {
@@ -40,8 +41,10 @@ func NewConfigurator(r OperatorStateReader) SapBtpServiceOperatorConfigurator {
 
 var _ SapBtpServiceOperatorConfigurator = (*configurator)(nil)
 
-func (c *configurator) Check(ctx context.Context) CheckResult {
+func (c *configurator) Check(ctx context.Context, secret *corev1.Secret) CheckResult {
 	logger := log.FromContext(ctx)
+
+	c.reader.InitializeFromSecret(secret)
 
 	defaultCredentialsSecret, err := c.reader.GetDefaultCredentialsSecret(ctx)
 	if err != nil {

--- a/internal/configurator/configurator_test.go
+++ b/internal/configurator/configurator_test.go
@@ -19,6 +19,7 @@ type stubReader struct {
 	configMapErr     error
 }
 
+func (s *stubReader) InitializeFromSecret(_ *corev1.Secret)   {}
 func (s *stubReader) CredentialsNamespaceFromManager() string { return s.credNs }
 func (s *stubReader) ClusterIdFromManager() string            { return s.clusterId }
 func (s *stubReader) GetDefaultCredentialsSecret(_ context.Context) (*corev1.Secret, error) {
@@ -43,7 +44,7 @@ func TestCheck_NoChanges(t *testing.T) {
 		defaultSecret: secret("kyma-system"),
 		configMap:     configMap("c1"),
 	})
-	result := c.Check(context.Background())
+	result := c.Check(context.Background(), &corev1.Secret{})
 	if result.ReprocessReason != "" || result.ErrorReason != "" {
 		t.Fatalf("expected empty result, got %+v", result)
 	}
@@ -51,7 +52,7 @@ func TestCheck_NoChanges(t *testing.T) {
 
 func TestCheck_NoDefaultSecret_NoConfigMap(t *testing.T) {
 	c := NewConfigurator(&stubReader{credNs: "kyma-system", clusterId: "c1"})
-	result := c.Check(context.Background())
+	result := c.Check(context.Background(), &corev1.Secret{})
 	if result.ReprocessReason != "" || result.ErrorReason != "" {
 		t.Fatalf("expected empty result when no operand resources exist, got %+v", result)
 	}
@@ -63,7 +64,7 @@ func TestCheck_CredentialsNamespaceDrift(t *testing.T) {
 		clusterId:     "c1",
 		defaultSecret: secret("old-ns"),
 	})
-	result := c.Check(context.Background())
+	result := c.Check(context.Background(), &corev1.Secret{})
 	if result.ReprocessReason != conditions.CredentialsNamespaceChanged {
 		t.Fatalf("expected CredentialsNamespaceChanged, got %v", result.ReprocessReason)
 	}
@@ -79,7 +80,7 @@ func TestCheck_ClusterIdDrift(t *testing.T) {
 		defaultSecret: secret("kyma-system"),
 		configMap:     configMap("old-id"),
 	})
-	result := c.Check(context.Background())
+	result := c.Check(context.Background(), &corev1.Secret{})
 	if result.ReprocessReason != conditions.ClusterIdChanged {
 		t.Fatalf("expected ClusterIdChanged, got %v", result.ReprocessReason)
 	}
@@ -90,7 +91,7 @@ func TestCheck_ClusterIdDrift(t *testing.T) {
 
 func TestCheck_DefaultSecretError(t *testing.T) {
 	c := NewConfigurator(&stubReader{defaultSecretErr: errors.New("api down")})
-	result := c.Check(context.Background())
+	result := c.Check(context.Background(), &corev1.Secret{})
 	if result.ErrorReason != conditions.GettingDefaultCredentialsSecretFailed {
 		t.Fatalf("expected GettingDefaultCredentialsSecretFailed, got %v", result.ErrorReason)
 	}
@@ -103,7 +104,7 @@ func TestCheck_ConfigMapError(t *testing.T) {
 		defaultSecret: secret("kyma-system"),
 		configMapErr:  errors.New("api down"),
 	})
-	result := c.Check(context.Background())
+	result := c.Check(context.Background(), &corev1.Secret{})
 	if result.ErrorReason != conditions.GettingSapBtpServiceOperatorConfigMapFailed {
 		t.Fatalf("expected GettingSapBtpServiceOperatorConfigMapFailed, got %v", result.ErrorReason)
 	}

--- a/internal/configurator/configurator_test.go
+++ b/internal/configurator/configurator_test.go
@@ -11,17 +11,18 @@ import (
 )
 
 type stubReader struct {
-	credNs           string
-	clusterId        string
-	defaultSecret    *corev1.Secret
-	configMap        *corev1.ConfigMap
-	defaultSecretErr error
-	configMapErr     error
+	credNs            string
+	clusterId         string
+	defaultSecret     *corev1.Secret
+	configMap         *corev1.ConfigMap
+	defaultSecretErr  error
+	configMapErr      error
+	initializedSecret *corev1.Secret
 }
 
-func (s *stubReader) InitializeFromSecret(_ *corev1.Secret)   {}
-func (s *stubReader) CredentialsNamespaceFromManager() string { return s.credNs }
-func (s *stubReader) ClusterIdFromManager() string            { return s.clusterId }
+func (s *stubReader) InitializeFromSecret(secret *corev1.Secret) { s.initializedSecret = secret }
+func (s *stubReader) CredentialsNamespaceFromManager() string    { return s.credNs }
+func (s *stubReader) ClusterIdFromManager() string               { return s.clusterId }
 func (s *stubReader) GetDefaultCredentialsSecret(_ context.Context) (*corev1.Secret, error) {
 	return s.defaultSecret, s.defaultSecretErr
 }
@@ -35,6 +36,16 @@ func secret(ns string) *corev1.Secret {
 
 func configMap(clusterId string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{Data: map[string]string{"CLUSTER_ID": clusterId}}
+}
+
+func TestCheck_InitializesFromSecret(t *testing.T) {
+	stub := &stubReader{credNs: "kyma-system", clusterId: "c1"}
+	c := NewConfigurator(stub)
+	passedSecret := secret("kyma-system")
+	c.Check(context.Background(), passedSecret)
+	if stub.initializedSecret != passedSecret {
+		t.Fatalf("expected InitializeFromSecret to be called with the passed secret, got %v", stub.initializedSecret)
+	}
 }
 
 func TestCheck_NoChanges(t *testing.T) {

--- a/internal/credentials/drift/detector.go
+++ b/internal/credentials/drift/detector.go
@@ -29,10 +29,6 @@ const (
 	operatorName = "btp-manager"
 	operandName  = "sap-btp-operator"
 
-	sapBtpServiceOperatorSecretName          = "sap-btp-service-operator"
-	sapBtpServiceOperatorClusterIdSecretName = operandName + "-clusterid"
-	sapBtpServiceOperatorConfigMapName       = operandName + "-config"
-
 	operatorLabelPrefix                       = "operator.kyma-project.io/"
 	previousClusterIdAnnotationKey            = operatorLabelPrefix + "previous-cluster-id"
 	previousCredentialsNamespaceAnnotationKey = operatorLabelPrefix + "previous-credentials-namespace"
@@ -127,14 +123,14 @@ func (d *DriftDetector) CheckCredentialsNamespaceDrift(ctx context.Context, requ
 
 	defaultCredentialsSecret, err := d.GetDefaultCredentialsSecret(ctx)
 	if err != nil {
-		logger.Error(err, fmt.Sprintf("while getting %s secret", sapBtpServiceOperatorSecretName))
+		logger.Error(err, fmt.Sprintf("while getting %s secret", SapBtpServiceOperatorSecretName))
 		return conditions.NewErrorWithReason(conditions.GettingDefaultCredentialsSecretFailed, err.Error())
 	}
 
 	if defaultCredentialsSecret != nil {
 		d.credentialsNamespaceFromSapBtpServiceOperatorSecret = defaultCredentialsSecret.Namespace
 		if d.credentialsNamespaceFromSapBtpManagerSecret != d.credentialsNamespaceFromSapBtpServiceOperatorSecret {
-			logger.Info(fmt.Sprintf("credentials namespaces between %s secret and %s secret don't match", config.SecretName, sapBtpServiceOperatorSecretName))
+			logger.Info(fmt.Sprintf("credentials namespaces between %s secret and %s secret don't match", config.SecretName, SapBtpServiceOperatorSecretName))
 			if err := d.annotateSecret(ctx, requiredSecret, previousCredentialsNamespaceAnnotationKey, d.credentialsNamespaceFromSapBtpServiceOperatorSecret); err != nil {
 				return conditions.NewErrorWithReason(conditions.AnnotatingSecretFailed, err.Error())
 			}
@@ -149,7 +145,7 @@ func (d *DriftDetector) CheckClusterIdConfigMapDrift(ctx context.Context, requir
 
 	sapBtpOperatorConfigMap, err := d.GetSapBtpServiceOperatorConfigMap(ctx)
 	if err != nil {
-		logger.Error(err, fmt.Sprintf("while getting %s ConfigMap", sapBtpServiceOperatorConfigMapName))
+		logger.Error(err, fmt.Sprintf("while getting %s ConfigMap", SapBtpServiceOperatorConfigMapName))
 		return conditions.NewErrorWithReason(conditions.GettingSapBtpServiceOperatorConfigMapFailed, err.Error())
 	}
 
@@ -157,7 +153,7 @@ func (d *DriftDetector) CheckClusterIdConfigMapDrift(ctx context.Context, requir
 		d.clusterIdFromSapBtpServiceOperatorConfigMap = sapBtpOperatorConfigMap.Data[strings.ToUpper(clusterIdSecretKey)]
 		d.clusterIdFromSapBtpServiceOperatorClusterIdSecret = d.clusterIdFromSapBtpServiceOperatorConfigMap
 		if d.clusterIdFromSapBtpManagerSecret != d.clusterIdFromSapBtpServiceOperatorConfigMap {
-			logger.Info(fmt.Sprintf("cluster IDs between %s secret and %s configmap don't match", config.SecretName, sapBtpServiceOperatorConfigMapName))
+			logger.Info(fmt.Sprintf("cluster IDs between %s secret and %s configmap don't match", config.SecretName, SapBtpServiceOperatorConfigMapName))
 			if err := d.annotateSecret(ctx, requiredSecret, previousClusterIdAnnotationKey, d.clusterIdFromSapBtpServiceOperatorConfigMap); err != nil {
 				return conditions.NewErrorWithReason(conditions.AnnotatingSecretFailed, err.Error())
 			}
@@ -170,9 +166,9 @@ func (d *DriftDetector) CheckClusterIdConfigMapDrift(ctx context.Context, requir
 func (d *DriftDetector) ResolveClusterIdSecretDrift(ctx context.Context, requiredSecret *corev1.Secret) *conditions.ErrorWithReason {
 	logger := log.FromContext(ctx)
 
-	clusterIdSecret, err := d.getSecretByNameAndNamespace(ctx, sapBtpServiceOperatorClusterIdSecretName, d.credentialsNamespaceFromSapBtpServiceOperatorSecret)
+	clusterIdSecret, err := d.getSecretByNameAndNamespace(ctx, SapBtpServiceOperatorClusterIdSecretName, d.credentialsNamespaceFromSapBtpServiceOperatorSecret)
 	if err != nil {
-		logger.Error(err, fmt.Sprintf("while getting %s secret", sapBtpServiceOperatorClusterIdSecretName))
+		logger.Error(err, fmt.Sprintf("while getting %s secret", SapBtpServiceOperatorClusterIdSecretName))
 		return conditions.NewErrorWithReason(conditions.GettingSapBtpServiceOperatorClusterIdSecretFailed, err.Error())
 	}
 
@@ -181,7 +177,7 @@ func (d *DriftDetector) ResolveClusterIdSecretDrift(ctx context.Context, require
 			d.clusterIdFromSapBtpServiceOperatorClusterIdSecret = string(clusterIdFromSecret)
 		}
 		if d.clusterIdFromSapBtpServiceOperatorConfigMap != d.clusterIdFromSapBtpServiceOperatorClusterIdSecret {
-			logger.Info(fmt.Sprintf("cluster IDs between %s configmap and %s secret don't match", sapBtpServiceOperatorConfigMapName, sapBtpServiceOperatorClusterIdSecretName))
+			logger.Info(fmt.Sprintf("cluster IDs between %s configmap and %s secret don't match", SapBtpServiceOperatorConfigMapName, SapBtpServiceOperatorClusterIdSecretName))
 			if err = d.annotateSecret(ctx, requiredSecret, previousClusterIdAnnotationKey, d.clusterIdFromSapBtpServiceOperatorClusterIdSecret); err != nil {
 				logger.Error(err, fmt.Sprintf("while annotating %s secret", requiredSecret.Name))
 				return conditions.NewErrorWithReason(conditions.AnnotatingSecretFailed, err.Error())
@@ -201,7 +197,7 @@ func (d *DriftDetector) ResolveClusterIdSecretDrift(ctx context.Context, require
 }
 
 func (d *DriftDetector) DeleteChangedResources(ctx context.Context) error {
-	clusterIdSecret, err := d.getSecretByNameAndNamespace(ctx, sapBtpServiceOperatorClusterIdSecretName, d.credentialsNamespaceFromSapBtpServiceOperatorSecret)
+	clusterIdSecret, err := d.getSecretByNameAndNamespace(ctx, SapBtpServiceOperatorClusterIdSecretName, d.credentialsNamespaceFromSapBtpServiceOperatorSecret)
 	if err != nil {
 		return err
 	}
@@ -209,7 +205,7 @@ func (d *DriftDetector) DeleteChangedResources(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	credentialsSecret, err := d.getSecretByNameAndNamespace(ctx, sapBtpServiceOperatorSecretName, d.credentialsNamespaceFromSapBtpServiceOperatorSecret)
+	credentialsSecret, err := d.getSecretByNameAndNamespace(ctx, SapBtpServiceOperatorSecretName, d.credentialsNamespaceFromSapBtpServiceOperatorSecret)
 	if err != nil {
 		return err
 	}
@@ -244,7 +240,7 @@ func (d *DriftDetector) DeleteChangedResources(ctx context.Context) error {
 }
 
 func (d *DriftDetector) DeleteClusterIdSecret(ctx context.Context) error {
-	clusterIdSecret, err := d.getSecretByNameAndNamespace(ctx, sapBtpServiceOperatorClusterIdSecretName, d.credentialsNamespaceFromSapBtpManagerSecret)
+	clusterIdSecret, err := d.getSecretByNameAndNamespace(ctx, SapBtpServiceOperatorClusterIdSecretName, d.credentialsNamespaceFromSapBtpManagerSecret)
 	if err != nil {
 		return fmt.Errorf("failed to get cluster ID secret: %w", err)
 	}
@@ -271,7 +267,7 @@ func (d *DriftDetector) GetDefaultCredentialsSecret(ctx context.Context) (*corev
 		return secrets.Items[i].Namespace < secrets.Items[j].Namespace
 	})
 	for i, s := range secrets.Items {
-		if s.Name != sapBtpServiceOperatorSecretName {
+		if s.Name != SapBtpServiceOperatorSecretName {
 			continue
 		}
 		if s.Namespace == d.previousCredentialsNamespace {
@@ -286,7 +282,7 @@ func (d *DriftDetector) GetDefaultCredentialsSecret(ctx context.Context) (*corev
 
 func (d *DriftDetector) GetSapBtpServiceOperatorConfigMap(ctx context.Context) (*corev1.ConfigMap, error) {
 	cm := &corev1.ConfigMap{}
-	if err := d.client.Get(ctx, client.ObjectKey{Namespace: config.ChartNamespace, Name: sapBtpServiceOperatorConfigMapName}, cm); err != nil {
+	if err := d.client.Get(ctx, client.ObjectKey{Namespace: config.ChartNamespace, Name: SapBtpServiceOperatorConfigMapName}, cm); err != nil {
 		if k8serrors.IsNotFound(err) {
 			return nil, nil
 		}

--- a/internal/credentials/drift/detector.go
+++ b/internal/credentials/drift/detector.go
@@ -18,6 +18,10 @@ import (
 const (
 	ClusterIdConfigMapKey = "CLUSTER_ID"
 
+	SapBtpServiceOperatorSecretName          = "sap-btp-service-operator"
+	SapBtpServiceOperatorClusterIdSecretName = operandName + "-clusterid"
+	SapBtpServiceOperatorConfigMapName       = operandName + "-config"
+
 	clusterIdSecretKey            = "cluster_id"
 	credentialsNamespaceSecretKey = "credentials_namespace"
 	initialClusterIdSecretKey     = "INITIAL_CLUSTER_ID"

--- a/internal/credentials/drift/detector.go
+++ b/internal/credentials/drift/detector.go
@@ -18,6 +18,9 @@ import (
 const (
 	ClusterIdConfigMapKey = "CLUSTER_ID"
 
+	operatorName = "btp-manager"
+	operandName  = "sap-btp-operator"
+
 	SapBtpServiceOperatorSecretName          = "sap-btp-service-operator"
 	SapBtpServiceOperatorClusterIdSecretName = operandName + "-clusterid"
 	SapBtpServiceOperatorConfigMapName       = operandName + "-config"
@@ -25,9 +28,6 @@ const (
 	clusterIdSecretKey            = "cluster_id"
 	credentialsNamespaceSecretKey = "credentials_namespace"
 	initialClusterIdSecretKey     = "INITIAL_CLUSTER_ID"
-
-	operatorName = "btp-manager"
-	operandName  = "sap-btp-operator"
 
 	operatorLabelPrefix                       = "operator.kyma-project.io/"
 	previousClusterIdAnnotationKey            = operatorLabelPrefix + "previous-cluster-id"

--- a/internal/credentials/drift/detector_test.go
+++ b/internal/credentials/drift/detector_test.go
@@ -572,8 +572,8 @@ var _ = Describe("Drift Detector", func() {
 				Expect(k8sClient.List(ctx, secrets)).To(Succeed())
 				secretNames := extractSecretNames(secrets.Items)
 				Expect(secretNames).To(ContainElements(
-					sapBtpServiceOperatorSecretName,
-					sapBtpServiceOperatorClusterIdSecretName,
+					drift.SapBtpServiceOperatorSecretName,
+					drift.SapBtpServiceOperatorClusterIdSecretName,
 				))
 
 				pods := &corev1.PodList{}
@@ -610,7 +610,7 @@ var _ = Describe("Drift Detector", func() {
 				secrets := &corev1.SecretList{}
 				Expect(k8sClient.List(ctx, secrets)).To(Succeed())
 				secretNames := extractSecretNames(secrets.Items)
-				Expect(secretNames).NotTo(ContainElement(sapBtpServiceOperatorClusterIdSecretName))
+				Expect(secretNames).NotTo(ContainElement(drift.SapBtpServiceOperatorClusterIdSecretName))
 			})
 
 			It("should not delete the operator credentials secret", func() {
@@ -621,7 +621,7 @@ var _ = Describe("Drift Detector", func() {
 				secrets := &corev1.SecretList{}
 				Expect(k8sClient.List(ctx, secrets)).To(Succeed())
 				secretNames := extractSecretNames(secrets.Items)
-				Expect(secretNames).To(ContainElement(sapBtpServiceOperatorSecretName))
+				Expect(secretNames).To(ContainElement(drift.SapBtpServiceOperatorSecretName))
 			})
 		})
 
@@ -650,8 +650,8 @@ var _ = Describe("Drift Detector", func() {
 				secrets := &corev1.SecretList{}
 				Expect(k8sClient.List(ctx, secrets)).To(Succeed())
 				secretNames := extractSecretNames(secrets.Items)
-				Expect(secretNames).NotTo(ContainElement(sapBtpServiceOperatorClusterIdSecretName))
-				Expect(secretNames).NotTo(ContainElement(sapBtpServiceOperatorSecretName))
+				Expect(secretNames).NotTo(ContainElement(drift.SapBtpServiceOperatorClusterIdSecretName))
+				Expect(secretNames).NotTo(ContainElement(drift.SapBtpServiceOperatorSecretName))
 			})
 		})
 

--- a/internal/credentials/drift/suite_test.go
+++ b/internal/credentials/drift/suite_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/kyma-project/btp-manager/internal/credentials/drift"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -19,11 +20,8 @@ import (
 const (
 	kymaNamespace = "kyma-system"
 
-	sapBtpManagerSecretName                  = "sap-btp-manager"
-	sapBtpServiceOperatorSecretName          = "sap-btp-service-operator"
-	sapBtpServiceOperatorClusterIdSecretName = "sap-btp-operator-clusterid"
-	sapBtpServiceOperatorConfigMapName       = "sap-btp-operator-config"
-	operandName                              = "sap-btp-operator"
+	sapBtpManagerSecretName = "sap-btp-manager"
+	operandName             = "sap-btp-operator"
 
 	managedByLabelKey = "app.kubernetes.io/managed-by"
 	instanceLabelKey  = "app.kubernetes.io/instance"
@@ -77,7 +75,7 @@ func btpManagerSecret(clusterID, credentialsNamespace string, annotations map[st
 func operatorSecret(namespace string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      sapBtpServiceOperatorSecretName,
+			Name:      drift.SapBtpServiceOperatorSecretName,
 			Namespace: namespace,
 			Labels:    map[string]string{managedByLabelKey: operatorName},
 		},
@@ -87,7 +85,7 @@ func operatorSecret(namespace string) *corev1.Secret {
 func clusterIdSecret(namespace, initialClusterID string) *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      sapBtpServiceOperatorClusterIdSecretName,
+			Name:      drift.SapBtpServiceOperatorClusterIdSecretName,
 			Namespace: namespace,
 		},
 		Data: map[string][]byte{
@@ -99,7 +97,7 @@ func clusterIdSecret(namespace, initialClusterID string) *corev1.Secret {
 func operatorConfigMap(clusterID string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      sapBtpServiceOperatorConfigMapName,
+			Name:      drift.SapBtpServiceOperatorConfigMapName,
 			Namespace: kymaNamespace,
 		},
 		Data: map[string]string{

--- a/internal/provisioning/handler.go
+++ b/internal/provisioning/handler.go
@@ -36,7 +36,7 @@ type ProvisionResult struct {
 type Handler interface {
 	Provision(ctx context.Context, cr *v1alpha1.BtpOperator) ProvisionResult
 	GetAndVerifyRequiredSecret(ctx context.Context) (*corev1.Secret, *conditions.ErrorWithReason)
-	ReconcileResources(ctx context.Context, cr *v1alpha1.BtpOperator, secret *corev1.Secret) error
+	ReconcileReady(ctx context.Context, cr *v1alpha1.BtpOperator, secret *corev1.Secret) error
 	ReconcileResourcesWithoutStatusChange(ctx context.Context, cr *v1alpha1.BtpOperator)
 }
 
@@ -146,6 +146,13 @@ func (h *handler) getRequiredSecret(ctx context.Context) (*corev1.Secret, error)
 		return nil, fmt.Errorf("unable to get Secret: %w", err)
 	}
 	return secret, nil
+}
+
+func (h *handler) ReconcileReady(ctx context.Context, cr *v1alpha1.BtpOperator, secret *corev1.Secret) error {
+	if err := h.moduleResourceManager.DeleteOutdatedResources(ctx); err != nil {
+		return err
+	}
+	return h.ReconcileResources(ctx, cr, secret)
 }
 
 func (h *handler) ReconcileResources(ctx context.Context, cr *v1alpha1.BtpOperator, s *corev1.Secret) error {

--- a/internal/provisioning/handler.go
+++ b/internal/provisioning/handler.go
@@ -99,7 +99,7 @@ func (h *handler) Provision(ctx context.Context, cr *v1alpha1.BtpOperator) Provi
 		return ProvisionResult{ErrorReason: conditions.NewErrorWithReason(conditions.ProvisioningFailed, err.Error())}
 	}
 
-	if err := h.ReconcileResources(ctx, cr, requiredSecret); err != nil {
+	if err := h.reconcileResources(ctx, cr, requiredSecret); err != nil {
 		return ProvisionResult{ErrorReason: conditions.NewErrorWithReason(conditions.ProvisioningFailed, err.Error())}
 	}
 
@@ -152,10 +152,10 @@ func (h *handler) ReconcileReady(ctx context.Context, cr *v1alpha1.BtpOperator, 
 	if err := h.moduleResourceManager.DeleteOutdatedResources(ctx); err != nil {
 		return err
 	}
-	return h.ReconcileResources(ctx, cr, secret)
+	return h.reconcileResources(ctx, cr, secret)
 }
 
-func (h *handler) ReconcileResources(ctx context.Context, cr *v1alpha1.BtpOperator, s *corev1.Secret) error {
+func (h *handler) reconcileResources(ctx context.Context, cr *v1alpha1.BtpOperator, s *corev1.Secret) error {
 	logger := log.FromContext(ctx)
 
 	logger.Info("getting module resources to apply")
@@ -224,7 +224,7 @@ func (h *handler) ReconcileResourcesWithoutStatusChange(ctx context.Context, cr 
 	if err := h.moduleResourceManager.DeleteOutdatedResources(ctx); err != nil {
 		logger.Error(err, "outdated resources deletion failed")
 	}
-	if err := h.ReconcileResources(ctx, cr, secret); err != nil {
+	if err := h.reconcileResources(ctx, cr, secret); err != nil {
 		logger.Error(err, "resources reconciliation failed")
 	}
 }

--- a/internal/provisioning/handler.go
+++ b/internal/provisioning/handler.go
@@ -149,6 +149,7 @@ func (h *handler) getRequiredSecret(ctx context.Context) (*corev1.Secret, error)
 }
 
 func (h *handler) ReconcileReady(ctx context.Context, cr *v1alpha1.BtpOperator, secret *corev1.Secret) error {
+	h.driftDetector.InitializeFromSecret(secret)
 	if err := h.moduleResourceManager.DeleteOutdatedResources(ctx); err != nil {
 		return err
 	}

--- a/internal/provisioning/handler.go
+++ b/internal/provisioning/handler.go
@@ -149,7 +149,6 @@ func (h *handler) getRequiredSecret(ctx context.Context) (*corev1.Secret, error)
 }
 
 func (h *handler) ReconcileReady(ctx context.Context, cr *v1alpha1.BtpOperator, secret *corev1.Secret) error {
-	h.driftDetector.InitializeFromSecret(secret)
 	if err := h.moduleResourceManager.DeleteOutdatedResources(ctx); err != nil {
 		return err
 	}

--- a/internal/webhook/certificate/manager.go
+++ b/internal/webhook/certificate/manager.go
@@ -18,13 +18,13 @@ import (
 )
 
 const (
-	caCertSecretName      = "ca-server-cert"
-	webhookCertSecretName = "webhook-server-cert"
+	CaCertSecretName      = "ca-server-cert"
+	WebhookCertSecretName = "webhook-server-cert"
 
-	caCertSecretCertField      = "ca.crt"
-	caCertSecretKeyField       = "ca.key"
-	webhookCertSecretCertField = "tls.crt"
-	webhookCertSecretKeyField  = "tls.key"
+	CaCertSecretCertField      = "ca.crt"
+	CaCertSecretKeyField       = "ca.key"
+	WebhookCertSecretCertField = "tls.crt"
+	WebhookCertSecretKeyField  = "tls.key"
 
 	MutatingWebhookConfigurationKind   = "MutatingWebhookConfiguration"
 	ValidatingWebhookConfigurationKind = "ValidatingWebhookConfiguration"
@@ -96,29 +96,29 @@ func (m *Manager) IsWebhookCertSignedBySelfSignedCA(ctx context.Context) (bool, 
 		return false, err
 	}
 	if caSecret == nil {
-		return false, fmt.Errorf("secret %q not found", caCertSecretName)
+		return false, fmt.Errorf("secret %q not found", CaCertSecretName)
 	}
-	caCert, err := getSecretDataValueByKey(caCertSecretCertField, caSecret.Data)
+	caCert, err := getSecretDataValueByKey(CaCertSecretCertField, caSecret.Data)
 	if err != nil {
-		return false, fmt.Errorf("CA secret %q: %w", caCertSecretName, err)
+		return false, fmt.Errorf("CA secret %q: %w", CaCertSecretName, err)
 	}
 	webhookSecret, err := m.secretsManager.GetWebhookServerCertSecret(ctx)
 	if err != nil {
 		return false, err
 	}
 	if webhookSecret == nil {
-		return false, fmt.Errorf("secret %q not found", webhookCertSecretName)
+		return false, fmt.Errorf("secret %q not found", WebhookCertSecretName)
 	}
-	webhookCert, err := getSecretDataValueByKey(webhookCertSecretCertField, webhookSecret.Data)
+	webhookCert, err := getSecretDataValueByKey(WebhookCertSecretCertField, webhookSecret.Data)
 	if err != nil {
-		return false, fmt.Errorf("webhook secret %q: %w", webhookCertSecretName, err)
+		return false, fmt.Errorf("webhook secret %q: %w", WebhookCertSecretName, err)
 	}
 	return certs.VerifyIfLeafIsSignedByGivenCA(caCert, webhookCert)
 }
 
 func (m *Manager) GetSecretData(ctx context.Context, name string) (map[string][]byte, error) {
 	switch name {
-	case caCertSecretName:
+	case CaCertSecretName:
 		s, err := m.secretsManager.GetCaServerCertSecret(ctx)
 		if err != nil {
 			return nil, err
@@ -127,7 +127,7 @@ func (m *Manager) GetSecretData(ctx context.Context, name string) (map[string][]
 			return nil, fmt.Errorf("secret %q not found", name)
 		}
 		return s.Data, nil
-	case webhookCertSecretName:
+	case WebhookCertSecretName:
 		s, err := m.secretsManager.GetWebhookServerCertSecret(ctx)
 		if err != nil {
 			return nil, err
@@ -158,7 +158,7 @@ func (m *Manager) PrepareAdmissionWebhooks(ctx context.Context, webhookResources
 		return m.regenerateCertificates(ctx, webhookResources)
 	}
 
-	caBundle := caCertSecret.Data[caCertSecretCertField]
+	caBundle := caCertSecret.Data[CaCertSecretCertField]
 
 	logger.Info("checking webhook certificate")
 	webhookCertSecret, err := m.secretsManager.GetWebhookServerCertSecret(ctx)
@@ -191,7 +191,7 @@ func (m *Manager) regenerateCertificates(ctx context.Context, webhookResources [
 		return nil, fmt.Errorf("while generating CA self signed cert: %w", err)
 	}
 
-	caSecret, err := m.buildCertificateSecret(caCertSecretName, caCertificate, caPrivateKey)
+	caSecret, err := m.buildCertificateSecret(CaCertSecretName, caCertificate, caPrivateKey)
 	if err != nil {
 		return nil, fmt.Errorf("while building secret with regenerated CA self signed cert: %w", err)
 	}
@@ -201,7 +201,7 @@ func (m *Manager) regenerateCertificates(ctx context.Context, webhookResources [
 		return nil, fmt.Errorf("while generating webhook signed cert: %w", err)
 	}
 
-	webhookSecret, err := m.buildCertificateSecret(webhookCertSecretName, webhookCertificate, webhookPrivateKey)
+	webhookSecret, err := m.buildCertificateSecret(WebhookCertSecretName, webhookCertificate, webhookPrivateKey)
 	if err != nil {
 		return nil, fmt.Errorf("while building regenerated webhook signed cert secret: %w", err)
 	}
@@ -220,17 +220,17 @@ func (m *Manager) regenerateWebhookCertificate(ctx context.Context, webhookResou
 	logger := log.FromContext(ctx)
 	logger.Info("regenerating webhook certificate")
 
-	webhookCertificate, webhookPrivateKey, err := m.generateSignedCert(ctx, caCertSecretData[caCertSecretCertField], caCertSecretData[caCertSecretKeyField])
+	webhookCertificate, webhookPrivateKey, err := m.generateSignedCert(ctx, caCertSecretData[CaCertSecretCertField], caCertSecretData[CaCertSecretKeyField])
 	if err != nil {
 		return nil, fmt.Errorf("while regenerating webhook signed cert: %w", err)
 	}
 
-	webhookSecret, err := m.buildCertificateSecret(webhookCertSecretName, webhookCertificate, webhookPrivateKey)
+	webhookSecret, err := m.buildCertificateSecret(WebhookCertSecretName, webhookCertificate, webhookPrivateKey)
 	if err != nil {
 		return nil, fmt.Errorf("while building regenerated webhook signed cert secret: %w", err)
 	}
 
-	preparedWebhooks, err := m.prepareWebhooksManifests(ctx, webhookResources, caCertSecretData[caCertSecretCertField])
+	preparedWebhooks, err := m.prepareWebhooksManifests(ctx, webhookResources, caCertSecretData[CaCertSecretCertField])
 	if err != nil {
 		return nil, fmt.Errorf("while preparing webhooks manifests: %w", err)
 	}
@@ -379,7 +379,7 @@ func (m *Manager) validateWebhookCert(webhookCertSecret *corev1.Secret, caCert [
 	if err := m.validateCert(webhookCertSecret); err != nil {
 		return err
 	}
-	return verifyCASign(caCert, webhookCertSecret.Data[webhookCertSecretCertField])
+	return verifyCASign(caCert, webhookCertSecret.Data[WebhookCertSecretCertField])
 }
 
 func verifyCASign(caCert, signedCert []byte) error {
@@ -406,20 +406,20 @@ func getSecretDataValueByKey(key string, data map[string][]byte) ([]byte, error)
 
 func certFieldFromSecretBySecretName(secretName string) (string, error) {
 	switch secretName {
-	case caCertSecretName:
-		return caCertSecretCertField, nil
-	case webhookCertSecretName:
-		return webhookCertSecretCertField, nil
+	case CaCertSecretName:
+		return CaCertSecretCertField, nil
+	case WebhookCertSecretName:
+		return WebhookCertSecretCertField, nil
 	}
 	return "", fmt.Errorf("unknown secret %q - cert field undefined", secretName)
 }
 
 func privateKeyFieldFromSecretBySecretName(secretName string) (string, error) {
 	switch secretName {
-	case caCertSecretName:
-		return caCertSecretKeyField, nil
-	case webhookCertSecretName:
-		return webhookCertSecretKeyField, nil
+	case CaCertSecretName:
+		return CaCertSecretKeyField, nil
+	case WebhookCertSecretName:
+		return WebhookCertSecretKeyField, nil
 	}
 	return "", fmt.Errorf("unknown secret %q - private key field undefined", secretName)
 }

--- a/internal/webhook/certificate/manager_test.go
+++ b/internal/webhook/certificate/manager_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Certificate Manager", func() {
 				result, err := mgr.PrepareAdmissionWebhooks(ctx, nil)
 
 				Expect(err).NotTo(HaveOccurred())
-				Expect(secretNamesIn(result)).To(ConsistOf(caCertSecretName, webhookCertSecretName))
+				Expect(secretNamesIn(result)).To(ConsistOf(certificate.CaCertSecretName, certificate.WebhookCertSecretName))
 			})
 
 			It("increments the regeneration counter", func() {
@@ -64,7 +64,7 @@ var _ = Describe("Certificate Manager", func() {
 				result, err := mgr.PrepareAdmissionWebhooks(ctx, nil)
 
 				Expect(err).NotTo(HaveOccurred())
-				Expect(secretNamesIn(result)).To(ConsistOf(caCertSecretName, webhookCertSecretName))
+				Expect(secretNamesIn(result)).To(ConsistOf(certificate.CaCertSecretName, certificate.WebhookCertSecretName))
 			})
 
 			It("increments the regeneration counter", func() {
@@ -86,8 +86,8 @@ var _ = Describe("Certificate Manager", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				names := secretNamesIn(result)
-				Expect(names).To(ConsistOf(webhookCertSecretName))
-				Expect(names).NotTo(ContainElement(caCertSecretName))
+				Expect(names).To(ConsistOf(certificate.WebhookCertSecretName))
+				Expect(names).NotTo(ContainElement(certificate.CaCertSecretName))
 			})
 
 			It("increments the regeneration counter", func() {
@@ -118,8 +118,8 @@ var _ = Describe("Certificate Manager", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				names := secretNamesIn(result)
-				Expect(names).To(ConsistOf(webhookCertSecretName))
-				Expect(names).NotTo(ContainElement(caCertSecretName))
+				Expect(names).To(ConsistOf(certificate.WebhookCertSecretName))
+				Expect(names).NotTo(ContainElement(certificate.CaCertSecretName))
 			})
 
 			It("increments the regeneration counter", func() {
@@ -140,7 +140,7 @@ var _ = Describe("Certificate Manager", func() {
 				result, err := mgr.PrepareAdmissionWebhooks(ctx, nil)
 
 				Expect(err).NotTo(HaveOccurred())
-				Expect(secretNamesIn(result)).To(ConsistOf(caCertSecretName, webhookCertSecretName))
+				Expect(secretNamesIn(result)).To(ConsistOf(certificate.CaCertSecretName, certificate.WebhookCertSecretName))
 			})
 
 			It("increments the regeneration counter", func() {
@@ -293,7 +293,7 @@ var _ = Describe("Certificate Manager", func() {
 			})
 
 			It("returns the secret data", func() {
-				data, err := mgr.GetSecretData(ctx, caCertSecretName)
+				data, err := mgr.GetSecretData(ctx, certificate.CaCertSecretName)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(data[caCertField]).To(Equal(validCACert))
 				Expect(data[caKeyField]).To(Equal(validCAKey))
@@ -306,7 +306,7 @@ var _ = Describe("Certificate Manager", func() {
 			})
 
 			It("returns an error", func() {
-				_, err := mgr.GetSecretData(ctx, caCertSecretName)
+				_, err := mgr.GetSecretData(ctx, certificate.CaCertSecretName)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("ca-server-cert"))
 			})
@@ -318,7 +318,7 @@ var _ = Describe("Certificate Manager", func() {
 			})
 
 			It("returns the secret data", func() {
-				data, err := mgr.GetSecretData(ctx, webhookCertSecretName)
+				data, err := mgr.GetSecretData(ctx, certificate.WebhookCertSecretName)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(data[webhookCertField]).To(Equal(validWebhookCert))
 				Expect(data[webhookKeyField]).To(Equal(validWebhookKey))
@@ -331,7 +331,7 @@ var _ = Describe("Certificate Manager", func() {
 			})
 
 			It("returns an error", func() {
-				_, err := mgr.GetSecretData(ctx, webhookCertSecretName)
+				_, err := mgr.GetSecretData(ctx, certificate.WebhookCertSecretName)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("webhook-server-cert"))
 			})
@@ -343,7 +343,7 @@ var _ = Describe("Certificate Manager", func() {
 			})
 
 			It("returns the error", func() {
-				_, err := mgr.GetSecretData(ctx, caCertSecretName)
+				_, err := mgr.GetSecretData(ctx, certificate.CaCertSecretName)
 				Expect(err).To(MatchError("api error"))
 			})
 		})

--- a/internal/webhook/certificate/suite_test.go
+++ b/internal/webhook/certificate/suite_test.go
@@ -18,9 +18,6 @@ import (
 const (
 	kymaNamespace = "kyma-system"
 
-	caCertSecretName      = "ca-server-cert"
-	webhookCertSecretName = "webhook-server-cert"
-
 	caCertField      = "ca.crt"
 	caKeyField       = "ca.key"
 	webhookCertField = "tls.crt"
@@ -114,14 +111,14 @@ func (f *fakeSecretsManager) GetSapBtpServiceOperatorClusterIdSecret(_ context.C
 
 func caSecret(cert, key []byte) *corev1.Secret {
 	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: caCertSecretName, Namespace: kymaNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: certificate.CaCertSecretName, Namespace: kymaNamespace},
 		Data:       map[string][]byte{caCertField: cert, caKeyField: key},
 	}
 }
 
 func webhookSecret(cert, key []byte) *corev1.Secret {
 	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{Name: webhookCertSecretName, Namespace: kymaNamespace},
+		ObjectMeta: metav1.ObjectMeta{Name: certificate.WebhookCertSecretName, Namespace: kymaNamespace},
 		Data:       map[string][]byte{webhookCertField: cert, webhookKeyField: key},
 	}
 }

--- a/main.go
+++ b/main.go
@@ -156,8 +156,6 @@ func main() {
 			configHandler,
 		},
 		networkPolicyManager,
-		driftDetector,
-		moduleResourceManager,
 		certManager,
 		provisioningHandler,
 		sapBtpConfigurator,


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Remove `driftDetector` and `moduleResourceManager` fields from `BtpOperatorReconciler` struct and constructor
- Move `InitializeFromSecret` call into `configurator.Check` by passing the required secret as a parameter
- Add `ReconcileReady` to `provisioning.Handler` interface, absorbing `DeleteOutdatedResources` + `ReconcileResources` into a single Ready-state delegation
- Remove three thin wrapper methods (`getAndVerifyRequiredSecret`, `reconcileResources`, `handleSecretVerificationFailure`) from the reconciler — call `provisioningHandler` directly
- Update `NewBtpOperatorReconciler` constructor, `main.go`, and test suite accordingly

**Related issue(s)**
See also #1313