### PR TITLE
Wait for sap-btp-operator Pod Ready Before Patching ServiceInstance

### DIFF
--- a/.github/workflows/run-e2e-tests-reusable.yaml
+++ b/.github/workflows/run-e2e-tests-reusable.yaml
@@ -54,7 +54,7 @@ jobs:
   run-e2e-matrix:
     runs-on: ubuntu-latest
     needs: prepare-tests
-    timeout-minutes: 10
+    timeout-minutes: 12
     strategy:
       matrix: ${{ fromJSON(needs.prepare-tests.outputs.versions) }}
     steps:

--- a/scripts/testing/run_e2e_module_tests.sh
+++ b/scripts/testing/run_e2e_module_tests.sh
@@ -391,7 +391,7 @@ ELAPSED=0
 TIMEOUT=120
 while true; do
   READY_COUNT=$(kubectl get pods -n kyma-system -l app.kubernetes.io/instance=sap-btp-operator \
-    -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>/dev/null | grep -c "True" || echo 0)
+    -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>/dev/null | grep -c "True") || READY_COUNT=0
   if [[ "${READY_COUNT}" -gt 0 ]]; then
     echo -e "--- sap-btp-operator pod is Ready"
     break

--- a/scripts/testing/run_e2e_module_tests.sh
+++ b/scripts/testing/run_e2e_module_tests.sh
@@ -347,6 +347,8 @@ if [[ "${operator_limited_cache_default}" != "true" ]]; then
   echo "Expected ENABLE_LIMITED_CACHE to be 'true' by default, but got: ${operator_limited_cache_default}" && exit 1
 fi
 
+SAP_BTP_OPERATOR_POD_BEFORE=$(getSapBtpOperatorRunningPod)
+
 echo -e "\n--- Disabling limited cache in sap-btp-manager ConfigMap"
 kubectl patch configmap sap-btp-manager -n kyma-system --type merge -p '{"data":{"EnableLimitedCache":"false"}}'
 
@@ -372,7 +374,24 @@ while true; do
   fi
 done
 
-SAP_BTP_OPERATOR_POD_BEFORE=$(getSapBtpOperatorRunningPod)
+echo -e "\n--- Waiting for sap-btp-operator pod to restart after disabling limited cache"
+sleep 2
+ELAPSED=0
+while true; do
+  SAP_BTP_OPERATOR_POD_AFTER_FALSE=$(getSapBtpOperatorRunningPod)
+  if [[ -n "${SAP_BTP_OPERATOR_POD_AFTER_FALSE}" && "${SAP_BTP_OPERATOR_POD_AFTER_FALSE}" != "${SAP_BTP_OPERATOR_POD_BEFORE}" ]]; then
+    echo -e "--- sap-btp-operator pod restarted"
+    break
+  elif [[ ${ELAPSED} -ge ${TIMEOUT} ]]; then
+    echo -e "FAILED: sap-btp-operator pod was not restarted within ${TIMEOUT}s" && exit 1
+  fi
+  sleep 5
+  ELAPSED=$((ELAPSED + 5))
+done
+
+echo -e "\n--- Waiting for sap-btp-operator pod to be Ready"
+kubectl wait pod "${SAP_BTP_OPERATOR_POD_AFTER_FALSE}" -n kyma-system --for=condition=Ready --timeout=120s
+echo -e "--- sap-btp-operator pod is Ready"
 
 echo -e "\n--- Enabling limited cache in sap-btp-manager ConfigMap"
 kubectl patch configmap sap-btp-manager -n kyma-system --type merge -p '{"data":{"EnableLimitedCache":"true"}}'
@@ -399,7 +418,7 @@ sleep 2
 ELAPSED=0
 while true; do
   SAP_BTP_OPERATOR_POD_AFTER=$(getSapBtpOperatorRunningPod)
-  if [[ -n "${SAP_BTP_OPERATOR_POD_AFTER}" && "${SAP_BTP_OPERATOR_POD_AFTER}" != "${SAP_BTP_OPERATOR_POD_BEFORE}" ]]; then
+  if [[ -n "${SAP_BTP_OPERATOR_POD_AFTER}" && "${SAP_BTP_OPERATOR_POD_AFTER}" != "${SAP_BTP_OPERATOR_POD_AFTER_FALSE}" ]]; then
     echo -e "--- sap-btp-operator pod restarted "
     break
   elif [[ ${ELAPSED} -ge ${TIMEOUT} ]]; then

--- a/scripts/testing/run_e2e_module_tests.sh
+++ b/scripts/testing/run_e2e_module_tests.sh
@@ -102,6 +102,12 @@ checkNetworkPoliciesExist() {
   return 0
 }
 
