### PR TITLE
Run CA Bundle Probe Immediately on Startup

### DIFF
--- a/controllers/probe_runner.go
+++ b/controllers/probe_runner.go
@@ -81,6 +81,9 @@ func (r *ProbeRunner) Start(ctx context.Context) error {
 
 	if err := r.runCycle(ctx); err != nil {
 		logger.Error(err, "probe cycle failed")
+		if ctx.Err() != nil {
+			return nil
+		}
 	}
 
 	ticker := time.NewTicker(interval)

--- a/controllers/probe_runner.go
+++ b/controllers/probe_runner.go
@@ -79,6 +79,10 @@ func (r *ProbeRunner) Start(ctx context.Context) error {
 
 	logger.Info("CA bundle probe runner started", "interval", interval, "image", r.probeImage)
 
+	if err := r.runCycle(ctx); err != nil {
+		logger.Error(err, "probe cycle failed")
+	}
+
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Run one CA bundle probe cycle immediately when `ProbeRunner.Start` is called, before the first ticker interval fires
- Eliminate the blind window on startup where the probe would not run for a full interval (up to 60 minutes) after btp-manager starts

**Related issue(s)**