### PR TITLE
Add Validate Release As Prerequisite For Unit Tests In Release Workflow

### DIFF
--- a/.github/workflows/create-release-with-version-submit.yaml
+++ b/.github/workflows/create-release-with-version-submit.yaml
@@ -96,6 +96,7 @@ jobs:
 
   run-unit-tests:
     name: Unit tests
+    needs: [validate-release]
     uses: "./.github/workflows/run-unit-tests-reusable.yaml"
 
   run-e2e-tests:

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -96,6 +96,7 @@ jobs:
 
   run-unit-tests:
     name: Unit tests
+    needs: [validate-release]
     uses: "./.github/workflows/run-unit-tests-reusable.yaml"
 
   run-e2e-tests:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add `needs: [validate-release]` to the `run-unit-tests` job in both release workflows so unit tests are skipped when release validation fails

**Related issue(s)**