+getSapBtpOperatorRunningPod() {
+  kubectl get pods -n kyma-system -l app.kubernetes.io/instance=sap-btp-operator \
+    -o go-template='{{range .items}}{{if not .metadata.deletionTimestamp}}{{.metadata.name}}{{"\n"}}{{end}}{{end}}' \
+    2>/dev/null | head -1 || echo ""
+}
+
 checkNetworkPoliciesDeleted() {
   echo -e "\n--- Checking if network policies are deleted"
   local policies=(
@@ -366,6 +372,8 @@ while true; do
   fi
 done
 
+SAP_BTP_OPERATOR_POD_BEFORE=$(getSapBtpOperatorRunningPod)
+
 echo -e "\n--- Enabling limited cache in sap-btp-manager ConfigMap"
 kubectl patch configmap sap-btp-manager -n kyma-system --type merge -p '{"data":{"EnableLimitedCache":"true"}}'
 
@@ -386,10 +394,24 @@ while true; do
   fi
 done
 
-echo -e "\n--- Waiting for sap-btp-operator pod to be Ready after restart"
+echo -e "\n--- Waiting for sap-btp-operator pod to restart"
 sleep 2
-kubectl wait pod -n kyma-system -l app.kubernetes.io/instance=sap-btp-operator \
-  --for=condition=Ready --timeout=120s
+ELAPSED=0
+while true; do
+  SAP_BTP_OPERATOR_POD_AFTER=$(getSapBtpOperatorRunningPod)
+  if [[ -n "${SAP_BTP_OPERATOR_POD_AFTER}" && "${SAP_BTP_OPERATOR_POD_AFTER}" != "${SAP_BTP_OPERATOR_POD_BEFORE}" ]]; then
+    echo -e "--- sap-btp-operator pod restarted "
+    break
+  elif [[ ${ELAPSED} -ge ${TIMEOUT} ]]; then
+    echo -e "FAILED: sap-btp-operator pod was not restarted within ${TIMEOUT}s" && exit 1
+  fi
+  sleep 5
+  ELAPSED=$((ELAPSED + 5))
+done
+
+echo -e "\n--- Waiting for sap-btp-operator pod to be Ready"
+kubectl wait pod "${SAP_BTP_OPERATOR_POD_AFTER}" -n kyma-system --for=condition=Ready --timeout=120s
+echo -e "--- sap-btp-operator pod is Ready"
 
 echo -e "\n--- EnableLimitedCache ConfigMap propagation test completed successfully"
 

--- a/scripts/testing/run_e2e_module_tests.sh
+++ b/scripts/testing/run_e2e_module_tests.sh
@@ -386,6 +386,23 @@ while true; do
   fi
 done
 
+echo -e "\n--- Waiting for sap-btp-operator pod to be Ready after restart"
+ELAPSED=0
+TIMEOUT=120
+while true; do
+  READY_COUNT=$(kubectl get pods -n kyma-system -l app.kubernetes.io/instance=sap-btp-operator \
+    -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>/dev/null | grep -c "True" || echo 0)
+  if [[ "${READY_COUNT}" -gt 0 ]]; then
+    echo -e "--- sap-btp-operator pod is Ready"
+    break
+  fi
+  if [[ ${ELAPSED} -ge ${TIMEOUT} ]]; then
+    echo "FAILED: sap-btp-operator pod not Ready within ${TIMEOUT}s" && exit 1
+  fi
+  sleep 5
+  ELAPSED=$((ELAPSED + 5))
+done
+
 echo -e "\n--- EnableLimitedCache ConfigMap propagation test completed successfully"
 
 echo -e "\n--- Removing sap-btp-manager configmap"

--- a/scripts/testing/run_e2e_module_tests.sh
+++ b/scripts/testing/run_e2e_module_tests.sh
@@ -108,6 +108,27 @@ getSapBtpOperatorRunningPod() {
     2>/dev/null | head -1 || echo ""
 }
 
+waitForSapBtpOperatorPodRestart() {
+  local before_pod=$1
+  local elapsed=0
+  sleep 2
+  echo -e "\n--- Waiting for sap-btp-operator pod to restart"
+  while true; do
+    SAP_BTP_OPERATOR_RESTARTED_POD=$(getSapBtpOperatorRunningPod)
+    if [[ -n "${SAP_BTP_OPERATOR_RESTARTED_POD}" && "${SAP_BTP_OPERATOR_RESTARTED_POD}" != "${before_pod}" ]]; then
+      echo -e "--- sap-btp-operator pod restarted (new pod: ${SAP_BTP_OPERATOR_RESTARTED_POD})"
+      break
+    elif [[ ${elapsed} -ge ${TIMEOUT} ]]; then
+      echo -e "FAILED: sap-btp-operator pod was not restarted within ${TIMEOUT}s" && exit 1
+    fi
+    sleep 5
+    elapsed=$((elapsed + 5))
+  done
+  echo -e "\n--- Waiting for sap-btp-operator pod to be Ready"
+  kubectl wait pod "${SAP_BTP_OPERATOR_RESTARTED_POD}" -n kyma-system --for=condition=Ready --timeout=120s
+  echo -e "--- sap-btp-operator pod is Ready"
+}
+
 checkNetworkPoliciesDeleted() {
   echo -e "\n--- Checking if network policies are deleted"
   local policies=(
@@ -374,24 +395,8 @@ while true; do
   fi
 done
 
-echo -e "\n--- Waiting for sap-btp-operator pod to restart after disabling limited cache"
-sleep 2
-ELAPSED=0
-while true; do
-  SAP_BTP_OPERATOR_POD_AFTER_FALSE=$(getSapBtpOperatorRunningPod)
-  if [[ -n "${SAP_BTP_OPERATOR_POD_AFTER_FALSE}" && "${SAP_BTP_OPERATOR_POD_AFTER_FALSE}" != "${SAP_BTP_OPERATOR_POD_BEFORE}" ]]; then
-    echo -e "--- sap-btp-operator pod restarted"
-    break
-  elif [[ ${ELAPSED} -ge ${TIMEOUT} ]]; then
-    echo -e "FAILED: sap-btp-operator pod was not restarted within ${TIMEOUT}s" && exit 1
-  fi
-  sleep 5
-  ELAPSED=$((ELAPSED + 5))
-done
-
-echo -e "\n--- Waiting for sap-btp-operator pod to be Ready"
-kubectl wait pod "${SAP_BTP_OPERATOR_POD_AFTER_FALSE}" -n kyma-system --for=condition=Ready --timeout=120s
-echo -e "--- sap-btp-operator pod is Ready"
+waitForSapBtpOperatorPodRestart "${SAP_BTP_OPERATOR_POD_BEFORE}"
+SAP_BTP_OPERATOR_POD_AFTER_FALSE=${SAP_BTP_OPERATOR_RESTARTED_POD}
 
 echo -e "\n--- Enabling limited cache in sap-btp-manager ConfigMap"
 kubectl patch configmap sap-btp-manager -n kyma-system --type merge -p '{"data":{"EnableLimitedCache":"true"}}'
@@ -413,24 +418,7 @@ while true; do
   fi
 done
 
-echo -e "\n--- Waiting for sap-btp-operator pod to restart"
-sleep 2
-ELAPSED=0
-while true; do
-  SAP_BTP_OPERATOR_POD_AFTER=$(getSapBtpOperatorRunningPod)
-  if [[ -n "${SAP_BTP_OPERATOR_POD_AFTER}" && "${SAP_BTP_OPERATOR_POD_AFTER}" != "${SAP_BTP_OPERATOR_POD_AFTER_FALSE}" ]]; then
-    echo -e "--- sap-btp-operator pod restarted "
-    break
-  elif [[ ${ELAPSED} -ge ${TIMEOUT} ]]; then
-    echo -e "FAILED: sap-btp-operator pod was not restarted within ${TIMEOUT}s" && exit 1
-  fi
-  sleep 5
-  ELAPSED=$((ELAPSED + 5))
-done
-
-echo -e "\n--- Waiting for sap-btp-operator pod to be Ready"
-kubectl wait pod "${SAP_BTP_OPERATOR_POD_AFTER}" -n kyma-system --for=condition=Ready --timeout=120s
-echo -e "--- sap-btp-operator pod is Ready"
+waitForSapBtpOperatorPodRestart "${SAP_BTP_OPERATOR_POD_AFTER_FALSE}"
 
 echo -e "\n--- EnableLimitedCache ConfigMap propagation test completed successfully"
 

--- a/scripts/testing/run_e2e_module_tests.sh
+++ b/scripts/testing/run_e2e_module_tests.sh
@@ -387,21 +387,9 @@ while true; do
 done
 
 echo -e "\n--- Waiting for sap-btp-operator pod to be Ready after restart"
-ELAPSED=0
-TIMEOUT=120
-while true; do
-  READY_COUNT=$(kubectl get pods -n kyma-system -l app.kubernetes.io/instance=sap-btp-operator \
-    -o jsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>/dev/null | grep -c "True") || READY_COUNT=0
-  if [[ "${READY_COUNT}" -gt 0 ]]; then
-    echo -e "--- sap-btp-operator pod is Ready"
-    break
-  fi
-  if [[ ${ELAPSED} -ge ${TIMEOUT} ]]; then
-    echo "FAILED: sap-btp-operator pod not Ready within ${TIMEOUT}s" && exit 1
-  fi
-  sleep 5
-  ELAPSED=$((ELAPSED + 5))
-done
+sleep 2
+kubectl wait pod -n kyma-system -l app.kubernetes.io/instance=sap-btp-operator \
+  --for=condition=Ready --timeout=120s
 
 echo -e "\n--- EnableLimitedCache ConfigMap propagation test completed successfully"
 


### PR DESCRIPTION
Description: 

- The fix adds a wait loop after ConfigMap propagation that polls until the
`sap-btp-operator` pod is in ready state before continuing. This ensures the webhook is
available when the ServiceInstance patch is attempted.
